### PR TITLE
fix: add --locked to uv run in tool wrapper scripts

### DIFF
--- a/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
+++ b/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.claude_statusline.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main "$@"
+exec mise exec -- uv run --locked --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.jules.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --project {{ .chezmoi.workingTree }}/src/python/jules_cli -m jules_cli.main "$@"
+exec mise exec -- uv run --locked --project {{ .chezmoi.workingTree }}/src/python/jules_cli -m jules_cli.main "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.transcribe.installation "uv" -}}
 #!/usr/bin/env bash
-exec uv run --project {{ .chezmoi.workingTree }}/src/python/transcribe -m transcribe.main "$@"
+exec uv run --locked --project {{ .chezmoi.workingTree }}/src/python/transcribe -m transcribe.main "$@"
 {{- end -}}


### PR DESCRIPTION
## Summary

- Adds `--locked` flag to all three `uv run` wrapper scripts (`claude_statusline`, `jules`, `transcribe`)
- Prevents `uv run` from updating `uv.lock` on each invocation, which was causing the lockfile to be perpetually dirty due to the global `exclude-newer = "P14D"` uv config recalculating a fresh timestamp every run
- Environment is still synced/installed from the existing lockfile; only lockfile mutations are prevented

## Test plan

- [x] Run each tool (`claude_statusline`, `jules`, `transcribe`) and verify `uv.lock` is not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)