### PR TITLE
feat(tmux): add robot icon for AI CLI tools in pane names

### DIFF
--- a/src/chezmoi/dot_dotfiles/tmux/snippets/status_bar_styling.tmux
+++ b/src/chezmoi/dot_dotfiles/tmux/snippets/status_bar_styling.tmux
@@ -29,7 +29,7 @@ set-window-option -g allow-rename off
 # Docs: https://man.openbsd.org/tmux#automatic-rename
 set-window-option -g automatic-rename on
 # Docs: https://man.openbsd.org/tmux#automatic-rename-format
-set-window-option -g automatic-rename-format "#{?#{==:#{pane_current_command},zsh},#{b:pane_current_path},#{pane_current_command}}"
+set-window-option -g automatic-rename-format "#{?#{==:#{pane_current_command},zsh},#{b:pane_current_path},#{?#{||:#{m:*claude*,#{pane_current_command}},#{m:*gemini*,#{pane_current_command}}},🤖 #{b:pane_current_path},#{pane_current_command}}}"
 
 # === BEHAVIOR SETTINGS ===
 # Use vi-style status line navigation


### PR DESCRIPTION
This PR updates the tmux `automatic-rename-format` string in `src/chezmoi/dot_dotfiles/tmux/snippets/status_bar_styling.tmux`. 

It uses tmux format string matching and conditionals to identify when `claude` or `gemini` commands are actively running in a pane. Instead of displaying a generic process name like "python" or "bash", it now updates the pane's name to prepend a robot emoji (🤖) to the trailing current working directory, giving you a quick visual cue when an AI CLI tool is operating. The existing behaviour for `zsh` showing just the directory is preserved.

---
*PR created automatically by Jules for task [16287286497727744506](https://jules.google.com/task/16287286497727744506) started by @mkobit*