### PR TITLE
chore: silence package manager normal logging in scripts

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install bat; then
+if brew install bat >/dev/null; then
     log_success "bat installed successfully via homebrew"
 else
     log_error "Failed to install bat via homebrew"
@@ -25,7 +25,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
-if sudo apt-get update && sudo apt-get install -y bat; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y bat >/dev/null; then
     log_success "bat installed successfully via apt"
 else
     log_error "Failed to install bat via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -12,14 +12,14 @@ if ! check_command brew; then
     log_error "Homebrew not found."
     exit 1
 fi
-if brew install chafa; then
+if brew install chafa >/dev/null; then
     log_success "chafa installed via homebrew"
 else
     log_error "Failed to install chafa via homebrew"
     exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
-if sudo apt-get update && sudo apt-get install -y chafa; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y chafa >/dev/null; then
     log_success "chafa installed via apt"
 else
     log_error "Failed to install chafa via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install eza; then
+if brew install eza >/dev/null; then
     log_success "eza installed successfully via homebrew"
 else
     log_error "Failed to install eza via homebrew"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install fzf; then
+if brew install fzf >/dev/null; then
     log_success "fzf installed successfully via homebrew"
 else
     log_error "Failed to install fzf via homebrew"
@@ -25,7 +25,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
-if sudo apt-get update && sudo apt-get install -y fzf; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y fzf >/dev/null; then
     log_success "fzf installed successfully via apt"
 else
     log_error "Failed to install fzf via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install --cask ghostty; then
+if brew install --cask ghostty >/dev/null; then
     log_success "ghostty installed successfully via homebrew cask"
 else
     log_error "Failed to install ghostty via homebrew cask"
@@ -34,7 +34,7 @@ if command -v apt-get >/dev/null 2>&1; then
         exit 1
     fi
 
-    if sudo snap install ghostty --classic; then
+    if sudo snap install ghostty --classic >/dev/null; then
         log_success "ghostty installed successfully via snap"
     else
         log_error "Failed to install ghostty via snap"
@@ -46,7 +46,7 @@ elif command -v pacman >/dev/null 2>&1; then
     # Arch Linux - official repos only
     log_info "Installing ghostty via pacman (Arch Linux)"
     
-    if sudo pacman -S --noconfirm ghostty; then
+    if sudo pacman -S --noconfirm ghostty >/dev/null; then
         log_success "ghostty installed successfully via pacman"
     else
         log_error "Failed to install ghostty via pacman"
@@ -59,7 +59,7 @@ elif command -v dnf >/dev/null 2>&1; then
     # Fedora
     log_info "Installing ghostty via dnf (Fedora)"
     
-    if sudo dnf install -y ghostty; then
+    if sudo dnf install -y ghostty >/dev/null; then
         log_success "ghostty installed successfully via dnf"
     else
         log_error "Failed to install ghostty via dnf"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
@@ -14,7 +14,7 @@ else
         exit 1
     fi
 
-    if brew install --cask hammerspoon; then
+    if brew install --cask hammerspoon >/dev/null; then
         log_success "hammerspoon installed successfully via homebrew cask"
     else
         log_error "Failed to install hammerspoon via homebrew cask"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install jq; then
+if brew install jq >/dev/null; then
     log_success "jq installed successfully via homebrew"
 else
     log_error "Failed to install jq via homebrew"
@@ -25,7 +25,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
-if sudo apt-get update && sudo apt-get install -y jq; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y jq >/dev/null; then
     log_success "jq installed successfully via apt"
 else
     log_error "Failed to install jq via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install ripgrep; then
+if brew install ripgrep >/dev/null; then
     log_success "ripgrep installed successfully via homebrew"
 else
     log_error "Failed to install ripgrep via homebrew"
@@ -25,7 +25,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
-if sudo apt-get update && sudo apt-get install -y ripgrep; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y ripgrep >/dev/null; then
     log_success "ripgrep installed successfully via apt"
 else
     log_error "Failed to install ripgrep via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-sandbox-deps.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-sandbox-deps.sh.tmpl
@@ -10,7 +10,7 @@ fi
 
 log_info "Installing bubblewrap and socat via package manager..."
 
-if sudo apt-get update && sudo apt-get install -y bubblewrap socat; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y bubblewrap socat >/dev/null; then
     log_success "bubblewrap and socat installed successfully via apt"
 else
     log_error "Failed to install bubblewrap and socat via apt"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
@@ -17,7 +17,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install zoxide; then
+if brew install zoxide >/dev/null; then
     log_success "zoxide installed successfully via homebrew"
 else
     log_error "Failed to install zoxide via homebrew"
@@ -25,7 +25,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - zoxide may not be in older Ubuntu repos
-if sudo apt-get update && sudo apt-get install -y zoxide; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y zoxide >/dev/null; then
     log_success "zoxide installed successfully via apt"
 else
     log_warn "zoxide not available in apt repos"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
@@ -18,7 +18,7 @@ if ! check_command brew; then
     exit 1
 fi
 
-if brew install zsh; then
+if brew install zsh >/dev/null; then
     log_success "zsh installed successfully"
 else
     log_error "Failed to install zsh"
@@ -26,7 +26,7 @@ else
 fi
 {{ else if eq .chezmoi.os "linux" -}}
 # Linux - use apt (Ubuntu/Debian)
-if sudo apt-get update && sudo apt-get install -y zsh; then
+if sudo apt-get update >/dev/null && sudo apt-get install -y zsh >/dev/null; then
     log_success "zsh installed successfully"
 else
     log_error "Failed to install zsh"

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -15,7 +15,7 @@ log_info "Uninstalling ghostty..."
 # macOS - use Homebrew Cask
 if check_command brew; then
     if brew list --cask ghostty >/dev/null 2>&1; then
-        if brew uninstall --cask ghostty; then
+        if brew uninstall --cask ghostty >/dev/null; then
             log_success "ghostty uninstalled successfully via homebrew cask"
         else
             log_error "Failed to uninstall ghostty via homebrew cask"
@@ -41,7 +41,7 @@ if command -v apt-get >/dev/null 2>&1; then
     log_info "Uninstalling ghostty via apt (Ubuntu/Debian)"
     
     if dpkg -l | grep -q ghostty; then
-        if sudo apt-get remove -y ghostty; then
+        if sudo apt-get remove -y ghostty >/dev/null; then
             log_success "ghostty uninstalled successfully via apt"
         else
             log_error "Failed to uninstall ghostty via apt"
@@ -71,7 +71,7 @@ elif command -v dnf >/dev/null 2>&1; then
     log_info "Uninstalling ghostty via dnf (Fedora)"
     
     if dnf list installed ghostty >/dev/null 2>&1; then
-        if sudo dnf remove -y ghostty; then
+        if sudo dnf remove -y ghostty >/dev/null; then
             log_success "ghostty uninstalled successfully via dnf"
         else
             log_error "Failed to uninstall ghostty via dnf"


### PR DESCRIPTION
Appended `>/dev/null` to standard package manager execution calls (like `apt-get`, `brew`, `pacman`, `dnf`, `snap`) within `src/chezmoi/.chezmoiscripts/*.tmpl` to suppress verbose normal-operation logging while still allowing `stderr` errors to surface. This simple redirection satisfies the requirement to reduce log garbage during standard execution.

---
*PR created automatically by Jules for task [7728536504148559882](https://jules.google.com/task/7728536504148559882) started by @mkobit*