### PR TITLE
chore: disable claude code sandbox locally

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,7 @@
     ]
   },
   "sandbox": {
-    "enabled": true,
+    "enabled": false,
     "filesystem": {
       "allowRead": [
         ".",


### PR DESCRIPTION
Disabled the Claude Code sandbox locally in `.claude/settings.json`. The sandbox was too restrictive for local workflows, blocking operations like `git push`, the `jules` CLI, and general web searches.

---
*PR created automatically by Jules for task [17098907109591185362](https://jules.google.com/task/17098907109591185362) started by @mkobit*