### PR TITLE
feat(zsh,ghostty): embrace vi mode with cursor shape feedback and fix…

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
@@ -1,3 +1,4 @@
+{{- if ne (dig "mise" "global_tools" "npm:@google/gemini-cli" "installation" "mise" .) "disabled" -}}
 #!/usr/bin/env bash
 {{/* Calculate hash from sorted JSON of extensions map for change detection in the script content itself */ -}}
 {{- $extensionsJson := .gemini.extensions | default dict | toJson -}}
@@ -32,3 +33,4 @@ fi
 {{- end }}
 
 log_success "Gemini extensions installation complete."
+{{- end -}}

--- a/src/chezmoi/.chezmoitemplates/zsh/530_keybindings.zsh
+++ b/src/chezmoi/.chezmoitemplates/zsh/530_keybindings.zsh
@@ -1,0 +1,18 @@
+#!/usr/bin/env zsh
+
+# =============================================================================
+# Zsh vi mode enhancements
+# Must run after bindkey -v (060_zsh_defaults.zsh).
+# =============================================================================
+
+# Cursor shape: beam in insert mode, block in normal mode.
+# Same visual language as terminal vim — you always know which mode you're in.
+# Uses VT escape sequences supported by Ghostty, iTerm2, and most modern terminals.
+function _zle_vi_mode_cursor() {
+    case $KEYMAP in
+        vicmd)      print -n '\e[2 q' ;;  # block
+        viins|main) print -n '\e[6 q' ;;  # beam
+    esac
+}
+zle -N zle-keymap-select _zle_vi_mode_cursor
+zle -N zle-line-init      _zle_vi_mode_cursor

--- a/src/chezmoi/dot_config/ghostty/conf.d/keybinds.conf
+++ b/src/chezmoi/dot_config/ghostty/conf.d/keybinds.conf
@@ -1,0 +1,9 @@
+# Terminal line navigation keybinds
+# Cmd+Left/Right send Ctrl+A/E, which zsh recognizes in both viins and emacs keymaps.
+# This avoids ESC-prefix sequences entirely for line start/end, sidestepping vi-mode conflicts.
+# https://ghostty.org/docs/config/reference#keybind
+keybind = super+left=text:\x01
+keybind = super+right=text:\x05
+
+# Cmd+Backspace: delete to beginning of line (Ctrl+U).
+keybind = super+backspace=text:\x15

--- a/src/chezmoi/dot_config/ghostty/config
+++ b/src/chezmoi/dot_config/ghostty/config
@@ -7,3 +7,4 @@ config-file = conf.d/claude-ide-shift-enter.conf
 config-file = conf.d/font.conf
 config-file = conf.d/macos.conf
 config-file = conf.d/interaction.conf
+config-file = conf.d/keybinds.conf

--- a/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
+++ b/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
@@ -18,6 +18,7 @@
 {{ template "zsh/500_oh-my-zsh.zsh" . }}
 {{ template "zsh/510_p10k.zsh" . }}
 {{ template "zsh/520_starship.zsh" . }}
+{{ template "zsh/530_keybindings.zsh" . }}
 {{ template "zsh/910_eza.zsh" . }}
 {{ template "zsh/remove_100_asdf.zsh" . }}
 


### PR DESCRIPTION
… key navigation

- Add 530_keybindings.zsh: beam cursor in insert mode, block in normal mode via zle-keymap-select hook (instant, no prompt re-render)
- Add ghostty conf.d/keybinds.conf: Cmd+Left/Right → ^A/^E (line start/end), Cmd+Backspace → ^U (delete to line start) — avoids ESC-prefix sequences that conflict with vi mode entirely
- Gate gemini extensions install script on gemini-cli not being disabled in mise global tools (was running unconditionally on work machine)


Committed-By-Agent: claude