### PR TITLE
fix: update shebang to use env in chezmoiscripts

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -1,5 +1,5 @@
 {{- if and (ne (dig "mise" "installation" "disabled" .) "disabled") (dig "mise" "global_tools" dict .) -}}
-#!/bin/bash
+#!/usr/bin/env bash
 {{/* Calculate hash from sorted JSON of global tools map for change detection in the script content itself */ -}}
 {{- $toolsJson := .mise.global_tools | default dict | toJson -}}
 # mise.global_tools hash: {{ $toolsJson | sha256sum }}

--- a/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 {{/* Calculate hash from sorted JSON of extensions map for change detection in the script content itself */ -}}
 {{- $extensionsJson := .gemini.extensions | default dict | toJson -}}
 # gemini.extensions hash: {{ $extensionsJson | sha256sum }}

--- a/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and (eq .chezmoi.os "darwin") (stat "/Applications/iTerm.app") }}#!/bin/bash
+{{ if and (eq .chezmoi.os "darwin") (stat "/Applications/iTerm.app") }}#!/usr/bin/env bash
 
 # logging.sh hash: {{ includeTemplate "shell/logging.sh" | sha256sum }}
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .bat.installation "package-manager" }}#!/bin/bash
+{{ if eq .bat.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -1,5 +1,5 @@
 {{- $installation := dig "chafa" "installation" "external-sources" . -}}
-{{- if eq $installation "package-manager" -}}#!/bin/bash
+{{- if eq $installation "package-manager" -}}#!/usr/bin/env bash
 CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
 source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 if check_command chafa; then

--- a/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq (index .eza.installation .chezmoi.os) "package-manager" }}#!/bin/bash
+{{ if eq (index .eza.installation .chezmoi.os) "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .fzf.installation "package-manager" }}#!/bin/bash
+{{ if eq .fzf.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .ghostty.installation "package-manager" }}#!/bin/bash
+{{ if eq .ghostty.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if and .hammerspoon.enabled (eq .hammerspoon.installation "package-manager") (eq .chezmoi.os "darwin") }}#!/bin/bash
+{{ if and .hammerspoon.enabled (eq .hammerspoon.installation "package-manager") (eq .chezmoi.os "darwin") }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .jq.installation "package-manager" }}#!/bin/bash
+{{ if eq .jq.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .ripgrep.installation "package-manager" }}#!/bin/bash
+{{ if eq .ripgrep.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .zoxide.installation "package-manager" }}#!/bin/bash
+{{ if eq .zoxide.installation "package-manager" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -1,4 +1,4 @@
-{{ if eq .ghostty.installation "disabled" }}#!/bin/bash
+{{ if eq .ghostty.installation "disabled" }}#!/usr/bin/env bash
 
 # logging.sh hash: {{ includeTemplate "shell/logging.sh" | sha256sum }}
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_install-zsh-set-default.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_install-zsh-set-default.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if .zsh.set_as_default_login_shell }}#!/bin/bash
+{{- if .zsh.set_as_default_login_shell }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 


### PR DESCRIPTION
This change updates the hardcoded `#!/bin/bash` shebangs across multiple script templates under `src/chezmoi/.chezmoiscripts/` to use `#!/usr/bin/env bash`. This improves cross-platform portability by relying on the user's `PATH` to locate bash, especially on systems where bash may not be located at `/bin/bash`. Replaced inline shebangs occurring immediately after `{{ if ... }}` template guard blocks.

---
*PR created automatically by Jules for task [9678616147249578847](https://jules.google.com/task/9678616147249578847) started by @mkobit*