### PR TITLE
feat(chezmoi): install chafa via external

### DIFF
--- a/src/chezmoi/.chezmoidata/chafa.toml
+++ b/src/chezmoi/.chezmoidata/chafa.toml
@@ -1,3 +1,0 @@
-[chafa]
-version = "1.18.1"
-installation = "external-sources"

--- a/src/chezmoi/.chezmoidata/chafa.toml
+++ b/src/chezmoi/.chezmoidata/chafa.toml
@@ -1,0 +1,2 @@
+[chafa]
+version = "1.18.1"

--- a/src/chezmoi/.chezmoidata/chafa.toml
+++ b/src/chezmoi/.chezmoidata/chafa.toml
@@ -1,2 +1,6 @@
 [chafa]
 version = "1.18.1"
+
+[chafa.checksums]
+linux_amd64 = "aae17508b9e21f67291f50b849e2ce5d31cf194ab65ac3b439bc45effa64be33"
+linux_arm = "94f6b33e3a417a3cafcb0fe31059ae015323dc4ae2eb57bbf57360a5962d8d82"

--- a/src/chezmoi/.chezmoidata/chafa.toml
+++ b/src/chezmoi/.chezmoidata/chafa.toml
@@ -1,0 +1,3 @@
+[chafa]
+version = "1.18.1"
+installation = "external-sources"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -1,0 +1,31 @@
+{{ if eq .chafa.installation "package-manager" }}#!/bin/bash
+CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
+source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
+if check_command chafa; then
+    log_success "chafa already installed"
+    exit 0
+fi
+log_info "Installing chafa via package manager..."
+{{ if eq .chezmoi.os "darwin" }}
+if ! check_command brew; then
+    log_error "Homebrew not found."
+    exit 1
+fi
+if brew install chafa; then
+    log_success "chafa installed via homebrew"
+else
+    log_error "Failed to install chafa via homebrew"
+    exit 1
+fi
+{{ else if eq .chezmoi.os "linux" }}
+if sudo apt-get update && sudo apt-get install -y chafa; then
+    log_success "chafa installed via apt"
+else
+    log_error "Failed to install chafa via apt"
+    exit 1
+fi
+{{ else }}
+log_error "Unsupported OS: {{ .chezmoi.os }}"
+exit 1
+{{ end }}
+{{ end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -1,4 +1,5 @@
-{{ if eq .chafa.installation "package-manager" }}#!/bin/bash
+{{-  := dig "chafa" "installation" "external-sources" . -}}
+{{- if eq  "package-manager" -}}#!/bin/bash
 CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
 source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 if check_command chafa; then
@@ -28,4 +29,4 @@ fi
 log_error "Unsupported OS: {{ .chezmoi.os }}"
 exit 1
 {{ end }}
-{{ end }}
+{{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -1,5 +1,5 @@
-{{-  := dig "chafa" "installation" "external-sources" . -}}
-{{- if eq  "package-manager" -}}#!/bin/bash
+{{- $installation := dig "chafa" "installation" "external-sources" . -}}
+{{- if eq $installation "package-manager" -}}#!/bin/bash
 CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
 source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 if check_command chafa; then

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
@@ -1,0 +1,17 @@
+{{- with .chafa -}}
+{{- if eq .installation "external-sources" -}}
+{{- $target := "" -}}
+{{- if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "amd64") -}}
+  {{- $target = "x86_64-linux-gnu" -}}
+{{- else if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "arm") -}}
+  {{- $target = "armv7l-linux-gnu" -}}
+{{- end -}}
+{{- if ne $target "" -}}
+["chafa"]
+type = "archive-file"
+url = "https://hpjansson.org/chafa/releases/static/chafa-{{ .version }}-1-{{ $target }}.tar.gz"
+path = "chafa-{{ .version }}-1-{{ $target }}/chafa"
+executable = true
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
@@ -1,6 +1,7 @@
 {{- $version := dig "chafa" "version" "1.18.1" . -}}
 {{- $installation := dig "chafa" "installation" "external-sources" . -}}
 {{- if eq $installation "external-sources" -}}
+{{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "amd64") -}}
   {{- $target = "x86_64-linux-gnu" -}}
@@ -13,5 +14,9 @@ type = "archive-file"
 url = "https://hpjansson.org/chafa/releases/static/chafa-{{ $version }}-1-{{ $target }}.tar.gz"
 path = "chafa-{{ $version }}-1-{{ $target }}/chafa"
 executable = true
+{{- $checksums := dig "chafa" "checksums" dict . -}}
+{{- if and (hasKey $checksums $platform) (ne (trim (index $checksums $platform)) "") }}
+checksum.sha256 = "{{ index $checksums $platform }}"
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
@@ -1,5 +1,6 @@
-{{- with .chafa -}}
-{{- if eq .installation "external-sources" -}}
+{{- $version := dig "chafa" "version" "1.18.1" . -}}
+{{- $installation := dig "chafa" "installation" "external-sources" . -}}
+{{- if eq $installation "external-sources" -}}
 {{- $target := "" -}}
 {{- if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "amd64") -}}
   {{- $target = "x86_64-linux-gnu" -}}
@@ -9,9 +10,8 @@
 {{- if ne $target "" -}}
 ["chafa"]
 type = "archive-file"
-url = "https://hpjansson.org/chafa/releases/static/chafa-{{ .version }}-1-{{ $target }}.tar.gz"
-path = "chafa-{{ .version }}-1-{{ $target }}/chafa"
+url = "https://hpjansson.org/chafa/releases/static/chafa-{{ $version }}-1-{{ $target }}.tar.gz"
+path = "chafa-{{ $version }}-1-{{ $target }}/chafa"
 executable = true
-{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This PR implements the installation of `chafa` via a Chezmoi external configuration.

1. Defines `chafa` version (`1.18.1`) and installation type (`external-sources`) in `src/chezmoi/.chezmoidata/chafa.toml`.
2. Adds `src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl` to download and extract the pre-built `chafa` binary archive from `hpjansson.org/chafa/releases/static`. The logic is scoped for supported platforms like Linux `amd64` and `arm`.
3. Includes a fallback installation script `src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl` utilizing standard package managers (Homebrew and APT) for situations where users set `installation = "package-manager"` or for unsupported environments like macOS.

These configurations follow the repository's convention for scoped externals inside `dot_local/bin/.chezmoiexternals`.

---
*PR created automatically by Jules for task [7358935035133777719](https://jules.google.com/task/7358935035133777719) started by @mkobit*