### PR TITLE
feat(claude_statusline): enhance statusline visuals

### DIFF
--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from claude_statusline.models import GitInfo, StatusLineStdIn
 from claude_statusline.segments import (
     DIVIDER_BAR,
-    DIVIDER_DOT,
     format_context_usage,
     format_cost,
     format_directory,
     format_git_full,
     format_model_info,
+    format_obsidian_vault,
     format_session_info,
 )
 
@@ -24,14 +24,16 @@ def render_lines(payload: StatusLineStdIn, git_info: GitInfo | None) -> list[str
     model_seg = format_model_info(payload)
     session_seg = format_session_info(payload)
     dir_seg = format_directory(cwd)
+    obsidian_seg = format_obsidian_vault(cwd)
     git_seg = format_git_full(git_info)
     context_seg = format_context_usage(payload.context_window)
     cost_seg = format_cost(payload)
 
-    line1 = DIVIDER_BAR.join(s.text for s in filter(None, [model_seg])) or None
+    line1_segs = filter(None, [model_seg, session_seg])
+    line1 = DIVIDER_BAR.join(s.text for s in line1_segs) or None
 
-    line2_segs = filter(None, [dir_seg, session_seg])
-    line2 = DIVIDER_DOT.join(s.text for s in line2_segs) or None
+    line2_segs = filter(None, [dir_seg, obsidian_seg])
+    line2 = DIVIDER_BAR.join(s.text for s in line2_segs) or None
 
     line3_segs = filter(None, [git_seg, context_seg, cost_seg])
     line3 = DIVIDER_BAR.join(s.text for s in line3_segs) or None

--- a/src/python/claude_statusline/claude_statusline/segments/__init__.py
+++ b/src/python/claude_statusline/claude_statusline/segments/__init__.py
@@ -10,7 +10,11 @@ from claude_statusline.segments.constants import (
     Segment,
 )
 from claude_statusline.segments.git import format_git_full
-from claude_statusline.segments.workspace import format_directory, shorten_path
+from claude_statusline.segments.workspace import (
+    format_directory,
+    format_obsidian_vault,
+    shorten_path,
+)
 
 __all__ = [
     "format_context_usage",
@@ -19,6 +23,7 @@ __all__ = [
     "format_session_info",
     "format_git_full",
     "format_directory",
+    "format_obsidian_vault",
     "shorten_path",
     "DIVIDER_BAR",
     "DIVIDER_DOT",

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -1,7 +1,5 @@
 from claude_statusline.models import ContextWindowInfo, StatusLineStdIn
 from claude_statusline.segments.constants import (
-    BLOCK_EMPTY,
-    BLOCK_FILLED,
     BLUE,
     BOLD,
     CYAN,
@@ -27,8 +25,20 @@ def format_context_usage(cw: ContextWindowInfo) -> Segment | None:
         color = YELLOW
 
     width = 10
-    filled = min(int(width * (used_pct / 100)), width)
-    visual_bar = (BLOCK_FILLED * filled) + (BLOCK_EMPTY * (width - filled))
+    blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
+
+    total_eighths = int((used_pct / 100.0) * width * 8)
+    full_blocks = total_eighths // 8
+    remainder = total_eighths % 8
+
+    visual_bar = ""
+    for i in range(width):
+        if i < full_blocks:
+            visual_bar += blocks[8]
+        elif i == full_blocks:
+            visual_bar += blocks[remainder]
+        else:
+            visual_bar += blocks[0]
 
     return Segment(f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%")
 
@@ -68,4 +78,6 @@ def format_session_info(payload: StatusLineStdIn) -> Segment | None:
 def format_cost(payload: StatusLineStdIn) -> Segment | None:
     if not payload.cost.total_cost_usd:
         return None
-    return Segment(f"{GREEN}{get_icon('cost')}{payload.cost.total_cost_usd:.2f}{RESET}")
+    return Segment(
+        f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"
+    )

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -25,20 +25,20 @@ def format_context_usage(cw: ContextWindowInfo) -> Segment | None:
         color = YELLOW
 
     width = 10
-    blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
+    blocks = [" ", " ", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
 
     total_eighths = int((used_pct / 100.0) * width * 8)
     full_blocks = total_eighths // 8
     remainder = total_eighths % 8
 
-    visual_bar = ""
-    for i in range(width):
-        if i < full_blocks:
-            visual_bar += blocks[8]
-        elif i == full_blocks:
-            visual_bar += blocks[remainder]
-        else:
-            visual_bar += blocks[0]
+    visual_bar = "".join(
+        blocks[8]
+        if i < full_blocks
+        else blocks[remainder]
+        if i == full_blocks
+        else blocks[0]
+        for i in range(width)
+    )
 
     return Segment(f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%")
 

--- a/src/python/claude_statusline/claude_statusline/segments/constants.py
+++ b/src/python/claude_statusline/claude_statusline/segments/constants.py
@@ -40,6 +40,7 @@ IconKey = Literal[
     "tokens",
     "robot",
     "worktree",
+    "obsidian",
 ]
 
 ICONS: dict[IconKey, tuple[str, str]] = {
@@ -56,6 +57,7 @@ ICONS: dict[IconKey, tuple[str, str]] = {
     "tokens": ("\uf4a5", "⚡"),
     "robot": ("\uf544", "🤖"),
     "worktree": ("\uf1bb", "🌳"),
+    "obsidian": ("\ue65d", "🟣"),
 }
 
 

--- a/src/python/claude_statusline/claude_statusline/segments/constants.py
+++ b/src/python/claude_statusline/claude_statusline/segments/constants.py
@@ -1,7 +1,13 @@
 import functools
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NamedTuple
+
+
+class IconPair(NamedTuple):
+    nerd_font: str
+    fallback: str
+
 
 RESET = "\033[0m"
 BOLD = "\033[1m"
@@ -43,28 +49,28 @@ IconKey = Literal[
     "obsidian",
 ]
 
-ICONS: dict[IconKey, tuple[str, str]] = {
+ICONS: dict[IconKey, IconPair] = {
     # key: (nerdfont, emoji)
-    "dir": ("\uf115", "📁"),
-    "branch": ("\ue0a0", "🪾"),
-    "remote": ("\uf0c1", "🔗"),
-    "dirty": ("\uf06a", "!"),
-    "clean": ("\uf00c", "✓"),
-    "staged": ("\uf067", "+"),
-    "untracked": ("\uf128", "?"),
-    "timer": ("\uf017", "⏱"),
-    "cost": ("💳", "💳"),
-    "tokens": ("\uf4a5", "⚡"),
-    "robot": ("\uf544", "🤖"),
-    "worktree": ("\uf1bb", "🌳"),
-    "obsidian": ("\ue65d", "🟣"),
+    "dir": IconPair("\uf115", "📁"),
+    "branch": IconPair("\ue0a0", "🪾"),
+    "remote": IconPair("\uf0c1", "🔗"),
+    "dirty": IconPair("\uf06a", "!"),
+    "clean": IconPair("\uf00c", "✓"),
+    "staged": IconPair("\uf067", "+"),
+    "untracked": IconPair("\uf128", "?"),
+    "timer": IconPair("\uf017", "⏱"),
+    "cost": IconPair("💳", "💳"),
+    "tokens": IconPair("\uf4a5", "⚡"),
+    "robot": IconPair("\uf544", "🤖"),
+    "worktree": IconPair("\uf1bb", "🌳"),
+    "obsidian": IconPair("\ue65d", "🟣"),
 }
 
 
 def get_icon(key: IconKey) -> str:
     """Returns the nerd font icon or emoji fallback based on environment."""
-    nerd_font, fallback = ICONS[key]
-    return nerd_font if use_icons() else fallback
+    icon_pair = ICONS[key]
+    return icon_pair.nerd_font if use_icons() else icon_pair.fallback
 
 
 BLOCK_FILLED = "\u2588"  # █

--- a/src/python/claude_statusline/claude_statusline/segments/workspace.py
+++ b/src/python/claude_statusline/claude_statusline/segments/workspace.py
@@ -24,3 +24,13 @@ def format_directory(cwd: Path) -> Segment | None:
     display_path = shorten_path(cwd)
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
     return Segment(f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}")
+
+
+def format_obsidian_vault(cwd: Path) -> Segment | None:
+    current = cwd
+    while current != current.parent:
+        if (current / ".obsidian").is_dir():
+            vault_name = current.name
+            return Segment(f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}")
+        current = current.parent
+    return None

--- a/src/python/claude_statusline/tests/test_main.py
+++ b/src/python/claude_statusline/tests/test_main.py
@@ -169,8 +169,7 @@ class TestStatusLine(unittest.TestCase):
             line1 = mock_print.call_args_list[0][0][0]
             self.assertIn("Claude 3", line1)
 
-            line2 = mock_print.call_args_list[1][0][0]
-            self.assertIn("MySession", line2)
+            self.assertIn("MySession", line1)
 
             line3 = mock_print.call_args_list[2][0][0]
             self.assertIn("main", line3)
@@ -259,8 +258,7 @@ class TestStatusLine(unittest.TestCase):
             self.assertIn("Opus", line1)
             self.assertIn("security-reviewer", line1)
 
-            line2 = mock_print.call_args_list[1][0][0]
-            self.assertIn("my-session", line2)
+            self.assertIn("my-session", line1)
 
             line3 = mock_print.call_args_list[2][0][0]
             self.assertIn("feature-branch", line3)


### PR DESCRIPTION
Enhance the Claude statusline visuals with the following changes:

- Format cost with a space and a `$` prefix to clarify currency format.
- Use partial left-to-right character blocks for context usage bar to more accurately represent progress.
- Shift the session info into the first line for better visual alignment.
- Standardize on using `DIVIDER_BAR` for separation instead of mixed dividers.
- Add dynamic detection and rendering for Obsidian vaults with a new icon.

---
*PR created automatically by Jules for task [10870539984372009041](https://jules.google.com/task/10870539984372009041) started by @mkobit*