### PR TITLE
fix: remove timestamps from modify templates and update Claude hooks

### DIFF
--- a/.agents/claude/.claude/settings.json
+++ b/.agents/claude/.claude/settings.json
@@ -18,21 +18,15 @@
     "additionalDirectories": []
   },
   "hooks": {
-    "PreToolUse": [
+    "PreToolUse": [],
+    "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
             "command": "bazel run //:format"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/bazel-validate.sh"

--- a/src/dot_dotfiles/git/config.tmpl
+++ b/src/dot_dotfiles/git/config.tmpl
@@ -15,7 +15,7 @@
   path = {{ .chezmoi.homeDir }}/.dotfiles/git/snippets/stash.gitconfig
   path = {{ .chezmoi.homeDir }}/.dotfiles/git/snippets/branch.gitconfig
   path = {{ .chezmoi.homeDir }}/.dotfiles/git/snippets/column.gitconfig
-  path = {{ .chezmoi.homeDir }}/.dotfiles/git/snippets/alias.gitconfig
+  path = {{ .chezmoi.homeDir }}/.dotfiles/git/snippets/aliases.gitconfig
 
 # Profile-specific configuration
 {{- if eq .profile "personal" }}

--- a/src/dot_dotfiles/git/snippets/alias.gitconfig
+++ b/src/dot_dotfiles/git/snippets/alias.gitconfig
@@ -1,3 +1,0 @@
-[alias]
-	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-alias
-	placeholder = !echo "work"

--- a/src/modify_dot_gitconfig.tmpl
+++ b/src/modify_dot_gitconfig.tmpl
@@ -15,7 +15,6 @@ fi
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:git:{{ include "modify_dot_gitconfig.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
-# Applied: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
 [include]
   path = {{ .chezmoi.homeDir }}/.dotfiles/git/config
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:git:{{ include "modify_dot_gitconfig.tmpl" | sha256sum | substr 0 8 }}

--- a/src/modify_dot_tmux.conf.tmpl
+++ b/src/modify_dot_tmux.conf.tmpl
@@ -15,7 +15,6 @@ fi
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:tmux:{{ include "modify_dot_tmux.conf.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
-# Applied: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
 source-file {{ .chezmoi.homeDir }}/.dotfiles/tmux/config.tmux
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:tmux:{{ include "modify_dot_tmux.conf.tmpl" | sha256sum | substr 0 8 }}
 EOF

--- a/src/modify_dot_vimrc.tmpl
+++ b/src/modify_dot_vimrc.tmpl
@@ -15,7 +15,6 @@ fi
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 " {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:vim:{{ include "modify_dot_vimrc.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
-" Applied: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
 source {{ .chezmoi.homeDir }}/.dotfiles/vim/config.vim
 " {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:vim:{{ include "modify_dot_vimrc.tmpl" | sha256sum | substr 0 8 }}
 EOF

--- a/src/modify_dot_zshrc.tmpl
+++ b/src/modify_dot_zshrc.tmpl
@@ -15,7 +15,6 @@ fi
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:zsh:{{ include "modify_dot_zshrc.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
-# Applied: {{ now.Format "2006-01-02T15:04:05Z07:00" }}
 source {{ .chezmoi.homeDir }}/.dotfiles/zsh/config.zsh
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:zsh:{{ include "modify_dot_zshrc.tmpl" | sha256sum | substr 0 8 }}
 EOF


### PR DESCRIPTION
Remove timestamp lines from modify_* templates to prevent constant regeneration. Move bazel format hook from PreToolUse to PostToolUse for better workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)


Committed-By-Agent: claude