### PR TITLE
fix(gemini): prevent chezmoi from deleting settings.json

### DIFF
--- a/src/chezmoi/dot_gemini/settings.json.tmpl
+++ b/src/chezmoi/dot_gemini/settings.json.tmpl
@@ -1,5 +1,5 @@
-{{- $geminiTool := index .mise.global_tools "npm:@google/gemini-cli" -}}
-{{- if and $geminiTool (eq $geminiTool.installation "mise") -}}
+{{- $geminiTool := index .mise.global_tools "npm:@google/gemini-cli" | default (dict "installation" "mise") -}}
+{{- if eq $geminiTool.installation "mise" -}}
 {{-   $settings := dict
         "model" (dict "name" .gemini.model)
         "telemetry" (dict "enabled" .gemini.telemetry.enabled "logPrompts" .gemini.telemetry.log_prompts)


### PR DESCRIPTION
This PR fixes an issue where the `~/.gemini/settings.json` file was being unexpectedly deleted by Chezmoi on certain machines.

**Root Cause:**
The template `src/chezmoi/dot_gemini/settings.json.tmpl` wrapped its contents in an `if` block that checked if `npm:@google/gemini-cli` was present in the `.mise.global_tools` configuration data and if its installation method was `"mise"`. If the `gemini-cli` key was completely missing from the `.mise.global_tools` data (which can happen due to `chezmoidata` merging overriding values), the variable lookup returned `nil`, causing the template to evaluate to an empty string. By default, when a template evaluates to an empty string, Chezmoi deletes the target file.

**Fix:**
This updates the template lookup to use Sprig's `default` function. If the `npm:@google/gemini-cli` key is missing from `.mise.global_tools`, it falls back to a default dictionary `(dict "installation" "mise")`. This ensures the template always evaluates to true, correctly generating the settings file instead of deleting it.

---
*PR created automatically by Jules for task [17386112174497037218](https://jules.google.com/task/17386112174497037218) started by @mkobit*