### PR TITLE
chore: convert --locked to --frozen in chezmoi script templates

### DIFF
--- a/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
+++ b/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.claude_statusline.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --locked --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main "$@"
+exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.jules.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --locked --project {{ .chezmoi.workingTree }}/src/python/jules_cli -m jules_cli.main "$@"
+exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/jules_cli -m jules_cli.main "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.transcribe.installation "uv" -}}
 #!/usr/bin/env bash
-exec uv run --locked --project {{ .chezmoi.workingTree }}/src/python/transcribe -m transcribe.main "$@"
+exec uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/transcribe -m transcribe.main "$@"
 {{- end -}}

--- a/src/chezmoi/run_once_install-claude.sh.tmpl
+++ b/src/chezmoi/run_once_install-claude.sh.tmpl
@@ -1,6 +1,10 @@
 {{- if eq .claude_code.installation "external-script" }}#!/bin/bash
 set -euo pipefail
 
+if [[ -n "${CI:-}" ]]; then
+    exit 0
+fi
+
 # Install Claude Code using official installer
 # See: https://docs.claude.com/en/docs/claude-code/setup#native-binary-installation-beta
 

--- a/src/chezmoi/run_once_install-claude.sh.tmpl
+++ b/src/chezmoi/run_once_install-claude.sh.tmpl
@@ -1,10 +1,6 @@
 {{- if eq .claude_code.installation "external-script" }}#!/bin/bash
 set -euo pipefail
 
-if [[ -n "${CI:-}" ]]; then
-    exit 0
-fi
-
 # Install Claude Code using official installer
 # See: https://docs.claude.com/en/docs/claude-code/setup#native-binary-installation-beta
 


### PR DESCRIPTION
Convert `--locked` to `--frozen` in `uv run` commands in the python CLI script templates. This bypasses lockfile validation errors resulting from the global exclude-newer policy for package minimum release age.

---
*PR created automatically by Jules for task [10114356261438014848](https://jules.google.com/task/10114356261438014848) started by @mkobit*