### PR TITLE
refactor(chezmoi): replace home directory references with destDir in templates

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
@@ -6,7 +6,7 @@ source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 log_info "Configuring iTerm2 to disable bell sounds..."
 
 # iTerm2 configuration is stored in com.googlecode.iterm2.plist
-PLIST_PATH="$HOME/Library/Preferences/com.googlecode.iterm2.plist"
+PLIST_PATH="{{ .chezmoi.destDir }}/Library/Preferences/com.googlecode.iterm2.plist"
 
 # Check if iTerm2 has been run at least once (plist exists)
 if [[ ! -f "$PLIST_PATH" ]]; then

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -87,9 +87,9 @@ else
 fi
 
 # Clean up manual installations
-if [[ -f "$HOME/.local/bin/ghostty" ]]; then
+if [[ -f "{{ .chezmoi.destDir }}/.local/bin/ghostty" ]]; then
     log_info "Removing ghostty from ~/.local/bin..."
-    rm -f "$HOME/.local/bin/ghostty" && log_success "Removed ~/.local/bin/ghostty"
+    rm -f "{{ .chezmoi.destDir }}/.local/bin/ghostty" && log_success "Removed ~/.local/bin/ghostty"
 fi
 
 if [[ -f "/usr/local/bin/ghostty" ]]; then
@@ -103,15 +103,15 @@ exit 1
 {{ end }}
 
 # Clean up configuration directory on all platforms
-if [[ -d "$HOME/.config/ghostty" ]]; then
+if [[ -d "{{ .chezmoi.destDir }}/.config/ghostty" ]]; then
     log_info "Removing ghostty configuration directory..."
-    rm -rf "$HOME/.config/ghostty" && log_success "Removed ~/.config/ghostty"
+    rm -rf "{{ .chezmoi.destDir }}/.config/ghostty" && log_success "Removed ~/.config/ghostty"
 fi
 
 # Clean up cache directory if it exists
-if [[ -d "$HOME/.cache/ghostty" ]]; then
+if [[ -d "{{ .chezmoi.destDir }}/.cache/ghostty" ]]; then
     log_info "Removing ghostty cache directory..."
-    rm -rf "$HOME/.cache/ghostty" && log_success "Removed ~/.cache/ghostty"
+    rm -rf "{{ .chezmoi.destDir }}/.cache/ghostty" && log_success "Removed ~/.cache/ghostty"
 fi
 
 log_success "ghostty uninstallation completed"

--- a/src/chezmoi/dot_dotfiles/hammerspoon/config.lua.tmpl
+++ b/src/chezmoi/dot_dotfiles/hammerspoon/config.lua.tmpl
@@ -3,7 +3,7 @@
 
 -- Global Configuration Table
 _G.DotfilesConfig = {
-    cache_dir = "{{ .chezmoi.homeDir }}/.cache",
+    cache_dir = "{{ .chezmoi.destDir }}/.cache",
     window_manager = {
         enabled = {{ .hammerspoon.window_manager.enabled | default "false" }}
     }


### PR DESCRIPTION
As per the `AGENTS.md` instructions, this PR removes all references to `$HOME` and `{{ .chezmoi.homeDir }}` in Chezmoi templates, swapping them out for `{{ .chezmoi.destDir }}`. This avoids issues in CI environments and automated tests by keeping file alterations contained within the designated destination sandbox.

Files modified:
*   `src/chezmoi/dot_dotfiles/hammerspoon/config.lua.tmpl`
*   `src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl`
*   `src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl`

---
*PR created automatically by Jules for task [13517800344191970842](https://jules.google.com/task/13517800344191970842) started by @mkobit*