### PR TITLE
ci: simplify CI workflow and remove push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -135,23 +132,3 @@ jobs:
           MISE_BIN=$(chezmoi --source=${{ github.workspace }} --destination=/tmp/chezmoi-test target-path ${{ github.workspace }}/src/chezmoi/dot_local/bin)/mise
           "$MISE_BIN" cache prune --yes
 
-  summary:
-    if: always()
-    needs: [lint, test, integration]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - name: Report results
-        run: |
-          echo "=== CI Summary ==="
-          echo "Lint:        ${{ needs.lint.result }}"
-          echo "Test:        ${{ needs.test.result }}"
-          echo "Integration: ${{ needs.integration.result }}"
-
-          if [[ "${{ needs.lint.result }}" == "failure" ||
-                "${{ needs.test.result }}" == "failure" ||
-                "${{ needs.integration.result }}" == "failure" ]]; then
-            echo "❌ CI failed"
-            exit 1
-          fi
-          echo "✅ All checks passed"


### PR DESCRIPTION
- Modified .github/workflows/ci.yml to trigger exclusively on pull_requests
- Removed the summary job at the end of the workflow to eliminate unnecessary fan-in complexity

---
*PR created automatically by Jules for task [2699833451913111565](https://jules.google.com/task/2699833451913111565) started by @mkobit*