### PR TITLE
feat(claude-statusline): enable external segment generators via CLI

### DIFF
--- a/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
+++ b/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.claude_statusline.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main "$@"
+exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main{{ range (dig "claude_code" "settings" "statusLine" "generators" list .) }} --generator {{ . | quote }}{{ end }} "$@"
 {{- end -}}

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -194,14 +194,18 @@ async def run_external_generator(
 
         if proc.returncode == 0 and stdout.strip():
             try:
-                # We can use TypeAdapter directly on the json string or parsed json
                 adapter = TypeAdapter(
                     list[SegmentGenerationResult] | SegmentGenerationResult
                 )
                 data = adapter.validate_json(stdout)
-                if isinstance(data, list):
-                    return data
-                return [data]
+
+                results = data if isinstance(data, list) else [data]
+
+                # set generator name from cmd
+                for item in results:
+                    item.generator = cmd
+                return results
+
             except ValidationError as e:
                 logger.warning(f"Validation error in external generator {cmd}: {e}")
             except Exception as e:

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -198,7 +198,7 @@ def run_external_generator(
 @click.option(
     "--generator",
     multiple=True,
-    help="External command or script to generate segments (receives JSON payload on stdin).",
+    help="External command or script to generate segments (takes JSON on stdin).",
 )
 def main(generator: tuple[str, ...]) -> None:
     raw_json_str = "{}"

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -6,12 +6,14 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Sequence
 from pathlib import Path
 from typing import NamedTuple
 
 import click
+from pydantic import TypeAdapter, ValidationError
 
-from claude_statusline.models import GitInfo, Segment, StatusLineStdIn
+from claude_statusline.models import GitInfo, SegmentGenerationResult, StatusLineStdIn
 from claude_statusline.render import render_lines
 
 CACHE_DURATION = 30  # seconds
@@ -165,7 +167,7 @@ def get_git_info(cwd: Path, session_id: str | None) -> GitInfo | None:
 
 def run_external_generator(
     cmd: str, payload_json: str, timeout: float = 2.0
-) -> list[Segment]:
+) -> Sequence[SegmentGenerationResult]:
     try:
         res = subprocess.run(
             shlex.split(cmd),
@@ -175,13 +177,20 @@ def run_external_generator(
             timeout=timeout,
         )
         if res.returncode == 0 and res.stdout.strip():
-            data = json.loads(res.stdout)
-            if isinstance(data, list):
-                return [Segment(**item) for item in data if isinstance(item, dict)]
-            elif isinstance(data, dict):
-                return [Segment(**data)]
-    except Exception:
-        pass
+            try:
+                data = json.loads(res.stdout)
+                if isinstance(data, dict):
+                    data = [data]
+                adapter = TypeAdapter(list[SegmentGenerationResult])
+                return adapter.validate_python(data)
+            except ValidationError as e:
+                # debug log instead of failing
+                print(
+                    f"Validation error in external generator {cmd}: {e}",
+                    file=sys.stderr,
+                )
+    except Exception as e:
+        print(f"Error running external generator {cmd}: {e}", file=sys.stderr)
     return []
 
 
@@ -216,7 +225,7 @@ def main(generator: tuple[str, ...]) -> None:
     if git_info and payload.workspace.git_worktree:
         git_info.is_worktree = True
 
-    extra_segments: list[Segment] = []
+    extra_segments: list[SegmentGenerationResult] = []
     if generator:
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=min(len(generator), 10)

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -1,6 +1,7 @@
-import concurrent.futures
+import asyncio
 import hashlib
 import json
+import logging
 import shlex
 import subprocess
 import sys
@@ -17,6 +18,11 @@ from claude_statusline.models import GitInfo, SegmentGenerationResult, StatusLin
 from claude_statusline.render import render_lines
 
 CACHE_DURATION = 30  # seconds
+
+logging.basicConfig(
+    level=logging.WARNING, stream=sys.stderr, format="%(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 
 class BranchRemoteInfo(NamedTuple):
@@ -165,32 +171,43 @@ def get_git_info(cwd: Path, session_id: str | None) -> GitInfo | None:
     return info
 
 
-def run_external_generator(
+async def run_external_generator(
     cmd: str, payload_json: str, timeout: float = 2.0
 ) -> Sequence[SegmentGenerationResult]:
     try:
-        res = subprocess.run(
-            shlex.split(cmd),
-            input=payload_json,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
+        proc = await asyncio.create_subprocess_exec(
+            *shlex.split(cmd),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        if res.returncode == 0 and res.stdout.strip():
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=payload_json.encode()), timeout=timeout
+            )
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            logger.warning(f"Timeout error in external generator {cmd}")
+            return []
+
+        if proc.returncode == 0 and stdout.strip():
             try:
-                data = json.loads(res.stdout)
-                if isinstance(data, dict):
-                    data = [data]
-                adapter = TypeAdapter(list[SegmentGenerationResult])
-                return adapter.validate_python(data)
-            except ValidationError as e:
-                # debug log instead of failing
-                print(
-                    f"Validation error in external generator {cmd}: {e}",
-                    file=sys.stderr,
+                # We can use TypeAdapter directly on the json string or parsed json
+                adapter = TypeAdapter(
+                    list[SegmentGenerationResult] | SegmentGenerationResult
                 )
+                data = adapter.validate_json(stdout)
+                if isinstance(data, list):
+                    return data
+                return [data]
+            except ValidationError as e:
+                logger.warning(f"Validation error in external generator {cmd}: {e}")
+            except Exception as e:
+                logger.warning(f"JSON parsing error in external generator {cmd}: {e}")
     except Exception as e:
-        print(f"Error running external generator {cmd}: {e}", file=sys.stderr)
+        logger.warning(f"Error running external generator {cmd}: {e}")
     return []
 
 
@@ -227,22 +244,20 @@ def main(generator: tuple[str, ...]) -> None:
 
     extra_segments: list[SegmentGenerationResult] = []
     if generator:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=min(len(generator), 10)
-        ) as executor:
-            futures = [
-                executor.submit(run_external_generator, cmd, raw_json_str)
-                for cmd in generator
-            ]
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    segs = future.result()
-                    if segs:
-                        extra_segments.extend(segs)
-                except Exception:
-                    pass
+
+        async def fetch_all():
+            tasks = [run_external_generator(cmd, raw_json_str) for cmd in generator]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for res in results:
+                if isinstance(res, Exception):
+                    continue
+                if res:
+                    extra_segments.extend(res)  # type: ignore
+
+        asyncio.run(fetch_all())
 
     lines = render_lines(payload, git_info, extra_segments)
+
     for line in lines:
         print(line)
 

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -14,7 +14,11 @@ from typing import NamedTuple
 import click
 from pydantic import TypeAdapter, ValidationError
 
-from claude_statusline.models import GitInfo, SegmentGenerationResult, StatusLineStdIn
+from claude_statusline.models import (
+    GitInfo,
+    SegmentGenerationResult,
+    StatusLineStdIn,
+)
 from claude_statusline.render import render_lines
 
 CACHE_DURATION = 30  # seconds

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -1,5 +1,7 @@
+import concurrent.futures
 import hashlib
 import json
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -7,7 +9,9 @@ import time
 from pathlib import Path
 from typing import NamedTuple
 
-from claude_statusline.models import GitInfo, StatusLineStdIn
+import click
+
+from claude_statusline.models import GitInfo, Segment, StatusLineStdIn
 from claude_statusline.render import render_lines
 
 CACHE_DURATION = 30  # seconds
@@ -159,19 +163,48 @@ def get_git_info(cwd: Path, session_id: str | None) -> GitInfo | None:
     return info
 
 
-def main() -> None:
+def run_external_generator(
+    cmd: str, payload_json: str, timeout: float = 2.0
+) -> list[Segment]:
+    try:
+        res = subprocess.run(
+            shlex.split(cmd),
+            input=payload_json,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            data = json.loads(res.stdout)
+            if isinstance(data, list):
+                return [Segment(**item) for item in data if isinstance(item, dict)]
+            elif isinstance(data, dict):
+                return [Segment(**data)]
+    except Exception:
+        pass
+    return []
+
+
+@click.command()
+@click.option(
+    "--generator",
+    multiple=True,
+    help="External command to generate segments (receives JSON payload on stdin).",
+)
+def main(generator: tuple[str, ...]) -> None:
+    raw_json_str = "{}"
     try:
         if not sys.stdin.isatty():
-            raw_data = json.load(sys.stdin)
+            raw_json_str = sys.stdin.read()
+            raw_data = json.loads(raw_json_str) if raw_json_str.strip() else {}
         else:
             raw_data = {}
-    except json.JSONDecodeError:
+    except Exception:
         raw_data = {}
 
     try:
         payload = StatusLineStdIn(**raw_data)
     except Exception:
-        # Fallback if parsing completely fails, though defaults should catch most
         payload = StatusLineStdIn()
 
     cwd_str = payload.workspace.current_dir
@@ -183,7 +216,24 @@ def main() -> None:
     if git_info and payload.workspace.git_worktree:
         git_info.is_worktree = True
 
-    lines = render_lines(payload, git_info)
+    extra_segments: list[Segment] = []
+    if generator:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(len(generator), 10)
+        ) as executor:
+            futures = [
+                executor.submit(run_external_generator, cmd, raw_json_str)
+                for cmd in generator
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    segs = future.result()
+                    if segs:
+                        extra_segments.extend(segs)
+                except Exception:
+                    pass
+
+    lines = render_lines(payload, git_info, extra_segments)
     for line in lines:
         print(line)
 

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -198,7 +198,7 @@ def run_external_generator(
 @click.option(
     "--generator",
     multiple=True,
-    help="External command to generate segments (receives JSON payload on stdin).",
+    help="External command or script to generate segments (receives JSON payload on stdin).",
 )
 def main(generator: tuple[str, ...]) -> None:
     raw_json_str = "{}"

--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -116,6 +116,8 @@ class Segment(BaseModel):
     text: str
 
 
-class SegmentGenerationResult(Segment):
+class SegmentGenerationResult(BaseModel):
+    segment: Segment
+    generator: str = "internal"
     line: int = 1
     index: int = 0

--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -121,3 +121,5 @@ class SegmentGenerationResult(BaseModel):
     generator: str = "internal"
     line: int = 1
     index: int = 0
+    cache_duration_seconds: int | None = None
+    next_call_timestamp: float | None = None

--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -110,3 +110,9 @@ class GitInfo(BaseModel):
     behind: int
     is_repo: bool
     is_worktree: bool = False
+
+
+class Segment(BaseModel):
+    text: str
+    line: int = 1
+    index: int = 0

--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from pydantic import BaseModel, Field
+from whenever import TimeDelta
 
 # --- Pydantic Models for Claude Code JSON Payload ---
 # See: https://code.claude.com/docs/en/statusline
@@ -121,5 +122,4 @@ class SegmentGenerationResult(BaseModel):
     generator: str = "internal"
     line: int = 1
     index: int = 0
-    cache_duration_seconds: int | None = None
-    next_call_timestamp: float | None = None
+    cache_duration: TimeDelta | None = None

--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -114,5 +114,8 @@ class GitInfo(BaseModel):
 
 class Segment(BaseModel):
     text: str
+
+
+class SegmentGenerationResult(Segment):
     line: int = 1
     index: int = 0

--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from pathlib import Path
 
-from claude_statusline.models import GitInfo, Segment, StatusLineStdIn
+from claude_statusline.models import GitInfo, SegmentGenerationResult, StatusLineStdIn
 from claude_statusline.segments import (
     DIVIDER_BAR,
     format_context_usage,
@@ -17,7 +17,7 @@ from claude_statusline.segments import (
 def render_lines(
     payload: StatusLineStdIn,
     git_info: GitInfo | None,
-    extra_segments: list[Segment] | None = None,
+    extra_segments: list[SegmentGenerationResult] | None = None,
 ) -> list[str]:
     """Renders the statusline as a list of strings."""
 
@@ -29,19 +29,21 @@ def render_lines(
         cwd_str = payload.cwd
     cwd = Path(cwd_str).resolve() if cwd_str else Path.cwd()
 
-    segments = extra_segments.copy()
-    segments.extend(
-        filter(
-            None,
-            [
-                format_model_info(payload),
-                format_session_info(payload),
-                format_directory(cwd),
-                format_obsidian_vault(cwd),
-                format_git_full(git_info),
-                format_context_usage(payload.context_window),
-                format_cost(payload),
-            ],
+    segments = tuple(
+        extra_segments
+        + list(
+            filter(
+                None,
+                [
+                    format_model_info(payload),
+                    format_session_info(payload),
+                    format_directory(cwd),
+                    format_obsidian_vault(cwd),
+                    format_git_full(git_info),
+                    format_context_usage(payload.context_window),
+                    format_cost(payload),
+                ],
+            )
         )
     )
 

--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -1,6 +1,7 @@
+from collections import defaultdict
 from pathlib import Path
 
-from claude_statusline.models import GitInfo, StatusLineStdIn
+from claude_statusline.models import GitInfo, Segment, StatusLineStdIn
 from claude_statusline.segments import (
     DIVIDER_BAR,
     format_context_usage,
@@ -13,29 +14,47 @@ from claude_statusline.segments import (
 )
 
 
-def render_lines(payload: StatusLineStdIn, git_info: GitInfo | None) -> list[str]:
-    """Renders the statusline as a list of strings, up to 3 lines."""
+def render_lines(
+    payload: StatusLineStdIn,
+    git_info: GitInfo | None,
+    extra_segments: list[Segment] | None = None,
+) -> list[str]:
+    """Renders the statusline as a list of strings."""
+
+    if extra_segments is None:
+        extra_segments = []
 
     cwd_str = payload.workspace.current_dir
     if not cwd_str and payload.cwd:
         cwd_str = payload.cwd
     cwd = Path(cwd_str).resolve() if cwd_str else Path.cwd()
 
-    model_seg = format_model_info(payload)
-    session_seg = format_session_info(payload)
-    dir_seg = format_directory(cwd)
-    obsidian_seg = format_obsidian_vault(cwd)
-    git_seg = format_git_full(git_info)
-    context_seg = format_context_usage(payload.context_window)
-    cost_seg = format_cost(payload)
+    segments = extra_segments.copy()
+    segments.extend(
+        filter(
+            None,
+            [
+                format_model_info(payload),
+                format_session_info(payload),
+                format_directory(cwd),
+                format_obsidian_vault(cwd),
+                format_git_full(git_info),
+                format_context_usage(payload.context_window),
+                format_cost(payload),
+            ],
+        )
+    )
 
-    line1_segs = filter(None, [model_seg, session_seg])
-    line1 = DIVIDER_BAR.join(s.text for s in line1_segs) or None
+    lines_map = defaultdict(list)
+    for seg in segments:
+        lines_map[seg.line].append(seg)
 
-    line2_segs = filter(None, [dir_seg, obsidian_seg])
-    line2 = DIVIDER_BAR.join(s.text for s in line2_segs) or None
+    result_lines = []
+    # Claude supports up to 3 lines. We render available lines sorted.
+    for line_num in sorted(lines_map.keys()):
+        line_segments = sorted(lines_map[line_num], key=lambda s: s.index)
+        text = DIVIDER_BAR.join(s.text for s in line_segments)
+        if text:
+            result_lines.append(text)
 
-    line3_segs = filter(None, [git_seg, context_seg, cost_seg])
-    line3 = DIVIDER_BAR.join(s.text for s in line3_segs) or None
-
-    return [line for line in [line1, line2, line3] if line]
+    return result_lines

--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -54,8 +54,10 @@ def render_lines(
     result_lines = []
     # Claude supports up to 3 lines. We render available lines sorted.
     for line_num in sorted(lines_map.keys()):
-        line_segments = sorted(lines_map[line_num], key=lambda s: s.index)
-        text = DIVIDER_BAR.join(s.text for s in line_segments)
+        line_segments = sorted(
+            lines_map[line_num], key=lambda s: (s.index, s.generator)
+        )
+        text = DIVIDER_BAR.join(s.segment.text for s in line_segments)
         if text:
             result_lines.append(text)
 

--- a/src/python/claude_statusline/claude_statusline/segments/__init__.py
+++ b/src/python/claude_statusline/claude_statusline/segments/__init__.py
@@ -1,3 +1,4 @@
+from claude_statusline.models import Segment
 from claude_statusline.segments.claude import (
     format_context_usage,
     format_cost,
@@ -7,7 +8,6 @@ from claude_statusline.segments.claude import (
 from claude_statusline.segments.constants import (
     DIVIDER_BAR,
     DIVIDER_DOT,
-    Segment,
 )
 from claude_statusline.segments.git import format_git_full
 from claude_statusline.segments.workspace import (

--- a/src/python/claude_statusline/claude_statusline/segments/__init__.py
+++ b/src/python/claude_statusline/claude_statusline/segments/__init__.py
@@ -1,4 +1,4 @@
-from claude_statusline.models import Segment
+from claude_statusline.models import SegmentGenerationResult
 from claude_statusline.segments.claude import (
     format_context_usage,
     format_cost,
@@ -27,5 +27,5 @@ __all__ = [
     "shorten_path",
     "DIVIDER_BAR",
     "DIVIDER_DOT",
-    "Segment",
+    "SegmentGenerationResult",
 ]

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -1,4 +1,4 @@
-from claude_statusline.models import ContextWindowInfo, StatusLineStdIn
+from claude_statusline.models import ContextWindowInfo, Segment, StatusLineStdIn
 from claude_statusline.segments.constants import (
     BLUE,
     BOLD,
@@ -9,7 +9,6 @@ from claude_statusline.segments.constants import (
     RED,
     RESET,
     YELLOW,
-    Segment,
     get_icon,
 )
 
@@ -40,7 +39,11 @@ def format_context_usage(cw: ContextWindowInfo) -> Segment | None:
         for i in range(width)
     )
 
-    return Segment(f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%")
+    return Segment(
+        line=3,
+        index=10,
+        text=f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%",
+    )
 
 
 def format_model_info(payload: StatusLineStdIn) -> Segment | None:
@@ -48,7 +51,7 @@ def format_model_info(payload: StatusLineStdIn) -> Segment | None:
         f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}",
         f"{MAGENTA}@{payload.agent.name}{RESET}" if payload.agent.name else None,
     ]
-    return Segment(" ".join(filter(None, parts)))
+    return Segment(line=1, index=0, text=" ".join(filter(None, parts)))
 
 
 def format_session_info(payload: StatusLineStdIn) -> Segment | None:
@@ -72,12 +75,14 @@ def format_session_info(payload: StatusLineStdIn) -> Segment | None:
 
     if not parts:
         return None
-    return Segment(" ".join(parts))
+    return Segment(line=1, index=10, text=" ".join(parts))
 
 
 def format_cost(payload: StatusLineStdIn) -> Segment | None:
     if not payload.cost.total_cost_usd:
         return None
     return Segment(
-        f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"
+        line=3,
+        index=20,
+        text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}",
     )

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -1,4 +1,8 @@
-from claude_statusline.models import ContextWindowInfo, Segment, StatusLineStdIn
+from claude_statusline.models import (
+    ContextWindowInfo,
+    SegmentGenerationResult,
+    StatusLineStdIn,
+)
 from claude_statusline.segments.constants import (
     BLUE,
     BOLD,
@@ -13,7 +17,7 @@ from claude_statusline.segments.constants import (
 )
 
 
-def format_context_usage(cw: ContextWindowInfo) -> Segment | None:
+def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | None:
     """Formats the context usage with a block-based progress bar and token stats."""
     used_pct = cw.used_percentage or 0.0
 
@@ -39,22 +43,22 @@ def format_context_usage(cw: ContextWindowInfo) -> Segment | None:
         for i in range(width)
     )
 
-    return Segment(
+    return SegmentGenerationResult(
         line=3,
         index=10,
         text=f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%",
     )
 
 
-def format_model_info(payload: StatusLineStdIn) -> Segment | None:
+def format_model_info(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
     parts = [
         f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}",
         f"{MAGENTA}@{payload.agent.name}{RESET}" if payload.agent.name else None,
     ]
-    return Segment(line=1, index=0, text=" ".join(filter(None, parts)))
+    return SegmentGenerationResult(line=1, index=0, text=" ".join(filter(None, parts)))
 
 
-def format_session_info(payload: StatusLineStdIn) -> Segment | None:
+def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
     parts = []
     if payload.session_name:
         parts.append(f"{CYAN}#{payload.session_name}{RESET}")
@@ -75,13 +79,13 @@ def format_session_info(payload: StatusLineStdIn) -> Segment | None:
 
     if not parts:
         return None
-    return Segment(line=1, index=10, text=" ".join(parts))
+    return SegmentGenerationResult(line=1, index=10, text=" ".join(parts))
 
 
-def format_cost(payload: StatusLineStdIn) -> Segment | None:
+def format_cost(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
     if not payload.cost.total_cost_usd:
         return None
-    return Segment(
+    return SegmentGenerationResult(
         line=3,
         index=20,
         text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}",

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -1,5 +1,6 @@
 from claude_statusline.models import (
     ContextWindowInfo,
+    Segment,
     SegmentGenerationResult,
     StatusLineStdIn,
 )
@@ -46,7 +47,9 @@ def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | Non
     return SegmentGenerationResult(
         line=3,
         index=10,
-        text=f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%",
+        segment=Segment(
+            text=f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%"
+        ),
     )
 
 
@@ -55,7 +58,9 @@ def format_model_info(payload: StatusLineStdIn) -> SegmentGenerationResult | Non
         f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}",
         f"{MAGENTA}@{payload.agent.name}{RESET}" if payload.agent.name else None,
     ]
-    return SegmentGenerationResult(line=1, index=0, text=" ".join(filter(None, parts)))
+    return SegmentGenerationResult(
+        line=1, index=0, segment=Segment(text=" ".join(filter(None, parts)))
+    )
 
 
 def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
@@ -79,7 +84,9 @@ def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | N
 
     if not parts:
         return None
-    return SegmentGenerationResult(line=1, index=10, text=" ".join(parts))
+    return SegmentGenerationResult(
+        line=1, index=10, segment=Segment(text=" ".join(parts))
+    )
 
 
 def format_cost(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
@@ -88,5 +95,7 @@ def format_cost(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
     return SegmentGenerationResult(
         line=3,
         index=20,
-        text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}",
+        segment=Segment(
+            text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"
+        ),
     )

--- a/src/python/claude_statusline/claude_statusline/segments/constants.py
+++ b/src/python/claude_statusline/claude_statusline/segments/constants.py
@@ -1,6 +1,5 @@
 import functools
 import os
-from dataclasses import dataclass
 from typing import Literal, NamedTuple
 
 
@@ -77,8 +76,3 @@ BLOCK_FILLED = "\u2588"  # █
 BLOCK_EMPTY = "\u2591"  # ░
 DIVIDER_DOT = " • "
 DIVIDER_BAR = " │ "
-
-
-@dataclass
-class Segment:
-    text: str

--- a/src/python/claude_statusline/claude_statusline/segments/git.py
+++ b/src/python/claude_statusline/claude_statusline/segments/git.py
@@ -1,4 +1,4 @@
-from claude_statusline.models import GitInfo, Segment
+from claude_statusline.models import GitInfo, SegmentGenerationResult
 from claude_statusline.segments.constants import (
     CYAN,
     GREEN,
@@ -10,7 +10,7 @@ from claude_statusline.segments.constants import (
 )
 
 
-def format_git_full(info: GitInfo | None) -> Segment | None:
+def format_git_full(info: GitInfo | None) -> SegmentGenerationResult | None:
     if not info:
         return None
 
@@ -38,4 +38,4 @@ def format_git_full(info: GitInfo | None) -> Segment | None:
     if info.remote:
         parts.append(f"\033]8;;{info.remote}\033\\{get_icon('remote')}\033]8;;\033\\")
 
-    return Segment(line=3, index=0, text=" ".join(parts))
+    return SegmentGenerationResult(line=3, index=0, text=" ".join(parts))

--- a/src/python/claude_statusline/claude_statusline/segments/git.py
+++ b/src/python/claude_statusline/claude_statusline/segments/git.py
@@ -1,4 +1,4 @@
-from claude_statusline.models import GitInfo, SegmentGenerationResult
+from claude_statusline.models import GitInfo, Segment, SegmentGenerationResult
 from claude_statusline.segments.constants import (
     CYAN,
     GREEN,
@@ -38,4 +38,6 @@ def format_git_full(info: GitInfo | None) -> SegmentGenerationResult | None:
     if info.remote:
         parts.append(f"\033]8;;{info.remote}\033\\{get_icon('remote')}\033]8;;\033\\")
 
-    return SegmentGenerationResult(line=3, index=0, text=" ".join(parts))
+    return SegmentGenerationResult(
+        line=3, index=0, segment=Segment(text=" ".join(parts))
+    )

--- a/src/python/claude_statusline/claude_statusline/segments/git.py
+++ b/src/python/claude_statusline/claude_statusline/segments/git.py
@@ -1,4 +1,4 @@
-from claude_statusline.models import GitInfo
+from claude_statusline.models import GitInfo, Segment
 from claude_statusline.segments.constants import (
     CYAN,
     GREEN,
@@ -6,7 +6,6 @@ from claude_statusline.segments.constants import (
     RED,
     RESET,
     YELLOW,
-    Segment,
     get_icon,
 )
 
@@ -39,4 +38,4 @@ def format_git_full(info: GitInfo | None) -> Segment | None:
     if info.remote:
         parts.append(f"\033]8;;{info.remote}\033\\{get_icon('remote')}\033]8;;\033\\")
 
-    return Segment(" ".join(parts))
+    return Segment(line=3, index=0, text=" ".join(parts))

--- a/src/python/claude_statusline/claude_statusline/segments/workspace.py
+++ b/src/python/claude_statusline/claude_statusline/segments/workspace.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from claude_statusline.models import SegmentGenerationResult
+from claude_statusline.models import Segment, SegmentGenerationResult
 from claude_statusline.segments.constants import BLUE, RESET, get_icon
 
 
@@ -25,7 +25,9 @@ def format_directory(cwd: Path) -> SegmentGenerationResult | None:
     display_path = shorten_path(cwd)
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
     return SegmentGenerationResult(
-        line=2, index=0, text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"
+        line=2,
+        index=0,
+        segment=Segment(text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"),
     )
 
 
@@ -37,7 +39,9 @@ def format_obsidian_vault(cwd: Path) -> SegmentGenerationResult | None:
             return SegmentGenerationResult(
                 line=2,
                 index=10,
-                text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}",
+                segment=Segment(
+                    text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}"
+                ),
             )
         current = current.parent
     return None

--- a/src/python/claude_statusline/claude_statusline/segments/workspace.py
+++ b/src/python/claude_statusline/claude_statusline/segments/workspace.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from claude_statusline.models import Segment
+from claude_statusline.models import SegmentGenerationResult
 from claude_statusline.segments.constants import BLUE, RESET, get_icon
 
 
@@ -21,18 +21,20 @@ def shorten_path(path: Path) -> str:
         return str(path)
 
 
-def format_directory(cwd: Path) -> Segment | None:
+def format_directory(cwd: Path) -> SegmentGenerationResult | None:
     display_path = shorten_path(cwd)
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
-    return Segment(line=2, index=0, text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}")
+    return SegmentGenerationResult(
+        line=2, index=0, text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"
+    )
 
 
-def format_obsidian_vault(cwd: Path) -> Segment | None:
+def format_obsidian_vault(cwd: Path) -> SegmentGenerationResult | None:
     current = cwd
     while current != current.parent:
         if (current / ".obsidian").is_dir():
             vault_name = current.name
-            return Segment(
+            return SegmentGenerationResult(
                 line=2,
                 index=10,
                 text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}",

--- a/src/python/claude_statusline/claude_statusline/segments/workspace.py
+++ b/src/python/claude_statusline/claude_statusline/segments/workspace.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from claude_statusline.segments.constants import BLUE, RESET, Segment, get_icon
+from claude_statusline.models import Segment
+from claude_statusline.segments.constants import BLUE, RESET, get_icon
 
 
 def shorten_path(path: Path) -> str:
@@ -23,7 +24,7 @@ def shorten_path(path: Path) -> str:
 def format_directory(cwd: Path) -> Segment | None:
     display_path = shorten_path(cwd)
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
-    return Segment(f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}")
+    return Segment(line=2, index=0, text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}")
 
 
 def format_obsidian_vault(cwd: Path) -> Segment | None:
@@ -31,6 +32,10 @@ def format_obsidian_vault(cwd: Path) -> Segment | None:
     while current != current.parent:
         if (current / ".obsidian").is_dir():
             vault_name = current.name
-            return Segment(f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}")
+            return Segment(
+                line=2,
+                index=10,
+                text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}",
+            )
         current = current.parent
     return None

--- a/src/python/claude_statusline/pyproject.toml
+++ b/src/python/claude_statusline/pyproject.toml
@@ -4,13 +4,16 @@ version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.12.5",
+    "click>=8.1.8",
 ]
 
 [project.scripts]
 claude-statusline = "claude_statusline.main:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = [
+    "hatchling",
+]
 build-backend = "hatchling.build"
 
 [dependency-groups]

--- a/src/python/claude_statusline/tests/test_main.py
+++ b/src/python/claude_statusline/tests/test_main.py
@@ -162,7 +162,7 @@ class TestStatusLine(unittest.TestCase):
                 import os
 
                 mock_term.return_value = os.terminal_size((80, 24))
-                main_module.main()
+                main_module.main(args=[], standalone_mode=False)
 
             self.assertEqual(mock_print.call_count, 3)
 
@@ -250,7 +250,7 @@ class TestStatusLine(unittest.TestCase):
                 import os
 
                 mock_term.return_value = os.terminal_size((80, 24))
-                main_module.main()
+                main_module.main(args=[], standalone_mode=False)
 
             self.assertEqual(mock_print.call_count, 3)
 

--- a/src/python/claude_statusline/tests/test_main.py
+++ b/src/python/claude_statusline/tests/test_main.py
@@ -24,26 +24,26 @@ class TestStatusLine(unittest.TestCase):
         res_low = format_context_usage(cw_low)
         self.assertIsNotNone(res_low)
         assert res_low is not None
-        self.assertIn(GREEN, res_low.text)
+        self.assertIn(GREEN, res_low.segment.text)
 
         cw_med = ContextWindowInfo(used_percentage=55.0)
         res_med = format_context_usage(cw_med)
         self.assertIsNotNone(res_med)
         assert res_med is not None
-        self.assertIn(YELLOW, res_med.text)
+        self.assertIn(YELLOW, res_med.segment.text)
 
         cw_high = ContextWindowInfo(used_percentage=95.0)
         res_high = format_context_usage(cw_high)
         self.assertIsNotNone(res_high)
         assert res_high is not None
-        self.assertIn(RED, res_high.text)
+        self.assertIn(RED, res_high.segment.text)
 
         cw_none = ContextWindowInfo(used_percentage=None)
         res_none = format_context_usage(cw_none)
         self.assertIsNotNone(res_none)
         assert res_none is not None
-        self.assertIn("0%", res_none.text)
-        self.assertIn(GREEN, res_none.text)
+        self.assertIn("0%", res_none.segment.text)
+        self.assertIn(GREEN, res_none.segment.text)
 
     def test_format_git_full(self) -> None:
         base_kwargs: dict[str, Any] = {
@@ -62,16 +62,16 @@ class TestStatusLine(unittest.TestCase):
         res = format_git_full(info)
         self.assertIsNotNone(res)
         assert res is not None
-        self.assertIn("main", res.text)
-        self.assertIn(get_icon("clean"), res.text)
-        self.assertIn(get_icon("remote"), res.text)
+        self.assertIn("main", res.segment.text)
+        self.assertIn(get_icon("clean"), res.segment.text)
+        self.assertIn(get_icon("remote"), res.segment.text)
 
         base_kwargs["dirty"] = True
         info = GitInfo(**base_kwargs)
         res = format_git_full(info)
         self.assertIsNotNone(res)
         assert res is not None
-        self.assertIn(get_icon("dirty"), res.text)
+        self.assertIn(get_icon("dirty"), res.segment.text)
 
         base_kwargs["dirty"] = False
         base_kwargs["staged"] = True
@@ -79,7 +79,7 @@ class TestStatusLine(unittest.TestCase):
         res = format_git_full(info)
         self.assertIsNotNone(res)
         assert res is not None
-        self.assertIn(get_icon("staged"), res.text)
+        self.assertIn(get_icon("staged"), res.segment.text)
 
         base_kwargs["staged"] = False
         base_kwargs["untracked"] = True
@@ -87,7 +87,7 @@ class TestStatusLine(unittest.TestCase):
         res = format_git_full(info)
         self.assertIsNotNone(res)
         assert res is not None
-        self.assertIn(get_icon("untracked"), res.text)
+        self.assertIn(get_icon("untracked"), res.segment.text)
 
         base_kwargs["untracked"] = False
         base_kwargs["ahead"] = 2
@@ -96,8 +96,8 @@ class TestStatusLine(unittest.TestCase):
         res = format_git_full(info)
         self.assertIsNotNone(res)
         assert res is not None
-        self.assertIn("↑2", res.text)
-        self.assertIn("↓1", res.text)
+        self.assertIn("↑2", res.segment.text)
+        self.assertIn("↓1", res.segment.text)
 
     @patch("subprocess.run")
     def test_get_git_info_fresh(self, mock_run: MagicMock) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,7 @@ name = "claude-statusline"
 version = "0.0.0"
 source = { editable = "src/python/claude_statusline" }
 dependencies = [
+    { name = "click" },
     { name = "pydantic" },
 ]
 
@@ -170,7 +171,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.12.5" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.1.8" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Refactored claude-statusline to use Click for CLI parsing.
Added `--generator` flag to concurrently execute external scripts that generate Pydantic Segment JSON models, which are then rendered.
Updated chezmoi template to parse generators using `dig` function without modifying the configuration schema directly.

---
*PR created automatically by Jules for task [13509057503192781451](https://jules.google.com/task/13509057503192781451) started by @mkobit*