### PR TITLE
Update tmux redraw rate and remove seconds from time segment

### DIFF
--- a/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
+++ b/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
@@ -28,7 +28,6 @@
 	export TMUX_POWERLINE_WINDOW_STATUS_LINE=1
 	# The status bar refresh interval in seconds.
 	# Note that events that force-refresh the status bar (such as window renaming) will ignore this.
-	# Set to 20s to reduce process spawning and SentinelOne scanning overhead
 	export TMUX_POWERLINE_STATUS_INTERVAL="20"
 	# The location of the window list. Can be {"absolute-centre, centre, left, right"}.
 	# Note that "absolute-centre" is only supported on `tmux -V` >= 3.2.

--- a/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
+++ b/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
@@ -28,8 +28,8 @@
 	export TMUX_POWERLINE_WINDOW_STATUS_LINE=1
 	# The status bar refresh interval in seconds.
 	# Note that events that force-refresh the status bar (such as window renaming) will ignore this.
-	# Set to 10s to reduce process spawning and SentinelOne scanning overhead
-	export TMUX_POWERLINE_STATUS_INTERVAL="10"
+	# Set to 20s to reduce process spawning and SentinelOne scanning overhead
+	export TMUX_POWERLINE_STATUS_INTERVAL="20"
 	# The location of the window list. Can be {"absolute-centre, centre, left, right"}.
 	# Note that "absolute-centre" is only supported on `tmux -V` >= 3.2.
 	export TMUX_POWERLINE_STATUS_JUSTIFICATION="centre"
@@ -344,8 +344,8 @@
 # }
 
 # time.sh {
-	# date(1) format for the time. Americans might want to have "%I:%M:%S %p".
-	export TMUX_POWERLINE_SEG_TIME_FORMAT="%H:%M:%S %Z"
+	# date(1) format for the time. Americans might want to have "%I:%M %p".
+	export TMUX_POWERLINE_SEG_TIME_FORMAT="%H:%M %Z"
 	# Change this to display a different timezone than the system default.
 	# Use TZ Identifier like "America/Los_Angeles"
 	# export TMUX_POWERLINE_SEG_TIME_TZ=""


### PR DESCRIPTION
- Updated the tmux-powerline redraw rate (`TMUX_POWERLINE_STATUS_INTERVAL`) from 10 seconds to 20 seconds to reduce overhead.
- Removed the seconds display from the time segment format (`TMUX_POWERLINE_SEG_TIME_FORMAT`).

---
*PR created automatically by Jules for task [1461863787604173404](https://jules.google.com/task/1461863787604173404) started by @mkobit*