### PR TITLE
Refactor documentation to use generic scratch zone references

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -4,6 +4,8 @@
 
 Personal dotfiles repository using Bazel for cross-platform configuration management. Configurations in `src/` with personal/work profiles and guarded installation.
 
+**🚧 Active Projects**: See [.agents/scratch_zone/](.agents/scratch_zone/) for current development status and tasks.
+
 ## Repository structure
 
 - `src/` - Tool configurations (git, zsh, tmux, vim, hammerspoon, jq)

--- a/.agents/claude/CLAUDE.md
+++ b/.agents/claude/CLAUDE.md
@@ -24,6 +24,10 @@ bazel run //config:install_all
 - Guarded installation prevents corruption
 - Test both personal/work profiles
 
+## Active projects
+
+See [.agents/scratch_zone/](.agents/scratch_zone/) for current development status and tasks.
+
 ## Scratch zone
 
 Use `.agents/scratch_zone/` for temporary project files, notes, and task tracking during sessions. See [.agents/scratch_zone/README.md](.agents/scratch_zone/README.md) for usage guidelines.


### PR DESCRIPTION
Replace specific project details with generic references to scratch zone for active project status. This prevents duplication and ensures agents check the scratch zone folder for current development information.

🤖 Generated with [Claude Code](https://claude.ai/code)