### PR TITLE
Fix ripgrep template URL generation for mixed target naming

### DIFF
--- a/src/dot_local/bin/.chezmoiexternals/rg.toml.tmpl
+++ b/src/dot_local/bin/.chezmoiexternals/rg.toml.tmpl
@@ -5,7 +5,11 @@
 {{- if eq $.chezmoi.os "darwin" -}}
   {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+  {{- if eq $.chezmoi.arch "arm64" -}}
+    {{- $target = "aarch64-unknown-linux-gnu" -}}
+  {{- else -}}
+    {{- $target = "x86_64-unknown-linux-musl" -}}
+  {{- end -}}
 {{- end }}
 ["rg"]
 type = "archive-file"


### PR DESCRIPTION
- Handle ripgrep's inconsistent target naming patterns:
  - linux_arm64: aarch64-unknown-linux-gnu
  - linux_amd64: x86_64-unknown-linux-musl
- Fixes 'no URL' error on remote linux devboxes
- URLs verified to exist via GitHub API and curl tests

🤖 Generated with [Claude Code](https://claude.ai/code)


Committed-By-Agent: claude