### PR TITLE
Add `djlint` formatting to chezmoi templates and introduce `pre-commit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: uv sync --all-packages --frozen
       - name: Lint (ruff)
         run: uv run ruff check .
+      - name: Template lint (djlint)
+        run: uv run djlint src/chezmoi/ --check
       - name: Format check (ruff)
         run: uv run ruff format --check .
       - name: Type check (ty)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: djlint
+        name: djlint
+        entry: uv run djlint
+        language: system
+        types_or: [file]
+        files: \.tmpl$
+        args: ["--reformat"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint-templates lint test
+
+lint-templates:
+	uv run djlint src/chezmoi/ --reformat
+
+lint:
+	uv run ruff check .
+	uv run djlint src/chezmoi/ --check
+
+test:
+	uv run pytest src/python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a10",
     "pytest-testinfra>=10",
+    "djlint>=1.36.4",
+    "pre-commit>=4.5.1",
 ]
 
 [tool.uv.workspace]
@@ -62,3 +64,11 @@ all = "error"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.djlint]
+profile = "golang"
+extension = "tmpl"
+preserve_blank_lines = true
+ignore = "H031,H017,H006,T008"
+ignore_blocks = "shell,bash,zsh,python,toml,ini,conf"
+custom_blocks = "if,range,with"

--- a/src/chezmoi/.chezmoiexternals/fzf-plugins.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/fzf-plugins.toml.tmpl
@@ -1,15 +1,15 @@
 {{- $config := dict -}}
 {{- $fzf_tab_completion := dict
-    "type" "archive"
-    "url" (printf "https://codeload.github.com/lincheney/fzf-tab-completion/zip/%s" .fzf_plugins_data.fzf_tab_completion.sha)
-    "exact" true
-    "stripComponents" 1
+"type" "archive"
+"url" (printf "https://codeload.github.com/lincheney/fzf-tab-completion/zip/%s" .fzf_plugins_data.fzf_tab_completion.sha)
+"exact" true
+"stripComponents" 1
 -}}
 {{- $fzf_tab := dict
-    "type" "archive"
-    "url" (printf "https://codeload.github.com/Aloxaf/fzf-tab/zip/%s" .fzf_plugins_data.fzf_tab.sha)
-    "exact" true
-    "stripComponents" 1
+"type" "archive"
+"url" (printf "https://codeload.github.com/Aloxaf/fzf-tab/zip/%s" .fzf_plugins_data.fzf_tab.sha)
+"exact" true
+"stripComponents" 1
 -}}
 {{- $_ := set $config ".dotfiles/external/fzf-tab-completion" $fzf_tab_completion -}}
 {{- $_ := set $config ".dotfiles/external/fzf-tab" $fzf_tab -}}

--- a/src/chezmoi/.chezmoiexternals/tmux-powerline.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/tmux-powerline.toml.tmpl
@@ -2,10 +2,10 @@
 {{- if $plugin.enabled -}}
 {{- $config := dict -}}
 {{- $powerline := dict
-    "type" "archive"
-    "url" (printf "https://github.com/erikw/tmux-powerline/archive/%s.tar.gz" $plugin.commit)
-    "exact" true
-    "stripComponents" 1
+"type" "archive"
+"url" (printf "https://github.com/erikw/tmux-powerline/archive/%s.tar.gz" $plugin.commit)
+"exact" true
+"stripComponents" 1
 -}}
 {{- $_ := set $config ".dotfiles/tmux/plugins/tmux-powerline" $powerline -}}
 {{- toToml $config -}}

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -11,8 +11,8 @@ source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 
 if ! command -v mise &>/dev/null; then
-    log_warn "mise not found in PATH. Skipping trust."
-    exit 0
+log_warn "mise not found in PATH. Skipping trust."
+exit 0
 fi
 
 log_info "Trusting mise config in working tree..."

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -16,23 +16,23 @@ export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 log_info "Ensuring mise global tools are installed..."
 
 if [[ ! -x "$MISE" ]]; then
-    log_warn "mise not found at $MISE. Skipping global tool installation."
-    exit 0
+log_warn "mise not found at $MISE. Skipping global tool installation."
+exit 0
 fi
 
 log_info "Running 'mise install' for global tools..."
 if "$MISE" install; then
-    log_success "Mise global tools installation complete."
+log_success "Mise global tools installation complete."
 else
-    log_error "Failed to install mise global tools."
-    exit 1
+log_error "Failed to install mise global tools."
+exit 1
 fi
 
 log_info "Reshimming mise tools..."
 if "$MISE" reshim; then
-    log_success "Mise reshim complete."
+log_success "Mise reshim complete."
 else
-    log_error "Failed to reshim mise tools."
-    exit 1
+log_error "Failed to reshim mise tools."
+exit 1
 fi
 {{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_20_install-gemini-extensions.sh.tmpl
@@ -17,8 +17,8 @@ export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 log_info "Ensuring Gemini CLI extensions are installed..."
 
 if ! command -v gemini &> /dev/null; then
-    log_warn "gemini command not found in PATH. Skipping extension installation."
-    exit 0
+log_warn "gemini command not found in PATH. Skipping extension installation."
+exit 0
 fi
 
 {{- range $name, $ext := .gemini.extensions }}
@@ -28,7 +28,7 @@ log_info "Installing/Updating extension: {{ $name }} ({{ $ext.ref }})"
 gemini extensions uninstall "{{ $name }}" > /dev/null 2>&1 || true
 # We use --consent to bypass prompts.
 if ! gemini extensions install "{{ $ext.url }}" --ref "{{ $ext.ref }}" --consent; then
-    log_warn "Failed to install {{ $name }}. There may have been a network error."
+log_warn "Failed to install {{ $name }}. There may have been a network error."
 fi
 {{-   end }}
 {{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
@@ -10,16 +10,16 @@ PLIST_PATH="{{ .chezmoi.destDir }}/Library/Preferences/com.googlecode.iterm2.pli
 
 # Check if iTerm2 has been run at least once (plist exists)
 if [[ ! -f "$PLIST_PATH" ]]; then
-    log_error "iTerm2 preferences not found. Please run iTerm2 at least once, then rerun 'chezmoi apply'"
-    exit 1
+log_error "iTerm2 preferences not found. Please run iTerm2 at least once, then rerun 'chezmoi apply'"
+exit 1
 fi
 
 # Use defaults command to set silence bell option
 if defaults write com.googlecode.iterm2 "SilenceBell" -bool true; then
-    log_success "iTerm2 bell sounds disabled successfully"
-    log_info "Restart iTerm2 for changes to take effect"
+log_success "iTerm2 bell sounds disabled successfully"
+log_info "Restart iTerm2 for changes to take effect"
 else
-    log_error "Failed to configure iTerm2 bell settings"
-    exit 1
+log_error "Failed to configure iTerm2 bell settings"
+exit 1
 fi
 {{ end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-bat.sh.tmpl
@@ -3,9 +3,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if bat is already installed
-if check_command bat; then 
-    log_success "bat already installed at $(command -v bat)"
-    exit 0
+if check_command bat; then
+log_success "bat already installed at $(command -v bat)"
+exit 0
 fi
 
 log_info "Installing bat via package manager..."
@@ -13,23 +13,23 @@ log_info "Installing bat via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install bat >/dev/null; then
-    log_success "bat installed successfully via homebrew"
+log_success "bat installed successfully via homebrew"
 else
-    log_error "Failed to install bat via homebrew"
-    exit 1
+log_error "Failed to install bat via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
 if sudo apt-get update >/dev/null && sudo apt-get install -y bat >/dev/null; then
-    log_success "bat installed successfully via apt"
+log_success "bat installed successfully via apt"
 else
-    log_error "Failed to install bat via apt"
-    exit 1
+log_error "Failed to install bat via apt"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-chafa.sh.tmpl
@@ -3,27 +3,27 @@
 CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
 source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 if check_command chafa; then
-    log_success "chafa already installed"
-    exit 0
+log_success "chafa already installed"
+exit 0
 fi
 log_info "Installing chafa via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 if ! check_command brew; then
-    log_error "Homebrew not found."
-    exit 1
+log_error "Homebrew not found."
+exit 1
 fi
 if brew install chafa >/dev/null; then
-    log_success "chafa installed via homebrew"
+log_success "chafa installed via homebrew"
 else
-    log_error "Failed to install chafa via homebrew"
-    exit 1
+log_error "Failed to install chafa via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 if sudo apt-get update >/dev/null && sudo apt-get install -y chafa >/dev/null; then
-    log_success "chafa installed via apt"
+log_success "chafa installed via apt"
 else
-    log_error "Failed to install chafa via apt"
-    exit 1
+log_error "Failed to install chafa via apt"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-eza.sh.tmpl
@@ -4,8 +4,8 @@ source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if eza is already installed
 if check_command eza; then
-    log_success "eza already installed at $(command -v eza)"
-    exit 0
+log_success "eza already installed at $(command -v eza)"
+exit 0
 fi
 
 log_info "Installing eza via package manager..."
@@ -13,15 +13,15 @@ log_info "Installing eza via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install eza >/dev/null; then
-    log_success "eza installed successfully via homebrew"
+log_success "eza installed successfully via homebrew"
 else
-    log_error "Failed to install eza via homebrew"
-    exit 1
+log_error "Failed to install eza via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - eza not in standard apt repos, suggest external sources

--- a/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-fzf.sh.tmpl
@@ -3,9 +3,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if fzf is already installed
-if check_command fzf; then 
-    log_success "fzf already installed at $(command -v fzf)"
-    exit 0
+if check_command fzf; then
+log_success "fzf already installed at $(command -v fzf)"
+exit 0
 fi
 
 log_info "Installing fzf via package manager..."
@@ -13,23 +13,23 @@ log_info "Installing fzf via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install fzf >/dev/null; then
-    log_success "fzf installed successfully via homebrew"
+log_success "fzf installed successfully via homebrew"
 else
-    log_error "Failed to install fzf via homebrew"
-    exit 1
+log_error "Failed to install fzf via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
 if sudo apt-get update >/dev/null && sudo apt-get install -y fzf >/dev/null; then
-    log_success "fzf installed successfully via apt"
+log_success "fzf installed successfully via apt"
 else
-    log_error "Failed to install fzf via apt"
-    exit 1
+log_error "Failed to install fzf via apt"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
@@ -3,9 +3,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if ghostty is already installed
-if check_command ghostty; then 
-    log_success "ghostty already installed at $(command -v ghostty)"
-    exit 0
+if check_command ghostty; then
+log_success "ghostty already installed at $(command -v ghostty)"
+exit 0
 fi
 
 log_info "Installing ghostty via package manager..."
@@ -13,66 +13,66 @@ log_info "Installing ghostty via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew Cask
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install --cask ghostty >/dev/null; then
-    log_success "ghostty installed successfully via homebrew cask"
+log_success "ghostty installed successfully via homebrew cask"
 else
-    log_error "Failed to install ghostty via homebrew cask"
-    exit 1
+log_error "Failed to install ghostty via homebrew cask"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux
 if command -v apt-get >/dev/null 2>&1; then
-    # Ubuntu/Debian - use snap for ghostty
-    log_info "Installing ghostty via snap (Ubuntu/Debian)"
+# Ubuntu/Debian - use snap for ghostty
+log_info "Installing ghostty via snap (Ubuntu/Debian)"
 
-    if ! command -v snap >/dev/null 2>&1; then
-        log_error "snap not found. Please install snapd first."
-        exit 1
-    fi
+if ! command -v snap >/dev/null 2>&1; then
+log_error "snap not found. Please install snapd first."
+exit 1
+fi
 
-    if sudo snap install ghostty --classic >/dev/null; then
-        log_success "ghostty installed successfully via snap"
-    else
-        log_error "Failed to install ghostty via snap"
-        log_info "See https://ghostty.org/docs/install/binary for manual installation"
-        exit 1
-    fi
-    
-elif command -v pacman >/dev/null 2>&1; then
-    # Arch Linux - official repos only
-    log_info "Installing ghostty via pacman (Arch Linux)"
-    
-    if sudo pacman -S --noconfirm ghostty >/dev/null; then
-        log_success "ghostty installed successfully via pacman"
-    else
-        log_error "Failed to install ghostty via pacman"
-        log_info "ghostty may not be available in official repositories"
-        log_info "Consider using AUR or see https://ghostty.org/docs/install/binary"
-        exit 1
-    fi
-    
-elif command -v dnf >/dev/null 2>&1; then
-    # Fedora
-    log_info "Installing ghostty via dnf (Fedora)"
-    
-    if sudo dnf install -y ghostty >/dev/null; then
-        log_success "ghostty installed successfully via dnf"
-    else
-        log_error "Failed to install ghostty via dnf"
-        log_info "ghostty may not be available in Fedora repositories"
-        log_info "See https://ghostty.org/docs/install/binary for manual installation"
-        exit 1
-    fi
-    
+if sudo snap install ghostty --classic >/dev/null; then
+log_success "ghostty installed successfully via snap"
 else
-    log_error "Unsupported Linux distribution or package manager not found"
-    log_info "Supported: apt (Ubuntu/Debian), pacman (Arch), dnf (Fedora)"
-    log_info "Please install ghostty manually from https://ghostty.org/docs/install/binary"
-    exit 1
+log_error "Failed to install ghostty via snap"
+log_info "See https://ghostty.org/docs/install/binary for manual installation"
+exit 1
+fi
+
+elif command -v pacman >/dev/null 2>&1; then
+# Arch Linux - official repos only
+log_info "Installing ghostty via pacman (Arch Linux)"
+
+if sudo pacman -S --noconfirm ghostty >/dev/null; then
+log_success "ghostty installed successfully via pacman"
+else
+log_error "Failed to install ghostty via pacman"
+log_info "ghostty may not be available in official repositories"
+log_info "Consider using AUR or see https://ghostty.org/docs/install/binary"
+exit 1
+fi
+
+elif command -v dnf >/dev/null 2>&1; then
+# Fedora
+log_info "Installing ghostty via dnf (Fedora)"
+
+if sudo dnf install -y ghostty >/dev/null; then
+log_success "ghostty installed successfully via dnf"
+else
+log_error "Failed to install ghostty via dnf"
+log_info "ghostty may not be available in Fedora repositories"
+log_info "See https://ghostty.org/docs/install/binary for manual installation"
+exit 1
+fi
+
+else
+log_error "Unsupported Linux distribution or package manager not found"
+log_info "Supported: apt (Ubuntu/Debian), pacman (Arch), dnf (Fedora)"
+log_info "Please install ghostty manually from https://ghostty.org/docs/install/binary"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-hammerspoon.sh.tmpl
@@ -4,22 +4,22 @@ source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if hammerspoon is already installed
 if check_command brew && brew list --cask hammerspoon &>/dev/null; then
-    log_success "hammerspoon already installed"
+log_success "hammerspoon already installed"
 else
-    log_info "Installing hammerspoon via package manager..."
+log_info "Installing hammerspoon via package manager..."
 
-    # macOS - use Homebrew Cask
-    if ! check_command brew; then
-        log_error "Homebrew not found. Please install Homebrew first."
-        exit 1
-    fi
+# macOS - use Homebrew Cask
+if ! check_command brew; then
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
+fi
 
-    if brew install --cask hammerspoon >/dev/null; then
-        log_success "hammerspoon installed successfully via homebrew cask"
-    else
-        log_error "Failed to install hammerspoon via homebrew cask"
-        exit 1
-    fi
+if brew install --cask hammerspoon >/dev/null; then
+log_success "hammerspoon installed successfully via homebrew cask"
+else
+log_error "Failed to install hammerspoon via homebrew cask"
+exit 1
+fi
 fi
 
 # Configure custom config directory

--- a/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-jq.sh.tmpl
@@ -4,8 +4,8 @@ source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if jq is already installed
 if check_command jq; then
-    log_success "jq already installed at $(command -v jq)"
-    exit 0
+log_success "jq already installed at $(command -v jq)"
+exit 0
 fi
 
 log_info "Installing jq via package manager..."
@@ -13,23 +13,23 @@ log_info "Installing jq via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install jq >/dev/null; then
-    log_success "jq installed successfully via homebrew"
+log_success "jq installed successfully via homebrew"
 else
-    log_error "Failed to install jq via homebrew"
-    exit 1
+log_error "Failed to install jq via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
 if sudo apt-get update >/dev/null && sudo apt-get install -y jq >/dev/null; then
-    log_success "jq installed successfully via apt"
+log_success "jq installed successfully via apt"
 else
-    log_error "Failed to install jq via apt"
-    exit 1
+log_error "Failed to install jq via apt"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ripgrep.sh.tmpl
@@ -3,9 +3,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if ripgrep is already installed
-if check_command rg; then 
-    log_success "ripgrep already installed at $(command -v rg)"
-    exit 0
+if check_command rg; then
+log_success "ripgrep already installed at $(command -v rg)"
+exit 0
 fi
 
 log_info "Installing ripgrep via package manager..."
@@ -13,23 +13,23 @@ log_info "Installing ripgrep via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install ripgrep >/dev/null; then
-    log_success "ripgrep installed successfully via homebrew"
+log_success "ripgrep installed successfully via homebrew"
 else
-    log_error "Failed to install ripgrep via homebrew"
-    exit 1
+log_error "Failed to install ripgrep via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - use apt (Ubuntu/Debian)
 if sudo apt-get update >/dev/null && sudo apt-get install -y ripgrep >/dev/null; then
-    log_success "ripgrep installed successfully via apt"
+log_success "ripgrep installed successfully via apt"
 else
-    log_error "Failed to install ripgrep via apt"
-    exit 1
+log_error "Failed to install ripgrep via apt"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-sandbox-deps.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-sandbox-deps.sh.tmpl
@@ -4,16 +4,16 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 if check_command bwrap && check_command socat; then
-    log_success "bubblewrap and socat already installed"
-    exit 0
+log_success "bubblewrap and socat already installed"
+exit 0
 fi
 
 log_info "Installing bubblewrap and socat via package manager..."
 
 if sudo apt-get update >/dev/null && sudo apt-get install -y bubblewrap socat >/dev/null; then
-    log_success "bubblewrap and socat installed successfully via apt"
+log_success "bubblewrap and socat installed successfully via apt"
 else
-    log_error "Failed to install bubblewrap and socat via apt"
-    exit 1
+log_error "Failed to install bubblewrap and socat via apt"
+exit 1
 fi
 {{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_once_install-tmux.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-tmux.sh.tmpl
@@ -3,30 +3,30 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 if check_command tmux; then
-    log_success "tmux already installed at $(command -v tmux)"
-    exit 0
+log_success "tmux already installed at $(command -v tmux)"
+exit 0
 fi
 
 log_info "Installing tmux..."
 
 {{ if eq .chezmoi.os "darwin" -}}
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install tmux >/dev/null; then
-    log_success "tmux installed successfully"
+log_success "tmux installed successfully"
 else
-    log_error "Failed to install tmux"
-    exit 1
+log_error "Failed to install tmux"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" -}}
 if sudo apt-get update >/dev/null && sudo apt-get install -y tmux >/dev/null; then
-    log_success "tmux installed successfully"
+log_success "tmux installed successfully"
 else
-    log_error "Failed to install tmux"
-    exit 1
+log_error "Failed to install tmux"
+exit 1
 fi
 {{ else -}}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zoxide.sh.tmpl
@@ -3,9 +3,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if zoxide is already installed
-if check_command zoxide; then 
-    log_success "zoxide already installed at $(command -v zoxide)"
-    exit 0
+if check_command zoxide; then
+log_success "zoxide already installed at $(command -v zoxide)"
+exit 0
 fi
 
 log_info "Installing zoxide via package manager..."
@@ -13,24 +13,24 @@ log_info "Installing zoxide via package manager..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install zoxide >/dev/null; then
-    log_success "zoxide installed successfully via homebrew"
+log_success "zoxide installed successfully via homebrew"
 else
-    log_error "Failed to install zoxide via homebrew"
-    exit 1
+log_error "Failed to install zoxide via homebrew"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - zoxide may not be in older Ubuntu repos
 if sudo apt-get update >/dev/null && sudo apt-get install -y zoxide >/dev/null; then
-    log_success "zoxide installed successfully via apt"
+log_success "zoxide installed successfully via apt"
 else
-    log_warn "zoxide not available in apt repos"
-    log_info "Consider changing installation method to 'external-sources' for zoxide"
-    exit 1
+log_warn "zoxide not available in apt repos"
+log_info "Consider changing installation method to 'external-sources' for zoxide"
+exit 1
 fi
 {{ else }}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-zsh.sh.tmpl
@@ -4,9 +4,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if zsh is already installed
-if check_command zsh; then 
-    log_success "zsh already installed at $(command -v zsh)"
-    exit 0
+if check_command zsh; then
+log_success "zsh already installed at $(command -v zsh)"
+exit 0
 fi
 
 log_info "Installing zsh..."
@@ -14,23 +14,23 @@ log_info "Installing zsh..."
 {{ if eq .chezmoi.os "darwin" -}}
 # macOS - use Homebrew
 if ! check_command brew; then
-    log_error "Homebrew not found. Please install Homebrew first."
-    exit 1
+log_error "Homebrew not found. Please install Homebrew first."
+exit 1
 fi
 
 if brew install zsh >/dev/null; then
-    log_success "zsh installed successfully"
+log_success "zsh installed successfully"
 else
-    log_error "Failed to install zsh"
-    exit 1
+log_error "Failed to install zsh"
+exit 1
 fi
 {{ else if eq .chezmoi.os "linux" -}}
 # Linux - use apt (Ubuntu/Debian)
 if sudo apt-get update >/dev/null && sudo apt-get install -y zsh >/dev/null; then
-    log_success "zsh installed successfully"
+log_success "zsh installed successfully"
 else
-    log_error "Failed to install zsh"
-    exit 1
+log_error "Failed to install zsh"
+exit 1
 fi
 {{ else -}}
 log_error "Unsupported OS: {{ .chezmoi.os }}"

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -4,9 +4,9 @@
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 
 # Check if ghostty is installed
-if ! check_command ghostty; then 
-    log_success "ghostty is not installed - nothing to uninstall"
-    exit 0
+if ! check_command ghostty; then
+log_success "ghostty is not installed - nothing to uninstall"
+exit 0
 fi
 
 log_info "Uninstalling ghostty..."
@@ -14,87 +14,87 @@ log_info "Uninstalling ghostty..."
 {{ if eq .chezmoi.os "darwin" }}
 # macOS - use Homebrew Cask
 if check_command brew; then
-    if brew list --cask ghostty >/dev/null 2>&1; then
-        if brew uninstall --cask ghostty >/dev/null; then
-            log_success "ghostty uninstalled successfully via homebrew cask"
-        else
-            log_error "Failed to uninstall ghostty via homebrew cask"
-            exit 1
-        fi
-    else
-        log_info "ghostty not installed via homebrew cask"
-    fi
+if brew list --cask ghostty >/dev/null 2>&1; then
+if brew uninstall --cask ghostty >/dev/null; then
+log_success "ghostty uninstalled successfully via homebrew cask"
 else
-    log_warning "Homebrew not found - cannot uninstall via brew"
+log_error "Failed to uninstall ghostty via homebrew cask"
+exit 1
+fi
+else
+log_info "ghostty not installed via homebrew cask"
+fi
+else
+log_warning "Homebrew not found - cannot uninstall via brew"
 fi
 
 # Clean up Applications folder (manual install)
 if [[ -d "/Applications/Ghostty.app" ]]; then
-    log_info "Removing Ghostty.app from Applications folder..."
-    rm -rf "/Applications/Ghostty.app" && log_success "Removed /Applications/Ghostty.app"
+log_info "Removing Ghostty.app from Applications folder..."
+rm -rf "/Applications/Ghostty.app" && log_success "Removed /Applications/Ghostty.app"
 fi
 
 {{ else if eq .chezmoi.os "linux" }}
 # Linux - explicit platform support
 if command -v apt-get >/dev/null 2>&1; then
-    # Ubuntu/Debian
-    log_info "Uninstalling ghostty via apt (Ubuntu/Debian)"
-    
-    if dpkg -l | grep -q ghostty; then
-        if sudo apt-get remove -y ghostty >/dev/null; then
-            log_success "ghostty uninstalled successfully via apt"
-        else
-            log_error "Failed to uninstall ghostty via apt"
-            exit 1
-        fi
-    else
-        log_info "ghostty not installed via apt"
-    fi
-    
-elif command -v pacman >/dev/null 2>&1; then
-    # Arch Linux
-    log_info "Uninstalling ghostty via pacman (Arch Linux)"
-    
-    if pacman -Q ghostty >/dev/null 2>&1; then
-        if sudo pacman -R --noconfirm ghostty; then
-            log_success "ghostty uninstalled successfully via pacman"
-        else
-            log_error "Failed to uninstall ghostty via pacman"
-            exit 1
-        fi
-    else
-        log_info "ghostty not installed via pacman"
-    fi
-    
-elif command -v dnf >/dev/null 2>&1; then
-    # Fedora
-    log_info "Uninstalling ghostty via dnf (Fedora)"
-    
-    if dnf list installed ghostty >/dev/null 2>&1; then
-        if sudo dnf remove -y ghostty >/dev/null; then
-            log_success "ghostty uninstalled successfully via dnf"
-        else
-            log_error "Failed to uninstall ghostty via dnf"
-            exit 1
-        fi
-    else
-        log_info "ghostty not installed via dnf"
-    fi
-    
+# Ubuntu/Debian
+log_info "Uninstalling ghostty via apt (Ubuntu/Debian)"
+
+if dpkg -l | grep -q ghostty; then
+if sudo apt-get remove -y ghostty >/dev/null; then
+log_success "ghostty uninstalled successfully via apt"
 else
-    log_warning "Unsupported package manager - cannot uninstall via package manager"
-    log_info "Supported: apt (Ubuntu/Debian), pacman (Arch), dnf (Fedora)"
+log_error "Failed to uninstall ghostty via apt"
+exit 1
+fi
+else
+log_info "ghostty not installed via apt"
+fi
+
+elif command -v pacman >/dev/null 2>&1; then
+# Arch Linux
+log_info "Uninstalling ghostty via pacman (Arch Linux)"
+
+if pacman -Q ghostty >/dev/null 2>&1; then
+if sudo pacman -R --noconfirm ghostty; then
+log_success "ghostty uninstalled successfully via pacman"
+else
+log_error "Failed to uninstall ghostty via pacman"
+exit 1
+fi
+else
+log_info "ghostty not installed via pacman"
+fi
+
+elif command -v dnf >/dev/null 2>&1; then
+# Fedora
+log_info "Uninstalling ghostty via dnf (Fedora)"
+
+if dnf list installed ghostty >/dev/null 2>&1; then
+if sudo dnf remove -y ghostty >/dev/null; then
+log_success "ghostty uninstalled successfully via dnf"
+else
+log_error "Failed to uninstall ghostty via dnf"
+exit 1
+fi
+else
+log_info "ghostty not installed via dnf"
+fi
+
+else
+log_warning "Unsupported package manager - cannot uninstall via package manager"
+log_info "Supported: apt (Ubuntu/Debian), pacman (Arch), dnf (Fedora)"
 fi
 
 # Clean up manual installations
 if [[ -f "{{ .chezmoi.destDir }}/.local/bin/ghostty" ]]; then
-    log_info "Removing ghostty from ~/.local/bin..."
-    rm -f "{{ .chezmoi.destDir }}/.local/bin/ghostty" && log_success "Removed ~/.local/bin/ghostty"
+log_info "Removing ghostty from ~/.local/bin..."
+rm -f "{{ .chezmoi.destDir }}/.local/bin/ghostty" && log_success "Removed ~/.local/bin/ghostty"
 fi
 
 if [[ -f "/usr/local/bin/ghostty" ]]; then
-    log_info "Removing ghostty from /usr/local/bin..."
-    sudo rm -f "/usr/local/bin/ghostty" && log_success "Removed /usr/local/bin/ghostty"
+log_info "Removing ghostty from /usr/local/bin..."
+sudo rm -f "/usr/local/bin/ghostty" && log_success "Removed /usr/local/bin/ghostty"
 fi
 
 {{ else }}
@@ -104,14 +104,14 @@ exit 1
 
 # Clean up configuration directory on all platforms
 if [[ -d "{{ .chezmoi.destDir }}/.config/ghostty" ]]; then
-    log_info "Removing ghostty configuration directory..."
-    rm -rf "{{ .chezmoi.destDir }}/.config/ghostty" && log_success "Removed ~/.config/ghostty"
+log_info "Removing ghostty configuration directory..."
+rm -rf "{{ .chezmoi.destDir }}/.config/ghostty" && log_success "Removed ~/.config/ghostty"
 fi
 
 # Clean up cache directory if it exists
 if [[ -d "{{ .chezmoi.destDir }}/.cache/ghostty" ]]; then
-    log_info "Removing ghostty cache directory..."
-    rm -rf "{{ .chezmoi.destDir }}/.cache/ghostty" && log_success "Removed ~/.cache/ghostty"
+log_info "Removing ghostty cache directory..."
+rm -rf "{{ .chezmoi.destDir }}/.cache/ghostty" && log_success "Removed ~/.cache/ghostty"
 fi
 
 log_success "ghostty uninstallation completed"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_install-zsh-set-default.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_install-zsh-set-default.sh.tmpl
@@ -6,18 +6,18 @@ source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 zsh_path="$(which zsh)"
 
 if [[ -z "$zsh_path" ]]; then
-    log_error "zsh not found in PATH"
-    exit 1
+log_error "zsh not found in PATH"
+exit 1
 fi
 
 if [[ "$SHELL" != "$zsh_path" ]]; then
-    log_info "Changing default shell from $SHELL to $zsh_path"
-    # Use sudo to avoid password prompt (works in both CI and interactive environments)
-    if sudo chsh -s "$zsh_path" "$(whoami)"; then
-        log_success "Default shell changed to zsh"
-    else
-        log_error "Failed to change shell to $zsh_path"
-        exit 1
-    fi
+log_info "Changing default shell from $SHELL to $zsh_path"
+# Use sudo to avoid password prompt (works in both CI and interactive environments)
+if sudo chsh -s "$zsh_path" "$(whoami)"; then
+log_success "Default shell changed to zsh"
+else
+log_error "Failed to change shell to $zsh_path"
+exit 1
+fi
 fi
 {{- end }}

--- a/src/chezmoi/.chezmoitemplates/vscode_keybindings.py.tmpl
+++ b/src/chezmoi/.chezmoitemplates/vscode_keybindings.py.tmpl
@@ -3,38 +3,38 @@ import sys
 import json
 
 def main():
-    content = sys.stdin.read().strip()
+content = sys.stdin.read().strip()
 
-    payload = {
-        "key": "shift+enter",
-        "command": "workbench.action.terminal.sendSequence",
-        "args": {
-            "text": "\u001b\r"
-        },
-        "when": "terminalFocus"
-    }
+payload = {
+"key": "shift+enter",
+"command": "workbench.action.terminal.sendSequence",
+"args": {
+"text": "\u001b\r"
+},
+"when": "terminalFocus"
+}
 
-    if not content:
-        print(json.dumps([payload], indent=4))
-        return
+if not content:
+print(json.dumps([payload], indent=4))
+return
 
-    try:
-        keybindings = json.loads(content)
+try:
+keybindings = json.loads(content)
 
-        if isinstance(keybindings, list):
-            # Filter out the existing keybinding to simulate an override/merge
-            keybindings = [item for item in keybindings if item.get("key") != payload["key"]]
-            keybindings.append(payload)
+if isinstance(keybindings, list):
+# Filter out the existing keybinding to simulate an override/merge
+keybindings = [item for item in keybindings if item.get("key") != payload["key"]]
+keybindings.append(payload)
 
-            # Sort by the 'key' alphabetically to get consistent and stable output
-            keybindings.sort(key=lambda item: (item.get("command", ""), item.get("key", "")))
+# Sort by the 'key' alphabetically to get consistent and stable output
+keybindings.sort(key=lambda item: (item.get("command", ""), item.get("key", "")))
 
-            print(json.dumps(keybindings, indent=4))
-        else:
-            print(content)
+print(json.dumps(keybindings, indent=4))
+else:
+print(content)
 
-    except Exception:
-        print(content)
+except Exception:
+print(content)
 
 if __name__ == "__main__":
-    main()
+main()

--- a/src/chezmoi/.chezmoitemplates/vscode_keybindings.py.tmpl
+++ b/src/chezmoi/.chezmoitemplates/vscode_keybindings.py.tmpl
@@ -3,38 +3,38 @@ import sys
 import json
 
 def main():
-content = sys.stdin.read().strip()
+    content = sys.stdin.read().strip()
 
-payload = {
-"key": "shift+enter",
-"command": "workbench.action.terminal.sendSequence",
-"args": {
-"text": "\u001b\r"
-},
-"when": "terminalFocus"
-}
+    payload = {
+        "key": "shift+enter",
+        "command": "workbench.action.terminal.sendSequence",
+        "args": {
+            "text": "\u001b\r"
+        },
+        "when": "terminalFocus"
+    }
 
-if not content:
-print(json.dumps([payload], indent=4))
-return
+    if not content:
+        print(json.dumps([payload], indent=4))
+        return
 
-try:
-keybindings = json.loads(content)
+    try:
+        keybindings = json.loads(content)
 
-if isinstance(keybindings, list):
-# Filter out the existing keybinding to simulate an override/merge
-keybindings = [item for item in keybindings if item.get("key") != payload["key"]]
-keybindings.append(payload)
+        if isinstance(keybindings, list):
+            # Filter out the existing keybinding to simulate an override/merge
+            keybindings = [item for item in keybindings if item.get("key") != payload["key"]]
+            keybindings.append(payload)
 
-# Sort by the 'key' alphabetically to get consistent and stable output
-keybindings.sort(key=lambda item: (item.get("command", ""), item.get("key", "")))
+            # Sort by the 'key' alphabetically to get consistent and stable output
+            keybindings.sort(key=lambda item: (item.get("command", ""), item.get("key", "")))
 
-print(json.dumps(keybindings, indent=4))
-else:
-print(content)
+            print(json.dumps(keybindings, indent=4))
+        else:
+            print(content)
 
-except Exception:
-print(content)
+    except Exception:
+        print(content)
 
 if __name__ == "__main__":
-main()
+    main()

--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -4,20 +4,20 @@ import json
 import sys
 
 try:
-existing = json.load(sys.stdin)
+    existing = json.load(sys.stdin)
 except Exception:
-existing = {}
+    existing = {}
 
 managed = json.loads("""{{ .claude_code.settings | toPrettyJson }}""")
 
 merged = {**existing, **managed}
 
 def sort_keys(obj):
-if isinstance(obj, dict):
-return {k: sort_keys(v) for k, v in sorted(obj.items())}
-elif isinstance(obj, list):
-return [sort_keys(i) for i in obj]
-return obj
+    if isinstance(obj, dict):
+        return {k: sort_keys(v) for k, v in sorted(obj.items())}
+    elif isinstance(obj, list):
+        return [sort_keys(i) for i in obj]
+    return obj
 
 print(json.dumps(sort_keys(merged), indent=2))
 {{- end }}

--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -4,20 +4,20 @@ import json
 import sys
 
 try:
-    existing = json.load(sys.stdin)
+existing = json.load(sys.stdin)
 except Exception:
-    existing = {}
+existing = {}
 
 managed = json.loads("""{{ .claude_code.settings | toPrettyJson }}""")
 
 merged = {**existing, **managed}
 
 def sort_keys(obj):
-    if isinstance(obj, dict):
-        return {k: sort_keys(v) for k, v in sorted(obj.items())}
-    elif isinstance(obj, list):
-        return [sort_keys(i) for i in obj]
-    return obj
+if isinstance(obj, dict):
+return {k: sort_keys(v) for k, v in sorted(obj.items())}
+elif isinstance(obj, list):
+return [sort_keys(i) for i in obj]
+return obj
 
 print(json.dumps(sort_keys(merged), indent=2))
 {{- end }}

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,24 +1,24 @@
 {{- /* Build enabled tools map - only include tools with installation = "mise" */ -}}
 {{- $tools := dict -}}
 {{- range $tool, $config := .mise.global_tools -}}
-  {{- if eq $config.installation "mise" -}}
-    {{- if hasKey $config "postinstall" -}}
-      {{- $_ := set $tools $tool (dict "version" $config.version "postinstall" $config.postinstall) -}}
-    {{- else -}}
-      {{- $_ := set $tools $tool $config.version -}}
-    {{- end -}}
-  {{- end -}}
+{{- if eq $config.installation "mise" -}}
+{{- if hasKey $config "postinstall" -}}
+{{- $_ := set $tools $tool (dict "version" $config.version "postinstall" $config.postinstall) -}}
+{{- else -}}
+{{- $_ := set $tools $tool $config.version -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- /* Build filtered settings map - omit sub-keys tied to disabled tools */ -}}
 {{- $settings := dict -}}
 {{- range $k, $v := .mise.settings -}}
-  {{- if and (eq $k "npm") (eq $.mise.global_tools.bun.installation "disabled") -}}
-    {{- $filtered := omit $v "package_manager" -}}
-    {{- if $filtered -}}{{- $_ := set $settings $k $filtered -}}{{- end -}}
-  {{- else -}}
-    {{- $_ := set $settings $k $v -}}
-  {{- end -}}
+{{- if and (eq $k "npm") (eq $.mise.global_tools.bun.installation "disabled") -}}
+{{- $filtered := omit $v "package_manager" -}}
+{{- if $filtered -}}{{- $_ := set $settings $k $filtered -}}{{- end -}}
+{{- else -}}
+{{- $_ := set $settings $k $v -}}
+{{- end -}}
 {{- end -}}
 
 {{- if $tools -}}

--- a/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
+++ b/src/chezmoi/dot_config/tmux-powerline/config.sh.tmpl
@@ -5,205 +5,205 @@
 # }
 
 # General {
-	# Show which segment fails and its exit code.
-	export TMUX_POWERLINE_DEBUG_MODE_ENABLED="false"
-	# Create error log in tmux runtime temp dir.
-	export TMUX_POWERLINE_ERROR_LOGS_ENABLED="false"
-	# Only log specific scopes. Space separated list of scopes. Supported scopes: weather.sh lib/text_roll.sh lib/powerline.sh lib/colors.sh config/helpers.sh
-	export TMUX_POWERLINE_ERROR_LOGS_SCOPES=""
-	# Use patched font symbols.
-	export TMUX_POWERLINE_PATCHED_FONT_IN_USE="true"
+# Show which segment fails and its exit code.
+export TMUX_POWERLINE_DEBUG_MODE_ENABLED="false"
+# Create error log in tmux runtime temp dir.
+export TMUX_POWERLINE_ERROR_LOGS_ENABLED="false"
+# Only log specific scopes. Space separated list of scopes. Supported scopes: weather.sh lib/text_roll.sh lib/powerline.sh lib/colors.sh config/helpers.sh
+export TMUX_POWERLINE_ERROR_LOGS_SCOPES=""
+# Use patched font symbols.
+export TMUX_POWERLINE_PATCHED_FONT_IN_USE="true"
 
-	# The theme to use.
-	export TMUX_POWERLINE_THEME="default"
-	# Overlay directory to look for themes.
-	export TMUX_POWERLINE_DIR_USER_THEMES="[[ .chezmoi.destDir ]]/.config/tmux-powerline/themes"
-	# Overlay directory to look for segments.
-	export TMUX_POWERLINE_DIR_USER_SEGMENTS="[[ .chezmoi.destDir ]]/.config/tmux-powerline/segments"
+# The theme to use.
+export TMUX_POWERLINE_THEME="default"
+# Overlay directory to look for themes.
+export TMUX_POWERLINE_DIR_USER_THEMES="[[ .chezmoi.destDir ]]/.config/tmux-powerline/themes"
+# Overlay directory to look for segments.
+export TMUX_POWERLINE_DIR_USER_SEGMENTS="[[ .chezmoi.destDir ]]/.config/tmux-powerline/segments"
 
-	# The initial visibility of the status bar. Can be {"on", "off", "2"}. 2 will create two status lines: one for the window list and one with status bar segments.
-	export TMUX_POWERLINE_STATUS_VISIBILITY="2"
-	# In case of visibility = 2, where to display window status and where left/right status bars.
-	# 0: window status top, left/right status bottom; 1: window status bottom, left/right status top
-	export TMUX_POWERLINE_WINDOW_STATUS_LINE=1
-	# The status bar refresh interval in seconds.
-	# Note that events that force-refresh the status bar (such as window renaming) will ignore this.
-	export TMUX_POWERLINE_STATUS_INTERVAL="20"
-	# The location of the window list. Can be {"absolute-centre, centre, left, right"}.
-	# Note that "absolute-centre" is only supported on `tmux -V` >= 3.2.
-	export TMUX_POWERLINE_STATUS_JUSTIFICATION="centre"
+# The initial visibility of the status bar. Can be {"on", "off", "2"}. 2 will create two status lines: one for the window list and one with status bar segments.
+export TMUX_POWERLINE_STATUS_VISIBILITY="2"
+# In case of visibility = 2, where to display window status and where left/right status bars.
+# 0: window status top, left/right status bottom; 1: window status bottom, left/right status top
+export TMUX_POWERLINE_WINDOW_STATUS_LINE=1
+# The status bar refresh interval in seconds.
+# Note that events that force-refresh the status bar (such as window renaming) will ignore this.
+export TMUX_POWERLINE_STATUS_INTERVAL="20"
+# The location of the window list. Can be {"absolute-centre, centre, left, right"}.
+# Note that "absolute-centre" is only supported on `tmux -V` >= 3.2.
+export TMUX_POWERLINE_STATUS_JUSTIFICATION="centre"
 
-	# The maximum length of the left status bar.
-	export TMUX_POWERLINE_STATUS_LEFT_LENGTH="60"
-	# The maximum length of the right status bar.
-	export TMUX_POWERLINE_STATUS_RIGHT_LENGTH="90"
+# The maximum length of the left status bar.
+export TMUX_POWERLINE_STATUS_LEFT_LENGTH="60"
+# The maximum length of the right status bar.
+export TMUX_POWERLINE_STATUS_RIGHT_LENGTH="90"
 
-	# The separator to use between windows on the status bar.
-	export TMUX_POWERLINE_WINDOW_STATUS_SEPARATOR=""
+# The separator to use between windows on the status bar.
+export TMUX_POWERLINE_WINDOW_STATUS_SEPARATOR=""
 
-	# Uncomment these if you want to enable tmux bindings for muting (hiding) one of the status bars.
-	# E.g. this example binding would mute the left status bar when pressing <prefix> followed by Ctrl-[
-	#export TMUX_POWERLINE_MUTE_LEFT_KEYBINDING="C-["
-	#export TMUX_POWERLINE_MUTE_RIGHT_KEYBINDING="C-]"
+# Uncomment these if you want to enable tmux bindings for muting (hiding) one of the status bars.
+# E.g. this example binding would mute the left status bar when pressing <prefix> followed by Ctrl-[
+#export TMUX_POWERLINE_MUTE_LEFT_KEYBINDING="C-["
+#export TMUX_POWERLINE_MUTE_RIGHT_KEYBINDING="C-]"
 # }
 
 # air.sh {
-	# The data provider to use. Currently only "openweather" is supported.
-	export TMUX_POWERLINE_SEG_AIR_DATA_PROVIDER="openweather"
-	# How often to update the weather in seconds.
-	export TMUX_POWERLINE_SEG_AIR_UPDATE_PERIOD="600"
-	# Location of the JSON parser, jq
-	export TMUX_POWERLINE_SEG_AIR_JSON="jq"
-	# Your location
-	# Latitude and Longitude:
-	TMUX_POWERLINE_SEG_AIR_LAT=""
-	TMUX_POWERLINE_SEG_AIR_LON=""
-	# Your Open Weather API Key:
-	TMUX_POWERLINE_SEG_AIR_OPEN_WEATHER_API_KEY=""
+# The data provider to use. Currently only "openweather" is supported.
+export TMUX_POWERLINE_SEG_AIR_DATA_PROVIDER="openweather"
+# How often to update the weather in seconds.
+export TMUX_POWERLINE_SEG_AIR_UPDATE_PERIOD="600"
+# Location of the JSON parser, jq
+export TMUX_POWERLINE_SEG_AIR_JSON="jq"
+# Your location
+# Latitude and Longitude:
+TMUX_POWERLINE_SEG_AIR_LAT=""
+TMUX_POWERLINE_SEG_AIR_LON=""
+# Your Open Weather API Key:
+TMUX_POWERLINE_SEG_AIR_OPEN_WEATHER_API_KEY=""
 # }
 
 # battery.sh {
-	# How to display battery remaining. Can be {percentage, cute, hearts}.
-	export TMUX_POWERLINE_SEG_BATTERY_TYPE="percentage"
-	# How may hearts to show if cute indicators are used.
-	export TMUX_POWERLINE_SEG_BATTERY_NUM_HEARTS="5"
+# How to display battery remaining. Can be {percentage, cute, hearts}.
+export TMUX_POWERLINE_SEG_BATTERY_TYPE="percentage"
+# How may hearts to show if cute indicators are used.
+export TMUX_POWERLINE_SEG_BATTERY_NUM_HEARTS="5"
 # }
 
 # cpu_temp.sh {
-	# CPU temperature icon
-	export TMUX_POWERLINE_SEG_CPU_TEMP_ICON=" "
-	# Linux only. Regexp to indicate a line containing CPU temperature in 'sensors' output.
-	# Check the output of 'sensors' program, decide which line contains desired CPU temperature
-	# and store an unique part of that line in this variable. It will be used by 'grep' program
-	# to distinct the 'CPU temperature' line from the rest output lines.
-	export TMUX_POWERLINE_SEG_CPU_TEMP_SENSORS_LINE_MARKER="Package id 0\|Physical id 0\|temp1"
+# CPU temperature icon
+export TMUX_POWERLINE_SEG_CPU_TEMP_ICON=" "
+# Linux only. Regexp to indicate a line containing CPU temperature in 'sensors' output.
+# Check the output of 'sensors' program, decide which line contains desired CPU temperature
+# and store an unique part of that line in this variable. It will be used by 'grep' program
+# to distinct the 'CPU temperature' line from the rest output lines.
+export TMUX_POWERLINE_SEG_CPU_TEMP_SENSORS_LINE_MARKER="Package id 0\|Physical id 0\|temp1"
 # }
 
 # date_week.sh {
-	# Symbol for calendar week.
-	# export TMUX_POWERLINE_SEG_DATE_WEEK_SYMBOL="󰨳"
-	# export TMUX_POWERLINE_SEG_DATE_WEEK_SYMBOL_COLOUR="255"
+# Symbol for calendar week.
+# export TMUX_POWERLINE_SEG_DATE_WEEK_SYMBOL="󰨳"
+# export TMUX_POWERLINE_SEG_DATE_WEEK_SYMBOL_COLOUR="255"
 # }
 
 # date.sh {
-	# date(1) format for the date. If you don't, for some reason, like ISO 8601 format you might want to have "%D" or "%m/%d/%Y".
-	# Include day name to consolidate date_day segment
-	export TMUX_POWERLINE_SEG_DATE_FORMAT="%a %F"
+# date(1) format for the date. If you don't, for some reason, like ISO 8601 format you might want to have "%D" or "%m/%d/%Y".
+# Include day name to consolidate date_day segment
+export TMUX_POWERLINE_SEG_DATE_FORMAT="%a %F"
 # }
 
 # disk_usage.sh {
-	# Filesystem to retrieve disk space information. Any from the filesystems available (run "df | awk '{print }'" to check them).
-	export TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM="/"
+# Filesystem to retrieve disk space information. Any from the filesystems available (run "df | awk '{print }'" to check them).
+export TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM="/"
 # }
 
 # dropbox_status.sh {
-	# The Dropbox glyph to use
-	export TMUX_POWERLINE_SEG_DROPBOX_GLYPH=""
-	# Replace 'Uploading' in the status
-	export TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH=""
-	# Replace 'Downloading' in the status
-	export TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH=""
-	# Replace 'Indexing' in the status
-	export TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH=""
-	# Replace 'Syncing' in the status
-	export TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH=""
+# The Dropbox glyph to use
+export TMUX_POWERLINE_SEG_DROPBOX_GLYPH=""
+# Replace 'Uploading' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH=""
+# Replace 'Downloading' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH=""
+# Replace 'Indexing' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH=""
+# Replace 'Syncing' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH=""
 # }
 
 # earthquake.sh {
-	# The data provider to use. Currently only "goo" is supported.
-	export TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER="goo"
-	# How often to update the earthquake data in seconds.
-	# Note: This is not an early warning detector, use this
-	# to be informed about recent earthquake magnitudes in your
-	# area. If this is too often, goo may decide to ban you form
-	# their server
-	export TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD="600"
-	# Only display information when earthquakes are within this many minutes
-	export TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW="60"
-	# Display time with this format
-	export TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT='(%H:%M)'
-	# Display only if magnitude is greater or equal to this number
-	export TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE="3"
+# The data provider to use. Currently only "goo" is supported.
+export TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER="goo"
+# How often to update the earthquake data in seconds.
+# Note: This is not an early warning detector, use this
+# to be informed about recent earthquake magnitudes in your
+# area. If this is too often, goo may decide to ban you form
+# their server
+export TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD="600"
+# Only display information when earthquakes are within this many minutes
+export TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW="60"
+# Display time with this format
+export TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT='(%H:%M)'
+# Display only if magnitude is greater or equal to this number
+export TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE="3"
 # }
 
 # gcalcli.sh {
-	# gcalcli uses 24hr time format by default - if you want to see 12hr time format, set TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT to 0
-	export TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT="1"
+# gcalcli uses 24hr time format by default - if you want to see 12hr time format, set TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT to 0
+export TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT="1"
 # }
 
 # github_notifications.sh {
-	# Github token (https://github.com/settings/tokens) with at least "notifications" scope
-	export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_TOKEN=""
-	# Include available notification reasons (https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#about-notification-reasons),
-	# in the format "REASON:SEPARATOR"
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS="approval_requested:-󰴄 |assign:-󰎔 |author:-󰔗 |comment:- |ci_activity:-󰙨 |invitation:- |manual:-󱥃 |mention:- |review_requested:- |security_alert:-󰒃 |state_change:-󱇯 |subscribed:- |team_mention:- "
-	# Or if you don't like so many symbols, try the abbreviation variant
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS="approval_requested:areq|assign:as|author:au|comment:co|ci_activity:ci|invitation:in|manual:ma|mention:me|review_requested:rreq|security_alert:sec|state_change:st|subscribed:sub|team_mention:team"
-	# Use symbol mode (ignored if you set TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS yourself)
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SYMBOL_MODE="yes"
-	# Summarize all notifications
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SUMMARIZE="no"
-	# Hide if no notifications
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_HIDE_NO_NOTIFICATIONS="yes"
-	# Only show new notifications since date (default: today) (takes up to UPDATE_INTERVAL time to take effect)
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SINCE="$(date +%Y-%m-%dT00:00:00Z)"
-	# Enable show only notifications since date (takes up to UPDATE_INTERVAL time to take effect)
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SINCE_ENABLE="no"
-	# Maximum notifications to retreive per page (upstream github default per_page, 50)
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_PER_PAGE="50"
-	# Maximum pages to retreive
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_MAX_PAGES="10"
-	# Update interval to pull latest state from github api
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_UPDATE_INTERVAL="60"
-	# Enable Test Mode (to test how the segment will look like when you have notifications for all types/reasons)
-	# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_TEST_MODE="no"
+# Github token (https://github.com/settings/tokens) with at least "notifications" scope
+export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_TOKEN=""
+# Include available notification reasons (https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#about-notification-reasons),
+# in the format "REASON:SEPARATOR"
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS="approval_requested:-󰴄 |assign:-󰎔 |author:-󰔗 |comment:- |ci_activity:-󰙨 |invitation:- |manual:-󱥃 |mention:- |review_requested:- |security_alert:-󰒃 |state_change:-󱇯 |subscribed:- |team_mention:- "
+# Or if you don't like so many symbols, try the abbreviation variant
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS="approval_requested:areq|assign:as|author:au|comment:co|ci_activity:ci|invitation:in|manual:ma|mention:me|review_requested:rreq|security_alert:sec|state_change:st|subscribed:sub|team_mention:team"
+# Use symbol mode (ignored if you set TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_REASONS yourself)
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SYMBOL_MODE="yes"
+# Summarize all notifications
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SUMMARIZE="no"
+# Hide if no notifications
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_HIDE_NO_NOTIFICATIONS="yes"
+# Only show new notifications since date (default: today) (takes up to UPDATE_INTERVAL time to take effect)
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SINCE="$(date +%Y-%m-%dT00:00:00Z)"
+# Enable show only notifications since date (takes up to UPDATE_INTERVAL time to take effect)
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_SINCE_ENABLE="no"
+# Maximum notifications to retreive per page (upstream github default per_page, 50)
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_PER_PAGE="50"
+# Maximum pages to retreive
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_MAX_PAGES="10"
+# Update interval to pull latest state from github api
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_UPDATE_INTERVAL="60"
+# Enable Test Mode (to test how the segment will look like when you have notifications for all types/reasons)
+# export TMUX_POWERLINE_SEG_GITHUB_NOTIFICATIONS_TEST_MODE="no"
 # }
 
 # hostname.sh {
-	# Use short, long or custom format for the hostname. Can be {"short", "long", "custom"}.
-	export TMUX_POWERLINE_SEG_HOSTNAME_FORMAT="short"
-	# Custom name to be used when format is "custom"
-	export TMUX_POWERLINE_SEG_HOSTNAME_CUSTOM=""
+# Use short, long or custom format for the hostname. Can be {"short", "long", "custom"}.
+export TMUX_POWERLINE_SEG_HOSTNAME_FORMAT="short"
+# Custom name to be used when format is "custom"
+export TMUX_POWERLINE_SEG_HOSTNAME_CUSTOM=""
 # }
 
 # ifstat.sh {
-	# Symbol for Download.
-	# export TMUX_POWERLINE_SEG_IFSTAT_DOWN_SYMBOL="⇊"
-	# Symbol for Upload.
-	# export TMUX_POWERLINE_SEG_IFSTAT_UP_SYMBOL="⇈"
-	# Symbol for Ethernet.
-	# export TMUX_POWERLINE_SEG_IFSTAT_ETHERNET_SYMBOL="󰈀"
-	# Symbol for WLAN.
-	# export TMUX_POWERLINE_SEG_IFSTAT_WLAN_SYMBOL="󱚻"
-	# Symbol for WWAN.
-	# export TMUX_POWERLINE_SEG_IFSTAT_WWAN_SYMBOL=""
-	# Separator for Interfaces.
-	# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_SEPARATOR=" | "
-	# Space separated list of interface names to be excluded. substring match, regexp can be used.
-	# Examples:
-	# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="tun" # will exclude 'tun0', 'utun0', 'itun', 'tun08127387'
-	# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="tun0 tuntun" # will exclude 'tun0', 'utun0', 'tuntun'
-	# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="^tun0$ ^tun1$" # excludes exactly 'tun0' and 'tun1'
-	# Default:
-	# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="^u?tun[0-9]+$"
+# Symbol for Download.
+# export TMUX_POWERLINE_SEG_IFSTAT_DOWN_SYMBOL="⇊"
+# Symbol for Upload.
+# export TMUX_POWERLINE_SEG_IFSTAT_UP_SYMBOL="⇈"
+# Symbol for Ethernet.
+# export TMUX_POWERLINE_SEG_IFSTAT_ETHERNET_SYMBOL="󰈀"
+# Symbol for WLAN.
+# export TMUX_POWERLINE_SEG_IFSTAT_WLAN_SYMBOL="󱚻"
+# Symbol for WWAN.
+# export TMUX_POWERLINE_SEG_IFSTAT_WWAN_SYMBOL=""
+# Separator for Interfaces.
+# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_SEPARATOR=" | "
+# Space separated list of interface names to be excluded. substring match, regexp can be used.
+# Examples:
+# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="tun" # will exclude 'tun0', 'utun0', 'itun', 'tun08127387'
+# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="tun0 tuntun" # will exclude 'tun0', 'utun0', 'tuntun'
+# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="^tun0$ ^tun1$" # excludes exactly 'tun0' and 'tun1'
+# Default:
+# export TMUX_POWERLINE_SEG_IFSTAT_INTERFACE_EXCLUDES="^u?tun[0-9]+$"
 # }
 
 # kubernetes_context.sh {
-	# Kubernetes config context display mode {"name_namespace", "name", "namespace"}.
-	# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_DISPLAY_MODE="name_namespace"
-	# Kubernetes config context symbol.
-	# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SYMBOL="󱃾"
-	# Kubernetes config context symbol colour.
-	# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SYMBOL_COLOUR="255"
-	# Separator for display mode "name_namespace"
-	# TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SEPARATOR="󰿟"
+# Kubernetes config context display mode {"name_namespace", "name", "namespace"}.
+# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_DISPLAY_MODE="name_namespace"
+# Kubernetes config context symbol.
+# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SYMBOL="󱃾"
+# Kubernetes config context symbol colour.
+# export TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SYMBOL_COLOUR="255"
+# Separator for display mode "name_namespace"
+# TMUX_POWERLINE_SEG_KUBERNETES_CONTEXT_SEPARATOR="󰿟"
 # }
 
 # lan_ip.sh {
-	# Symbol for LAN IP.
-	# export TMUX_POWERLINE_SEG_LAN_IP_SYMBOL="ⓛ "
-	# Symbol colour for LAN IP
-	# export TMUX_POWERLINE_SEG_LAN_IP_SYMBOL_COLOUR="255"
+# Symbol for LAN IP.
+# export TMUX_POWERLINE_SEG_LAN_IP_SYMBOL="ⓛ "
+# Symbol colour for LAN IP
+# export TMUX_POWERLINE_SEG_LAN_IP_SYMBOL_COLOUR="255"
 # }
 
 # macos_notification_count.sh {
@@ -211,271 +211,271 @@
 # }
 
 # mailcount.sh {
-	# Mailbox type to use. Can be any of {apple_mail, gmail, maildir, mbox, mailcheck}
-	export TMUX_POWERLINE_SEG_MAILCOUNT_MAILBOX_TYPE=""
+# Mailbox type to use. Can be any of {apple_mail, gmail, maildir, mbox, mailcheck}
+export TMUX_POWERLINE_SEG_MAILCOUNT_MAILBOX_TYPE=""
 
-	## Gmail
-	# Enter your Gmail username here WITH OUT @gmail.com.( OR @domain)
-	export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_USERNAME=""
-	# Google password. Recomenned to use application specific password (https://accounts.google.com/b/0/IssuedAuthSubTokens) Leave this empty to get password from OS X keychain.
-	# For macOS users : MAKE SURE that you add a key to the keychain in the format as follows
-	# Keychain Item name : http://<value-you-fill-in-server-variable-below>
-	# Account name : <username-below>@<server-below>
-	# Password : Your password ( Once again, try to use 2 step-verification and application-specific password)
-	# See http://support.google.com/accounts/bin/answer.py?hl=en&answer=185833 for more info.
-	export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD=""
-	# Domain name that will complete your email. For normal GMail users it probably is "gmail.com but can be "foo.tld" for Google Apps users.
-	export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER="gmail.com"
-	# How often in minutes to check for new mails.
-	export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_INTERVAL="5"
+## Gmail
+# Enter your Gmail username here WITH OUT @gmail.com.( OR @domain)
+export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_USERNAME=""
+# Google password. Recomenned to use application specific password (https://accounts.google.com/b/0/IssuedAuthSubTokens) Leave this empty to get password from OS X keychain.
+# For macOS users : MAKE SURE that you add a key to the keychain in the format as follows
+# Keychain Item name : http://<value-you-fill-in-server-variable-below>
+# Account name : <username-below>@<server-below>
+# Password : Your password ( Once again, try to use 2 step-verification and application-specific password)
+# See http://support.google.com/accounts/bin/answer.py?hl=en&answer=185833 for more info.
+export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD=""
+# Domain name that will complete your email. For normal GMail users it probably is "gmail.com but can be "foo.tld" for Google Apps users.
+export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER="gmail.com"
+# How often in minutes to check for new mails.
+export TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_INTERVAL="5"
 
-	## Maildir
-	# Path to the maildir to check.
-	export TMUX_POWERLINE_SEG_MAILCOUNT_MAILDIR_INBOX="[[ .chezmoi.destDir ]]/.mail/inbox/new"
+## Maildir
+# Path to the maildir to check.
+export TMUX_POWERLINE_SEG_MAILCOUNT_MAILDIR_INBOX="[[ .chezmoi.destDir ]]/.mail/inbox/new"
 
-	## mbox
-	# Path to the mbox to check.
-	export TMUX_POWERLINE_SEG_MAILCOUNT_MBOX_INBOX=""
+## mbox
+# Path to the mbox to check.
+export TMUX_POWERLINE_SEG_MAILCOUNT_MBOX_INBOX=""
 
-	## mailcheck
-	# Optional path to mailcheckrc
-	export TMUX_POWERLINE_SEG_MAILCOUNT_MAILCHECKRC="[[ .chezmoi.destDir ]]/.mailcheckrc"
+## mailcheck
+# Optional path to mailcheckrc
+export TMUX_POWERLINE_SEG_MAILCOUNT_MAILCHECKRC="[[ .chezmoi.destDir ]]/.mailcheckrc"
 # }
 
 # mem_used.sh {
-	# Memory icon
-	export TMUX_POWERLINE_SEG_MEM_USED_ICON=" "
-	# Measure unit of memory: "GB" or "MB".
-	# In context of this segment "1 GB" equals "2 ^ 30 bytes" and "1 MB" eqauls "2 ^ 20 bytes".
-	export TMUX_POWERLINE_SEG_MEM_USED_UNIT="GB"
+# Memory icon
+export TMUX_POWERLINE_SEG_MEM_USED_ICON=" "
+# Measure unit of memory: "GB" or "MB".
+# In context of this segment "1 GB" equals "2 ^ 30 bytes" and "1 MB" eqauls "2 ^ 20 bytes".
+export TMUX_POWERLINE_SEG_MEM_USED_UNIT="GB"
 # }
 
 # mode_indicator.sh {
-	# Whether the normal & prefix mode section should be enabled. Should be {"true, "false"}.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED="true"
-	# Normal mode text & color overrides. Defaults to "normal" & the segment foreground color set in the theme used.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT="normal"
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR=""
-	# Prefix mode text & color overrides. Defaults to "prefix" & the segment foreground color set in the theme used.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT="prefix"
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR=""
-	# Whether the mouse mode section should be enabled. Should be {"true, "false"}.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED="true"
-	# Mouse mode text & color overrides. Defaults to "mouse" & the segment foreground color set in the theme used.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT="mouse"
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR=""
-	# Whether the copy mode section should be enabled. Should be {"true, "false"}.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED="true"
-	# Copy mode text & color overrides. Defaults to "copy" & the segment foreground color set in the theme used.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT="copy"
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR=""
-	# Suspend mode text & color overrides. Defaults to "SUSPEND" & the segment foreground color set in the theme used.
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_SUSPEND_MODE_TEXT="SUSPEND"
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_SUSPEND_MODE_TEXT_COLOR=""
-	# Separator text override. Defaults to " • ".
-	export TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT=" • "
+# Whether the normal & prefix mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED="true"
+# Normal mode text & color overrides. Defaults to "normal" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT="normal"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR=""
+# Prefix mode text & color overrides. Defaults to "prefix" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT="prefix"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR=""
+# Whether the mouse mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED="true"
+# Mouse mode text & color overrides. Defaults to "mouse" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT="mouse"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR=""
+# Whether the copy mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED="true"
+# Copy mode text & color overrides. Defaults to "copy" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT="copy"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR=""
+# Suspend mode text & color overrides. Defaults to "SUSPEND" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_SUSPEND_MODE_TEXT="SUSPEND"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_SUSPEND_MODE_TEXT_COLOR=""
+# Separator text override. Defaults to " • ".
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT=" • "
 # }
 
 # now_playing.sh {
-	# Music player to use. Can be any of {audacious, banshee, cmus, apple_music, itunes, lastfm, plexamp, mocp, mpd, mpd_simple, pithos, playerctl, rdio, rhythmbox, spotify, file}.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_MUSIC_PLAYER="spotify"
-	# File to be read in case the song is being read from a file
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_FILE_NAME=""
-	# Maximum output length.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_MAX_LEN="40"
-	# How to handle too long strings. Can be {trim, roll}.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_TRIM_METHOD="trim"
-	# Characters per second to roll if rolling trim method is used.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_SPEED="2"
-	# Mode of roll text {"space", "repeat"}. space: fill up with empty space; repeat: repeat text from beginning
-	# export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_MODE="repeat"
-	# Separator for "repeat" roll mode
-	# export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_SEPARATOR="   "
-	# If set to 'true', 'yes', 'on' or '1', played tracks will be logged to a file.
-	# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_ENABLE="false"
-	# If enabled, log played tracks to the following file:
-	# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_FILEPATH="[[ .chezmoi.destDir ]]/.now_playing.log"
-	# Maximum number of logged song entries. Set to "unlimited" for unlimited entries.
-	# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_MAX_ENTRIES="100"
+# Music player to use. Can be any of {audacious, banshee, cmus, apple_music, itunes, lastfm, plexamp, mocp, mpd, mpd_simple, pithos, playerctl, rdio, rhythmbox, spotify, file}.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_MUSIC_PLAYER="spotify"
+# File to be read in case the song is being read from a file
+export TMUX_POWERLINE_SEG_NOW_PLAYING_FILE_NAME=""
+# Maximum output length.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_MAX_LEN="40"
+# How to handle too long strings. Can be {trim, roll}.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_TRIM_METHOD="trim"
+# Characters per second to roll if rolling trim method is used.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_SPEED="2"
+# Mode of roll text {"space", "repeat"}. space: fill up with empty space; repeat: repeat text from beginning
+# export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_MODE="repeat"
+# Separator for "repeat" roll mode
+# export TMUX_POWERLINE_SEG_NOW_PLAYING_ROLL_SEPARATOR="   "
+# If set to 'true', 'yes', 'on' or '1', played tracks will be logged to a file.
+# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_ENABLE="false"
+# If enabled, log played tracks to the following file:
+# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_FILEPATH="[[ .chezmoi.destDir ]]/.now_playing.log"
+# Maximum number of logged song entries. Set to "unlimited" for unlimited entries.
+# export TMUX_POWERLINE_SEG_NOW_PLAYING_TRACK_LOG_MAX_ENTRIES="100"
 
-	# Hostname for MPD server in the format "[password@]host"
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_HOST="localhost"
-	# Port the MPD server is running on.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_PORT="6600"
-	# Song display format for mpd_simple. See mpc(1) for delimiters.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_SIMPLE_FORMAT="%artist% - %title%"
-	# Song display format for playerctl. see "Format Strings" in playerctl(1).
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_PLAYERCTL_FORMAT="{{ artist }} - {{ title }}"
-	# Song display format for rhythmbox. see "FORMATS" in rhythmbox-client(1).
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_RHYTHMBOX_FORMAT="%aa - %tt"
+# Hostname for MPD server in the format "[password@]host"
+export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_HOST="localhost"
+# Port the MPD server is running on.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_PORT="6600"
+# Song display format for mpd_simple. See mpc(1) for delimiters.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_MPD_SIMPLE_FORMAT="%artist% - %title%"
+# Song display format for playerctl. see "Format Strings" in playerctl(1).
+export TMUX_POWERLINE_SEG_NOW_PLAYING_PLAYERCTL_FORMAT="{{ artist }} - {{ title }}"
+# Song display format for rhythmbox. see "FORMATS" in rhythmbox-client(1).
+export TMUX_POWERLINE_SEG_NOW_PLAYING_RHYTHMBOX_FORMAT="%aa - %tt"
 
-	# Last.fm
-	# Set up steps for Last.fm
-	# 1. Make sure jq(1) is installed on the system.
-	# 2. Create a new API application at https://www.last.fm/api/account/create (name it tmux-powerline) and copy the API key and insert it below in the setting TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_API_KEY
-	# 3. Make sure the API can access your recently played song by going to you user privacy settings https://www.last.fm/settings/privacy and make sure "Hide recent listening information" is UNCHECKED.
-	# Username for Last.fm if that music player is used.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_USERNAME=""
-	# API Key for the API.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_API_KEY=""
-	# How often in seconds to update the data from last.fm.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_UPDATE_PERIOD="30"
-	# Fancy char to display before now playing track
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_NOTE_CHAR="♫"
+# Last.fm
+# Set up steps for Last.fm
+# 1. Make sure jq(1) is installed on the system.
+# 2. Create a new API application at https://www.last.fm/api/account/create (name it tmux-powerline) and copy the API key and insert it below in the setting TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_API_KEY
+# 3. Make sure the API can access your recently played song by going to you user privacy settings https://www.last.fm/settings/privacy and make sure "Hide recent listening information" is UNCHECKED.
+# Username for Last.fm if that music player is used.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_USERNAME=""
+# API Key for the API.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_API_KEY=""
+# How often in seconds to update the data from last.fm.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_LASTFM_UPDATE_PERIOD="30"
+# Fancy char to display before now playing track
+export TMUX_POWERLINE_SEG_NOW_PLAYING_NOTE_CHAR="♫"
 
-	# Plexamp
-	# Set up steps for Plexamp
-	# 1. Make sure jq(1) is installed on the system.
-	# 2. Make sure you have an instance of Tautulli that is accessible by the computer running tmux-powerline.
-	# Username for Plexamp if that music player is used.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_USERNAME=""
-	# Hostname for Tautulli server in the format "[password@]host"
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_TAUTULLI_HOST=""
-	# API Key for Tautulli.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_TAUTULLI_API_KEY=""
-	# How often in seconds to update the data from Plexamp.
-	export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_UPDATE_PERIOD="30"
+# Plexamp
+# Set up steps for Plexamp
+# 1. Make sure jq(1) is installed on the system.
+# 2. Make sure you have an instance of Tautulli that is accessible by the computer running tmux-powerline.
+# Username for Plexamp if that music player is used.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_USERNAME=""
+# Hostname for Tautulli server in the format "[password@]host"
+export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_TAUTULLI_HOST=""
+# API Key for Tautulli.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_TAUTULLI_API_KEY=""
+# How often in seconds to update the data from Plexamp.
+export TMUX_POWERLINE_SEG_NOW_PLAYING_PLEXAMP_UPDATE_PERIOD="30"
 # }
 
 # pwd.sh {
-	# Maximum length of output.
-	export TMUX_POWERLINE_SEG_PWD_MAX_LEN="40"
+# Maximum length of output.
+export TMUX_POWERLINE_SEG_PWD_MAX_LEN="40"
 # }
 
 # time.sh {
-	# date(1) format for the time. Americans might want to have "%I:%M %p".
-	export TMUX_POWERLINE_SEG_TIME_FORMAT="%H:%M %Z"
-	# Change this to display a different timezone than the system default.
-	# Use TZ Identifier like "America/Los_Angeles"
-	# export TMUX_POWERLINE_SEG_TIME_TZ=""
+# date(1) format for the time. Americans might want to have "%I:%M %p".
+export TMUX_POWERLINE_SEG_TIME_FORMAT="%H:%M %Z"
+# Change this to display a different timezone than the system default.
+# Use TZ Identifier like "America/Los_Angeles"
+# export TMUX_POWERLINE_SEG_TIME_TZ=""
 # }
 
 # tmux_continuum_save.sh {
-	# Path to the tmux-continuum git repo.
-	export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PATH="[[ .chezmoi.destDir ]]/.tmux/plugins/tmux-continuum"
+# Path to the tmux-continuum git repo.
+export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PATH="[[ .chezmoi.destDir ]]/.tmux/plugins/tmux-continuum"
 # }
 
 # tmux_continuum_status.sh {
-	# Path to the tmux-continuum git repo.
-	export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PATH="[[ .chezmoi.destDir ]]/.tmux/plugins/tmux-continuum"
-	# Message to perfix the status indication with.
-	export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PREFIX="Continuum status: "
+# Path to the tmux-continuum git repo.
+export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PATH="[[ .chezmoi.destDir ]]/.tmux/plugins/tmux-continuum"
+# Message to perfix the status indication with.
+export TMUX_POWERLINE_SEG_TMUX_CONTINUUM_PREFIX="Continuum status: "
 # }
 
 # tmux_mem_cpu_load.sh {
-	# Arguments passed to tmux-mem-cpu-load.
-	# See https://github.com/thewtex/tmux-mem-cpu-load for all available options.
-	# export TMUX_POWERLINE_SEG_TMUX_MEM_CPU_LOAD_ARGS="-v"
+# Arguments passed to tmux-mem-cpu-load.
+# See https://github.com/thewtex/tmux-mem-cpu-load for all available options.
+# export TMUX_POWERLINE_SEG_TMUX_MEM_CPU_LOAD_ARGS="-v"
 # }
 
 # tmux_session_info.sh {
-	# Session info format to feed into the command: tmux display-message -p
-	# For example, if FORMAT is '[ #S ]', the command is: tmux display-message -p '[ #S ]'
-	export TMUX_POWERLINE_SEG_TMUX_SESSION_INFO_FORMAT="#S:#I.#P"
+# Session info format to feed into the command: tmux display-message -p
+# For example, if FORMAT is '[ #S ]', the command is: tmux display-message -p '[ #S ]'
+export TMUX_POWERLINE_SEG_TMUX_SESSION_INFO_FORMAT="#S:#I.#P"
 # }
 
 # utc_time.sh {
-	# date(1) format for the UTC time.
-	export TMUX_POWERLINE_SEG_UTC_TIME_FORMAT="%H:%M %Z"
+# date(1) format for the UTC time.
+export TMUX_POWERLINE_SEG_UTC_TIME_FORMAT="%H:%M %Z"
 # }
 
 # vcs_branch.sh {
-	# Max length of the branch name.
-	export TMUX_POWERLINE_SEG_VCS_BRANCH_MAX_LEN=""
-	# Symbol when branch length exceeds max length
-	# export TMUX_POWERLINE_SEG_VCS_BRANCH_TRUNCATE_SYMBOL="…"
-	# Default branch symbol
-	export TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL=""
-	# Branch symbol for git repositories
-	# export TMUX_POWERLINE_SEG_VCS_BRANCH_GIT_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
-	# Branch symbol for hg/mercurial repositories
-	# export TMUX_POWERLINE_SEG_VCS_BRANCH_HG_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
-	# Branch symbol for SVN repositories
-	# export TMUX_POWERLINE_SEG_VCS_BRANCH_SVN_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
-	# Branch symbol colour for git repositories
-	export TMUX_POWERLINE_SEG_VCS_BRANCH_GIT_SYMBOL_COLOUR="5"
-	# Branch symbol colour for hg/mercurial repositories
-	export TMUX_POWERLINE_SEG_VCS_BRANCH_HG_SYMBOL_COLOUR="45"
-	# Branch symbol colour for SVN repositories
-	export TMUX_POWERLINE_SEG_VCS_BRANCH_SVN_SYMBOL_COLOUR="220"
+# Max length of the branch name.
+export TMUX_POWERLINE_SEG_VCS_BRANCH_MAX_LEN=""
+# Symbol when branch length exceeds max length
+# export TMUX_POWERLINE_SEG_VCS_BRANCH_TRUNCATE_SYMBOL="…"
+# Default branch symbol
+export TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL=""
+# Branch symbol for git repositories
+# export TMUX_POWERLINE_SEG_VCS_BRANCH_GIT_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
+# Branch symbol for hg/mercurial repositories
+# export TMUX_POWERLINE_SEG_VCS_BRANCH_HG_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
+# Branch symbol for SVN repositories
+# export TMUX_POWERLINE_SEG_VCS_BRANCH_SVN_SYMBOL="${TMUX_POWERLINE_SEG_VCS_BRANCH_DEFAULT_SYMBOL}"
+# Branch symbol colour for git repositories
+export TMUX_POWERLINE_SEG_VCS_BRANCH_GIT_SYMBOL_COLOUR="5"
+# Branch symbol colour for hg/mercurial repositories
+export TMUX_POWERLINE_SEG_VCS_BRANCH_HG_SYMBOL_COLOUR="45"
+# Branch symbol colour for SVN repositories
+export TMUX_POWERLINE_SEG_VCS_BRANCH_SVN_SYMBOL_COLOUR="220"
 # }
 
 # vcs_compare.sh {
-	# Symbol if local branch is behind.
-	# export TMUX_POWERLINE_SEG_VCS_COMPARE_AHEAD_SYMBOL="↑ "
-	# Symbol colour if local branch is ahead. Defaults to "current segment foreground colour"
-	# export TMUX_POWERLINE_SEG_VCS_COMPARE_AHEAD_SYMBOL_COLOUR=""
-	# Symbol if local branch is ahead.
-	# export TMUX_POWERLINE_SEG_VCS_COMPARE_BEHIND_SYMBOL="↓ "
-	# Symbol colour if local branch is behind. Defaults to "current segment foreground colour"
-	# export TMUX_POWERLINE_SEG_VCS_COMPARE_BEHIND_SYMBOL_COLOUR=""
+# Symbol if local branch is behind.
+# export TMUX_POWERLINE_SEG_VCS_COMPARE_AHEAD_SYMBOL="↑ "
+# Symbol colour if local branch is ahead. Defaults to "current segment foreground colour"
+# export TMUX_POWERLINE_SEG_VCS_COMPARE_AHEAD_SYMBOL_COLOUR=""
+# Symbol if local branch is ahead.
+# export TMUX_POWERLINE_SEG_VCS_COMPARE_BEHIND_SYMBOL="↓ "
+# Symbol colour if local branch is behind. Defaults to "current segment foreground colour"
+# export TMUX_POWERLINE_SEG_VCS_COMPARE_BEHIND_SYMBOL_COLOUR=""
 # }
 
 # vcs_modified.sh {
-	# Symbol for count of modified vcs files.
-	# export TMUX_POWERLINE_SEG_VCS_MODIFIED_SYMBOL="± "
+# Symbol for count of modified vcs files.
+# export TMUX_POWERLINE_SEG_VCS_MODIFIED_SYMBOL="± "
 # }
 
 # vcs_others.sh {
-	# Symbol for count of untracked vcs files.
-	# export TMUX_POWERLINE_SEG_VCS_OTHERS_SYMBOL="⋯"
+# Symbol for count of untracked vcs files.
+# export TMUX_POWERLINE_SEG_VCS_OTHERS_SYMBOL="⋯"
 # }
 
 # vcs_rootpath.sh {
-	# Display mode for vcs_rootpath.
-	# Example: (name: folder name only; path: full path, w/o expansion; user_path: full path, w/ tilde expansion)
-	# export TMUX_POWERLINE_SEG_VCS_ROOTPATH_MODE="name"
+# Display mode for vcs_rootpath.
+# Example: (name: folder name only; path: full path, w/o expansion; user_path: full path, w/ tilde expansion)
+# export TMUX_POWERLINE_SEG_VCS_ROOTPATH_MODE="name"
 # }
 
 # vcs_staged.sh {
-	# Symbol for count of staged vcs files.
-	# export TMUX_POWERLINE_SEG_VCS_STAGED_SYMBOL="⊕ "
+# Symbol for count of staged vcs files.
+# export TMUX_POWERLINE_SEG_VCS_STAGED_SYMBOL="⊕ "
 # }
 
 # vpn.sh {
-	# Mode for VPN segment {"both", "ip", "name"}. both: Show NIC/IP; ip: Show only IP; name: Show only NIC name
-	# export TMUX_POWERLINE_SEG_VPN_DISPLAY_MODE="both"
-	# Space separated list of tunnel interface names. First match is being used. substring match, regexp can be used.
-	# Examples:
-	# export TMUX_POWERLINE_SEG_VPN_NICS="tun" # will match 'tun0', 'utun0', 'itun', 'tun08127387'
-	# export TMUX_POWERLINE_SEG_VPN_NICS="tun0 tuntun" # will match 'tun0', 'utun0', 'tuntun'
-	# export TMUX_POWERLINE_SEG_VPN_NICS="^tun0$ ^tun1$" # exactly 'tun0' and 'tun1'
-	# Default:
-	# export TMUX_POWERLINE_SEG_VPN_NICS='^u?tun[0-9]+$'
-	# Symbol to use for vpn tunnel.
-	# export TMUX_POWERLINE_SEG_VPN_SYMBOL="󱠾 "
-	# Colour for vpn tunnel symbol
-	# export TMUX_POWERLINE_SEG_VPN_SYMBOL_COLOUR="255"
-	# Symbol for separator
-	# export TMUX_POWERLINE_SEG_VPN_DISPLAY_SEPARATOR="󰿟"
+# Mode for VPN segment {"both", "ip", "name"}. both: Show NIC/IP; ip: Show only IP; name: Show only NIC name
+# export TMUX_POWERLINE_SEG_VPN_DISPLAY_MODE="both"
+# Space separated list of tunnel interface names. First match is being used. substring match, regexp can be used.
+# Examples:
+# export TMUX_POWERLINE_SEG_VPN_NICS="tun" # will match 'tun0', 'utun0', 'itun', 'tun08127387'
+# export TMUX_POWERLINE_SEG_VPN_NICS="tun0 tuntun" # will match 'tun0', 'utun0', 'tuntun'
+# export TMUX_POWERLINE_SEG_VPN_NICS="^tun0$ ^tun1$" # exactly 'tun0' and 'tun1'
+# Default:
+# export TMUX_POWERLINE_SEG_VPN_NICS='^u?tun[0-9]+$'
+# Symbol to use for vpn tunnel.
+# export TMUX_POWERLINE_SEG_VPN_SYMBOL="󱠾 "
+# Colour for vpn tunnel symbol
+# export TMUX_POWERLINE_SEG_VPN_SYMBOL_COLOUR="255"
+# Symbol for separator
+# export TMUX_POWERLINE_SEG_VPN_DISPLAY_SEPARATOR="󰿟"
 # }
 
 # wan_ip.sh {
-	# Symbol for WAN IP
-	# export TMUX_POWERLINE_SEG_WAN_IP_SYMBOL="ⓦ "
-	# Symbol colour for WAN IP
-	# export TMUX_POWERLINE_SEG_WAN_IP_SYMBOL_COLOUR="255"
+# Symbol for WAN IP
+# export TMUX_POWERLINE_SEG_WAN_IP_SYMBOL="ⓦ "
+# Symbol colour for WAN IP
+# export TMUX_POWERLINE_SEG_WAN_IP_SYMBOL_COLOUR="255"
 # }
 
 # weather.sh {
-	# The data provider to use. Currently only "yrno" is supported.
-	export TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER="yrno"
-	# What unit to use. Can be any of {c,f,k}.
-	export TMUX_POWERLINE_SEG_WEATHER_UNIT="f"
-	# How often to update the weather in seconds.
-	export TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD="600"
-	# How often to update the weather location in seconds (this is only used when latitude and longitude settings are set to "auto")
-	export TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD="86400"
-	# Your location
-	# Latitude and Longtitude for use with yr.no
-	# Set both to "auto" to detect automatically based on your IP address, or set them manually
-	export TMUX_POWERLINE_SEG_WEATHER_LAT="auto"
-	export TMUX_POWERLINE_SEG_WEATHER_LON="auto"
+# The data provider to use. Currently only "yrno" is supported.
+export TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER="yrno"
+# What unit to use. Can be any of {c,f,k}.
+export TMUX_POWERLINE_SEG_WEATHER_UNIT="f"
+# How often to update the weather in seconds.
+export TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD="600"
+# How often to update the weather location in seconds (this is only used when latitude and longitude settings are set to "auto")
+export TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD="86400"
+# Your location
+# Latitude and Longtitude for use with yr.no
+# Set both to "auto" to detect automatically based on your IP address, or set them manually
+export TMUX_POWERLINE_SEG_WEATHER_LAT="auto"
+export TMUX_POWERLINE_SEG_WEATHER_LON="auto"
 # }
 
 # xkb_layout.sh {
-	# Keyboard icon
-	export TMUX_POWERLINE_SEG_XKB_LAYOUT_ICON="⌨ "
+# Keyboard icon
+export TMUX_POWERLINE_SEG_XKB_LAYOUT_ICON="⌨ "
 # }
 
 # =============================================
@@ -493,17 +493,17 @@ export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT=""
 export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR="201"
 
 export TMUX_POWERLINE_LEFT_STATUS_SEGMENTS=(
-	"tmux_session_info 148 234"
-	"hostname 33 0"
-	"mode_indicator 238 default_fg_color"
-	"vcs_branch 29 88"
+"tmux_session_info 148 234"
+"hostname 33 0"
+"mode_indicator 238 default_fg_color"
+"vcs_branch 29 88"
 )
 
 export TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS=(
-	"pwd 89 211"
-	# Removed disk_usage, battery - spawn expensive subprocesses every refresh
-	"weather 37 255"
-	# date_day merged into date format (%a %F)
-	"date 235 136"
-	"time 235 136"
+"pwd 89 211"
+# Removed disk_usage, battery - spawn expensive subprocesses every refresh
+"weather 37 255"
+# date_day merged into date format (%a %F)
+"date 235 136"
+"time 235 136"
 )

--- a/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
+++ b/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
@@ -9,4 +9,3 @@
 {{ template "shell/fzf_tab.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/zoxide.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/git_alias.sh" (merge (dict "shell" "bash") .) }}
-

--- a/src/chezmoi/dot_dotfiles/external/.chezmoiexternals/eza-completions.toml.tmpl
+++ b/src/chezmoi/dot_dotfiles/external/.chezmoiexternals/eza-completions.toml.tmpl
@@ -3,10 +3,10 @@
 {{- if and $installation (ne $installation "disabled") -}}
 {{- $config := dict -}}
 {{- $ezaCompletions := dict
-    "type" "archive"
-    "url" (gitHubReleaseAssetURL "eza-community/eza" (printf "v%s" .version) (printf "completions-%s.tar.gz" .version))
-    "include" (list "zsh/_eza")
-    "readonly" true
+"type" "archive"
+"url" (gitHubReleaseAssetURL "eza-community/eza" (printf "v%s" .version) (printf "completions-%s.tar.gz" .version))
+"include" (list "zsh/_eza")
+"readonly" true
 -}}
 {{- $_ := set $config "eza-completions" $ezaCompletions -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_dotfiles/external/.chezmoiexternals/oh-my-zsh.toml.tmpl
+++ b/src/chezmoi/dot_dotfiles/external/.chezmoiexternals/oh-my-zsh.toml.tmpl
@@ -4,20 +4,20 @@
 {{- if and (eq $prompt "oh-my-zsh") (eq $installation "external-sources") -}}
 {{- $config := dict -}}
 {{- $ohMyZsh := dict
-    "type" "archive"
-    "url" (printf "https://github.com/ohmyzsh/ohmyzsh/archive/%s.tar.gz" .sha)
-    "exact" true
-    "stripComponents" 1
+"type" "archive"
+"url" (printf "https://github.com/ohmyzsh/ohmyzsh/archive/%s.tar.gz" .sha)
+"exact" true
+"stripComponents" 1
 -}}
 {{- $_ := set $config "oh-my-zsh" $ohMyZsh -}}
 {{- if .powerlevel10k.enabled -}}
-  {{- $p10k := dict
-    "type" "archive"
-    "url" (printf "https://github.com/romkatv/powerlevel10k/archive/refs/tags/%s.tar.gz" .powerlevel10k.version)
-    "exact" true
-    "stripComponents" 1
+{{- $p10k := dict
+"type" "archive"
+"url" (printf "https://github.com/romkatv/powerlevel10k/archive/refs/tags/%s.tar.gz" .powerlevel10k.version)
+"exact" true
+"stripComponents" 1
 -}}
-  {{- $_ := set $config "oh-my-zsh/custom/themes/powerlevel10k" $p10k -}}
+{{- $_ := set $config "oh-my-zsh/custom/themes/powerlevel10k" $p10k -}}
 {{- end -}}
 {{- toToml $config -}}
 {{- end -}}

--- a/src/chezmoi/dot_dotfiles/git/config.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/config.tmpl
@@ -3,29 +3,29 @@
 
 # Core configuration (all profiles)
 [include]
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/core.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/color.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/diff.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/fetch.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/merge.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/pull.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/push.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/rebase.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/rerere.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/stash.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/branch.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/column.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/aliases.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/core.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/color.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/diff.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/fetch.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/merge.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/pull.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/push.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/rebase.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/rerere.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/stash.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/branch.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/column.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/aliases.gitconfig
 
 # Conditionally apply pruning only for GitHub remotes
 [includeIf "hasconfig:remote.*.url:https://github.com/**"]
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/prune.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/prune.gitconfig
 [includeIf "hasconfig:remote.*.url:git@github.com:*/**"]
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/prune.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/prune.gitconfig
 
 # Personal configuration
 {{- if .git.personal.enabled }}
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/personal.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/github.gitconfig
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/init.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/personal.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/github.gitconfig
+path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/init.gitconfig
 {{- end }}

--- a/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
@@ -1,13 +1,13 @@
 [core]
-	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeditor
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeditor
 {{- if lookPath "nvim" }}
-	editor = nvim
+editor = nvim
 {{- else if lookPath "vim" }}
-	editor = vim
+editor = vim
 {{- end }}
-	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf
-	autocrlf = input
-	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile
-	excludesFile = ~/.gitignore_global
-	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefsmonitor
-	fsmonitor = true
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf
+autocrlf = input
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile
+excludesFile = ~/.gitignore_global
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefsmonitor
+fsmonitor = true

--- a/src/chezmoi/dot_dotfiles/git/snippets/personal.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/personal.gitconfig.tmpl
@@ -5,20 +5,20 @@
 {{- end }}
 
 [user]
-  name = {{ .name | quote }}
-  email = {{ .email | quote }}
+name = {{ .name | quote }}
+email = {{ .email | quote }}
 {{- if .signing_key }}
-  signingkey = {{ .signing_key }}
+signingkey = {{ .signing_key }}
 {{- end }}
 
 [commit]
 {{- if .signing_key }}
-  gpgsign = true
+gpgsign = true
 {{- else }}
-  gpgsign = false
+gpgsign = false
 {{- end }}
 
 [gpg]
-  program = gpg
+program = gpg
 {{- end }}
 {{- end }}

--- a/src/chezmoi/dot_dotfiles/git/snippets/user.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/user.gitconfig.tmpl
@@ -1,8 +1,7 @@
 [user]
-  # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-username
-  name = {{ .git.personal.name | quote }}
-  # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-useremail
-  email = {{ .git.personal.email | quote }}
-  # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
-  signingkey = {{ .git.personal.signing_key }}
-
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-username
+name = {{ .git.personal.name | quote }}
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-useremail
+email = {{ .git.personal.email | quote }}
+# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
+signingkey = {{ .git.personal.signing_key }}

--- a/src/chezmoi/dot_dotfiles/hammerspoon/config.lua.tmpl
+++ b/src/chezmoi/dot_dotfiles/hammerspoon/config.lua.tmpl
@@ -3,10 +3,10 @@
 
 -- Global Configuration Table
 _G.DotfilesConfig = {
-    cache_dir = "{{ .chezmoi.destDir }}/.cache",
-    window_manager = {
-        enabled = {{ .hammerspoon.window_manager.enabled | default "false" }}
-    }
+cache_dir = "{{ .chezmoi.destDir }}/.cache",
+window_manager = {
+enabled = {{ .hammerspoon.window_manager.enabled | default "false" }}
+}
 }
 
 -- Load base configuration

--- a/src/chezmoi/dot_dotfiles/vim/config.vim.tmpl
+++ b/src/chezmoi/dot_dotfiles/vim/config.vim.tmpl
@@ -6,7 +6,7 @@
 
 " Source all vim snippet files
 for file in split(glob('{{ $targetDir }}/snippets/*.vim'), '\n')
-    if filereadable(file)
-        execute 'source' file
-    endif
+if filereadable(file)
+execute 'source' file
+endif
 endfor

--- a/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
+++ b/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
@@ -22,4 +22,3 @@
 {{ template "zsh/530_keybindings.zsh" . }}
 {{ template "zsh/910_eza.zsh" . }}
 {{ template "zsh/remove_100_asdf.zsh" . }}
-

--- a/src/chezmoi/dot_gemini/settings.json.tmpl
+++ b/src/chezmoi/dot_gemini/settings.json.tmpl
@@ -1,39 +1,39 @@
 {{- $geminiTool := index .mise.global_tools "npm:@google/gemini-cli" -}}
 {{- if eq $geminiTool.installation "mise" -}}
 {{-   $settings := dict
-        "model" (dict "name" .gemini.model)
-        "telemetry" (dict "enabled" .gemini.telemetry.enabled "logPrompts" .gemini.telemetry.log_prompts)
-        "ui" (dict
-          "showLineNumbers" .gemini.ui.show_line_numbers
-          "showMemoryUsage" .gemini.ui.show_memory_usage
-          "showModelInfoInChat" .gemini.ui.show_model_info_in_chat
-          "footer" (dict "hideContextPercentage" .gemini.ui.footer.hide_context_percentage)
-        )
-        "general" (dict
-          "enableAutoUpdate" .gemini.general.enable_auto_update
-          "previewFeatures" .gemini.general.preview_features
-          "vimMode" .gemini.general.vim_mode
-          "sessionRetention" (dict
-            "enabled" .gemini.general.sessionRetention.enabled
-            "maxAge" .gemini.general.sessionRetention.max_age
-            "warningAcknowledged" .gemini.general.sessionRetention.warning_acknowledged
-          )
-        )
-        "security" (dict
-          "auth" (dict
-            "selectedType" "oauth-personal"
-          )
-        )
-        "tools" (dict
-          "sandbox" .gemini.tools.sandbox
-          "sandboxAllowedPaths" .gemini.tools.sandbox_allowed_paths
-        )
-        "context" (dict
-          "includeDirectories" .gemini.context.include_directories
-        )
-        "experimental" (dict
-          "worktrees" .gemini.experimental.worktrees
-        )
+"model" (dict "name" .gemini.model)
+"telemetry" (dict "enabled" .gemini.telemetry.enabled "logPrompts" .gemini.telemetry.log_prompts)
+"ui" (dict
+"showLineNumbers" .gemini.ui.show_line_numbers
+"showMemoryUsage" .gemini.ui.show_memory_usage
+"showModelInfoInChat" .gemini.ui.show_model_info_in_chat
+"footer" (dict "hideContextPercentage" .gemini.ui.footer.hide_context_percentage)
+)
+"general" (dict
+"enableAutoUpdate" .gemini.general.enable_auto_update
+"previewFeatures" .gemini.general.preview_features
+"vimMode" .gemini.general.vim_mode
+"sessionRetention" (dict
+"enabled" .gemini.general.sessionRetention.enabled
+"maxAge" .gemini.general.sessionRetention.max_age
+"warningAcknowledged" .gemini.general.sessionRetention.warning_acknowledged
+)
+)
+"security" (dict
+"auth" (dict
+"selectedType" "oauth-personal"
+)
+)
+"tools" (dict
+"sandbox" .gemini.tools.sandbox
+"sandboxAllowedPaths" .gemini.tools.sandbox_allowed_paths
+)
+"context" (dict
+"includeDirectories" .gemini.context.include_directories
+)
+"experimental" (dict
+"worktrees" .gemini.experimental.worktrees
+)
 -}}
 {{-   $settings | toPrettyJson "  " -}}
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/bat.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/bat.toml.tmpl
@@ -3,22 +3,22 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-gnu" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-unknown-linux-gnu" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $bat := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "sharkdp/bat" (printf "v%s" .version) (printf "bat-v%s-%s.tar.gz" .version $target))
-    "path" (printf "bat-v%s-%s/bat" .version $target)
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "sharkdp/bat" (printf "v%s" .version) (printf "bat-v%s-%s.tar.gz" .version $target))
+"path" (printf "bat-v%s-%s/bat" .version $target)
+"executable" true
 -}}
 {{- if ne .checksums.type "disabled" -}}
-  {{- if not (hasKey .checksums $platform) -}}
-    {{- fail (printf "Checksum validation enabled but no checksum found for platform: %s" $platform) -}}
-  {{- end -}}
-  {{- $_ := set $bat "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- if not (hasKey .checksums $platform) -}}
+{{- fail (printf "Checksum validation enabled but no checksum found for platform: %s" $platform) -}}
+{{- end -}}
+{{- $_ := set $bat "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "bat" $bat -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/chafa.toml.tmpl
@@ -4,21 +4,21 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "amd64") -}}
-  {{- $target = "x86_64-linux-gnu" -}}
+{{- $target = "x86_64-linux-gnu" -}}
 {{- else if and (eq $.chezmoi.os "linux") (eq $.chezmoi.arch "arm") -}}
-  {{- $target = "armv7l-linux-gnu" -}}
+{{- $target = "armv7l-linux-gnu" -}}
 {{- end -}}
 {{- if ne $target "" -}}
 {{- $config := dict -}}
 {{- $chafa := dict
-    "type" "archive-file"
-    "url" (printf "https://hpjansson.org/chafa/releases/static/chafa-%s-1-%s.tar.gz" $version $target)
-    "path" (printf "chafa-%s-1-%s/chafa" $version $target)
-    "executable" true
+"type" "archive-file"
+"url" (printf "https://hpjansson.org/chafa/releases/static/chafa-%s-1-%s.tar.gz" $version $target)
+"path" (printf "chafa-%s-1-%s/chafa" $version $target)
+"executable" true
 -}}
 {{- $checksums := dig "chafa" "checksums" dict . -}}
 {{- if and (hasKey $checksums $platform) (ne (trim (index $checksums $platform)) "") -}}
-  {{- $_ := set $chafa "checksum" (dict "sha256" (index $checksums $platform)) -}}
+{{- $_ := set $chafa "checksum" (dict "sha256" (index $checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "chafa" $chafa -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/eza.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/eza.toml.tmpl
@@ -3,29 +3,29 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "linux" -}}
-  {{- if eq $.chezmoi.arch "arm64" -}}
-    {{- $target = "aarch64-unknown-linux-gnu" -}}
-  {{- else -}}
-    {{- $target = "x86_64-unknown-linux-musl" -}}
-  {{- end -}}
+{{- if eq $.chezmoi.arch "arm64" -}}
+{{- $target = "aarch64-unknown-linux-gnu" -}}
+{{- else -}}
+{{- $target = "x86_64-unknown-linux-musl" -}}
+{{- end -}}
 {{- else if eq $.chezmoi.os "darwin" -}}
-  {{- if eq $.chezmoi.arch "arm64" -}}
-    {{- $target = "aarch64-apple-darwin" -}}
-  {{- else -}}
-    {{- $target = "x86_64-apple-darwin" -}}
-  {{- end -}}
+{{- if eq $.chezmoi.arch "arm64" -}}
+{{- $target = "aarch64-apple-darwin" -}}
+{{- else -}}
+{{- $target = "x86_64-apple-darwin" -}}
+{{- end -}}
 {{- end -}}
 {{- if ne $target "" -}}
 {{- $config := dict -}}
 {{- $eza := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "eza-community/eza" (printf "v%s" .version) (printf "eza_%s.tar.gz" $target))
-    "path" "eza"
-    "stripComponents" 1
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "eza-community/eza" (printf "v%s" .version) (printf "eza_%s.tar.gz" $target))
+"path" "eza"
+"stripComponents" 1
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $eza "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $eza "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "eza" $eza -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/fd.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/fd.toml.tmpl
@@ -3,19 +3,19 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $fd := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "sharkdp/fd" (printf "v%s" .version) (printf "fd-v%s-%s.tar.gz" .version $target))
-    "path" (printf "fd-v%s-%s/fd" .version $target)
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "sharkdp/fd" (printf "v%s" .version) (printf "fd-v%s-%s.tar.gz" .version $target))
+"path" (printf "fd-v%s-%s/fd" .version $target)
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $fd "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $fd "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "fd" $fd -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/fzf.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/fzf.toml.tmpl
@@ -3,11 +3,11 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $config := dict -}}
 {{- $fzf := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "junegunn/fzf" (printf "v%s" .version) (printf "fzf-%s-%s_%s.tar.gz" .version $.chezmoi.os $.chezmoi.arch))
-    "path" "fzf"
-    "executable" true
-    "checksum" (dict "sha256" (index .checksums $platform))
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "junegunn/fzf" (printf "v%s" .version) (printf "fzf-%s-%s_%s.tar.gz" .version $.chezmoi.os $.chezmoi.arch))
+"path" "fzf"
+"executable" true
+"checksum" (dict "sha256" (index .checksums $platform))
 -}}
 {{- $_ := set $config "fzf" $fzf -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/gh.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/gh.toml.tmpl
@@ -3,27 +3,27 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $os_name := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $os_name = "macOS" -}}
+{{- $os_name = "macOS" -}}
 {{- else -}}
-  {{- $os_name = $.chezmoi.os -}}
+{{- $os_name = $.chezmoi.os -}}
 {{- end -}}
 {{- $file_ext := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $file_ext = "zip" -}}
+{{- $file_ext = "zip" -}}
 {{- else -}}
-  {{- $file_ext = "tar.gz" -}}
+{{- $file_ext = "tar.gz" -}}
 {{- end -}}
 {{- $archive_name := printf "gh_%s_%s_%s.%s" .version $os_name $.chezmoi.arch $file_ext -}}
 {{- $archive_path := printf "gh_%s_%s_%s/bin/gh" .version $os_name $.chezmoi.arch -}}
 {{- $config := dict -}}
 {{- $gh := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "cli/cli" (printf "v%s" .version) $archive_name)
-    "path" $archive_path
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "cli/cli" (printf "v%s" .version) $archive_name)
+"path" $archive_path
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $gh "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $gh "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "gh" $gh -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/jq.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/jq.toml.tmpl
@@ -3,18 +3,18 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "macos-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "amd64") -}}
+{{- $target = printf "macos-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "amd64") -}}
 {{- else -}}
-  {{- $target = printf "linux-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "amd64") -}}
+{{- $target = printf "linux-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "amd64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $jq := dict
-    "type" "file"
-    "url" (gitHubReleaseAssetURL "jqlang/jq" (printf "jq-%s" .version) (printf "jq-%s" $target))
-    "executable" true
+"type" "file"
+"url" (gitHubReleaseAssetURL "jqlang/jq" (printf "jq-%s" .version) (printf "jq-%s" $target))
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $jq "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $jq "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "jq" $jq -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/mise.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/mise.toml.tmpl
@@ -3,18 +3,18 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "macos-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "x64") -}}
+{{- $target = printf "macos-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "x64") -}}
 {{- else -}}
-  {{- $target = printf "linux-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "x64") -}}
+{{- $target = printf "linux-%s" (eq $.chezmoi.arch "arm64" | ternary "arm64" "x64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $mise := dict
-    "type" "file"
-    "url" (gitHubReleaseAssetURL "jdx/mise" .version (printf "mise-%s-%s" .version $target))
-    "executable" true
+"type" "file"
+"url" (gitHubReleaseAssetURL "jdx/mise" .version (printf "mise-%s-%s" .version $target))
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $mise "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $mise "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "mise" $mise -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/rg.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/rg.toml.tmpl
@@ -3,23 +3,23 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- if eq $.chezmoi.arch "arm64" -}}
-    {{- $target = "aarch64-unknown-linux-gnu" -}}
-  {{- else -}}
-    {{- $target = "x86_64-unknown-linux-musl" -}}
-  {{- end -}}
+{{- if eq $.chezmoi.arch "arm64" -}}
+{{- $target = "aarch64-unknown-linux-gnu" -}}
+{{- else -}}
+{{- $target = "x86_64-unknown-linux-musl" -}}
+{{- end -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $rg := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "BurntSushi/ripgrep" .version (printf "ripgrep-%s-%s.tar.gz" .version $target))
-    "path" (printf "ripgrep-%s-%s/rg" .version $target)
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "BurntSushi/ripgrep" .version (printf "ripgrep-%s-%s.tar.gz" .version $target))
+"path" (printf "ripgrep-%s-%s/rg" .version $target)
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $rg "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $rg "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "rg" $rg -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/rulesync.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/rulesync.toml.tmpl
@@ -10,12 +10,12 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $config := dict -}}
 {{- $rulesync := dict
-    "type" "file"
-    "url" (gitHubReleaseAssetURL "dyoshikawa/rulesync" (printf "v%s" .version) $asset)
-    "executable" true
+"type" "file"
+"url" (gitHubReleaseAssetURL "dyoshikawa/rulesync" (printf "v%s" .version) $asset)
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $rulesync "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $rulesync "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "rulesync" $rulesync -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/starship.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/starship.toml.tmpl
@@ -4,22 +4,22 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-%s" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") (eq $.chezmoi.arch "arm64" | ternary "musl" "gnu") -}}
+{{- $target = printf "%s-unknown-linux-%s" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") (eq $.chezmoi.arch "arm64" | ternary "musl" "gnu") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $starship := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "starship/starship" (printf "v%s" .version) (printf "starship-%s.tar.gz" $target))
-    "path" "starship"
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "starship/starship" (printf "v%s" .version) (printf "starship-%s.tar.gz" $target))
+"path" "starship"
+"executable" true
 -}}
 {{- if ne .checksums.type "disabled" -}}
-  {{- if not (hasKey .checksums $platform) -}}
-    {{- fail (printf "Checksum validation enabled but no checksum found for platform: %s" $platform) -}}
-  {{- end -}}
-  {{- $_ := set $starship "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- if not (hasKey .checksums $platform) -}}
+{{- fail (printf "Checksum validation enabled but no checksum found for platform: %s" $platform) -}}
+{{- end -}}
+{{- $_ := set $starship "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "starship" $starship -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/zellij.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/zellij.toml.tmpl
@@ -3,14 +3,14 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $entry := dict "type" "archive-file" "url" (gitHubReleaseAssetURL "zellij-org/zellij" .version (printf "zellij-%s.tar.gz" $target)) "path" "zellij" "executable" true -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $entry "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $entry "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "zellij" $entry -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/zoxide.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/zoxide.toml.tmpl
@@ -3,19 +3,19 @@
 {{- $platform := printf "%s_%s" $.chezmoi.os $.chezmoi.arch -}}
 {{- $target := "" -}}
 {{- if eq $.chezmoi.os "darwin" -}}
-  {{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-apple-darwin" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- else -}}
-  {{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
+{{- $target = printf "%s-unknown-linux-musl" (eq $.chezmoi.arch "arm64" | ternary "aarch64" "x86_64") -}}
 {{- end -}}
 {{- $config := dict -}}
 {{- $zoxide := dict
-    "type" "archive-file"
-    "url" (gitHubReleaseAssetURL "ajeetdsouza/zoxide" (printf "v%s" .version) (printf "zoxide-%s-%s.tar.gz" .version $target))
-    "path" "zoxide"
-    "executable" true
+"type" "archive-file"
+"url" (gitHubReleaseAssetURL "ajeetdsouza/zoxide" (printf "v%s" .version) (printf "zoxide-%s-%s.tar.gz" .version $target))
+"path" "zoxide"
+"executable" true
 -}}
 {{- if and (hasKey .checksums $platform) (ne (trim (index .checksums $platform)) "") -}}
-  {{- $_ := set $zoxide "checksum" (dict "sha256" (index .checksums $platform)) -}}
+{{- $_ := set $zoxide "checksum" (dict "sha256" (index .checksums $platform)) -}}
 {{- end -}}
 {{- $_ := set $config "zoxide" $zoxide -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_obsidian-wsl-wrapper.sh.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_obsidian-wsl-wrapper.sh.tmpl
@@ -5,18 +5,18 @@ set -euo pipefail
 # Prefer direct WSL interop; fall back to locating via PowerShell when the
 # Windows PATH has not been refreshed in this session after Obsidian install.
 if command -v Obsidian.com &>/dev/null; then
-    obsidian_cmd="Obsidian.com"
+obsidian_cmd="Obsidian.com"
 else
-    ps_exec=$(command -v pwsh.exe || command -v powershell.exe || echo "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
-    win_path=$("$ps_exec" -NoProfile -Command "(Get-Command Obsidian.com -ErrorAction SilentlyContinue).Source" 2>/dev/null | tr -d '\r')
-    if [[ -z "$win_path" ]]; then
-        printf '\033[31m⚠️  Obsidian.com not found.\033[0m\n'                                                           >&2
-        printf '\033[31m   • Install Obsidian 1.12.7+: https://obsidian.md/help/cli#Windows\033[0m\n'                  >&2
-        printf '\033[31m   • Register the CLI in the Obsidian app: Settings → General → Register CLI\033[0m\n'         >&2
-        printf '\033[31m   • Restart your terminal after installation\033[0m\n'                                         >&2
-        exit 1
-    fi
-    obsidian_cmd=$(wslpath "$win_path")
+ps_exec=$(command -v pwsh.exe || command -v powershell.exe || echo "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
+win_path=$("$ps_exec" -NoProfile -Command "(Get-Command Obsidian.com -ErrorAction SilentlyContinue).Source" 2>/dev/null | tr -d '\r')
+if [[ -z "$win_path" ]]; then
+printf '\033[31m⚠️  Obsidian.com not found.\033[0m\n'                                                           >&2
+printf '\033[31m   • Install Obsidian 1.12.7+: https://obsidian.md/help/cli#Windows\033[0m\n'                  >&2
+printf '\033[31m   • Register the CLI in the Obsidian app: Settings → General → Register CLI\033[0m\n'         >&2
+printf '\033[31m   • Restart your terminal after installation\033[0m\n'                                         >&2
+exit 1
+fi
+obsidian_cmd=$(wslpath "$win_path")
 fi
 
 "$obsidian_cmd" "$@" | tr -d '\r'

--- a/src/chezmoi/dot_local/share/ai/.chezmoiexternals/claude-plugins.toml.tmpl
+++ b/src/chezmoi/dot_local/share/ai/.chezmoiexternals/claude-plugins.toml.tmpl
@@ -14,15 +14,15 @@
 */ -}}
 {{- $config := dict -}}
 {{- range (index .ai_plugins "items") -}}
-  {{- if eq .tool "claude" -}}
-    {{- $target := printf ".local/share/ai/marketplace/plugins/%s/skills/%s.md" .name .name -}}
-    {{- $plugin := dict
-        "type" "file"
-        "url" (printf "https://raw.githubusercontent.com/%s/%s/%s" .repo .commit .path)
-        "checksum" (dict "sha256" .sha256)
-    -}}
-    {{- $_ := set $config $target $plugin -}}
-  {{- end -}}
+{{- if eq .tool "claude" -}}
+{{- $target := printf ".local/share/ai/marketplace/plugins/%s/skills/%s.md" .name .name -}}
+{{- $plugin := dict
+"type" "file"
+"url" (printf "https://raw.githubusercontent.com/%s/%s/%s" .repo .commit .path)
+"checksum" (dict "sha256" .sha256)
+-}}
+{{- $_ := set $config $target $plugin -}}
+{{- end -}}
 {{- end -}}
 {{- if not (empty $config) -}}
 {{- toToml $config -}}

--- a/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
+++ b/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
@@ -22,8 +22,8 @@ MARKETPLACE_DIR="{{ .chezmoi.destDir }}/.local/share/ai/marketplace"
 MARKETPLACE_NAME="personal-plugins"
 
 if ! command -v claude &> /dev/null; then
-    log_warn "claude not found in PATH — skipping personal plugin sync."
-    exit 0
+log_warn "claude not found in PATH — skipping personal plugin sync."
+exit 0
 fi
 
 log_info "Syncing personal Claude plugins..."
@@ -31,10 +31,10 @@ log_info "Syncing personal Claude plugins..."
 # --- 1. Register marketplace if not already known ---
 KNOWN=$(claude plugin marketplace list --json 2>/dev/null | jq -r '.[].name' 2>/dev/null || echo "")
 if echo "$KNOWN" | grep -qx "$MARKETPLACE_NAME"; then
-    log_info "Marketplace '${MARKETPLACE_NAME}' already registered."
+log_info "Marketplace '${MARKETPLACE_NAME}' already registered."
 else
-    log_info "Registering marketplace '${MARKETPLACE_NAME}' from ${MARKETPLACE_DIR}..."
-    claude plugin marketplace add "$MARKETPLACE_DIR"
+log_info "Registering marketplace '${MARKETPLACE_NAME}' from ${MARKETPLACE_DIR}..."
+claude plugin marketplace add "$MARKETPLACE_DIR"
 fi
 
 # --- 2. Desired set (rendered from registry at chezmoi apply time) ---
@@ -49,26 +49,26 @@ DESIRED_PLUGINS
 
 # --- 3. Currently installed from @personal-plugins (user scope only) ---
 INSTALLED=$(claude plugin list --json 2>/dev/null \
-    | jq -r --arg mp "@${MARKETPLACE_NAME}" \
-        '.[] | select(.scope == "user") | select(.id | endswith($mp)) | .id | split("@")[0]' \
-    2>/dev/null || echo "")
+| jq -r --arg mp "@${MARKETPLACE_NAME}" \
+'.[] | select(.scope == "user") | select(.id | endswith($mp)) | .id | split("@")[0]' \
+2>/dev/null || echo "")
 
 # --- 4. Install: in desired but not installed ---
 while IFS= read -r name; do
-    [[ -z "$name" ]] && continue
-    if ! echo "$INSTALLED" | grep -qx "$name"; then
-        log_info "Installing plugin: ${name}@${MARKETPLACE_NAME}"
-        claude plugin install "${name}@${MARKETPLACE_NAME}"
-    fi
+[[ -z "$name" ]] && continue
+if ! echo "$INSTALLED" | grep -qx "$name"; then
+log_info "Installing plugin: ${name}@${MARKETPLACE_NAME}"
+claude plugin install "${name}@${MARKETPLACE_NAME}"
+fi
 done <<< "$DESIRED"
 
 # --- 5. Uninstall: installed from @personal-plugins but no longer in desired ---
 while IFS= read -r installed; do
-    [[ -z "$installed" ]] && continue
-    if ! echo "$DESIRED" | grep -qx "$installed"; then
-        log_info "Uninstalling plugin: ${installed}@${MARKETPLACE_NAME}"
-        claude plugin uninstall "${installed}@${MARKETPLACE_NAME}"
-    fi
+[[ -z "$installed" ]] && continue
+if ! echo "$DESIRED" | grep -qx "$installed"; then
+log_info "Uninstalling plugin: ${installed}@${MARKETPLACE_NAME}"
+claude plugin uninstall "${installed}@${MARKETPLACE_NAME}"
+fi
 done <<< "$INSTALLED"
 
 log_success "Personal Claude plugin sync complete."

--- a/src/chezmoi/dot_local/share/fonts/.chezmoiexternals/fonts.toml.tmpl
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoiexternals/fonts.toml.tmpl
@@ -1,15 +1,15 @@
 {{- $config := dict -}}
 {{- range $key, $font := .fonts -}}
-  {{- if eq $font.installation "external-sources" -}}
-    {{- $target := printf "NerdFonts/%s" $font.name -}}
-    {{- $fontConfig := dict
-        "type" "archive"
-        "url" (printf "https://github.com/ryanoasis/nerd-fonts/releases/download/%s/%s.tar.xz" $font.version $font.name)
-        "exact" true
-        "checksum" (dict "sha256" $font.sha256)
-    -}}
-    {{- $_ := set $config $target $fontConfig -}}
-  {{- end -}}
+{{- if eq $font.installation "external-sources" -}}
+{{- $target := printf "NerdFonts/%s" $font.name -}}
+{{- $fontConfig := dict
+"type" "archive"
+"url" (printf "https://github.com/ryanoasis/nerd-fonts/releases/download/%s/%s.tar.xz" $font.version $font.name)
+"exact" true
+"checksum" (dict "sha256" $font.sha256)
+-}}
+{{- $_ := set $config $target $fontConfig -}}
+{{- end -}}
 {{- end -}}
 {{- if not (empty $config) -}}
 {{- toToml $config -}}

--- a/src/chezmoi/modify_dot_bash_profile.tmpl
+++ b/src/chezmoi/modify_dot_bash_profile.tmpl
@@ -9,14 +9,14 @@ sed -i.bak '/.*modify_dot_bash_profile\.tmpl:BEGIN:chezmoi:bash/,/.*modify_dot_b
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:bash:{{ include "modify_dot_bash_profile.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
 if [[ -f "{{ .chezmoi.destDir }}/.bashrc" ]]; then
-  source "{{ .chezmoi.destDir }}/.bashrc"
+source "{{ .chezmoi.destDir }}/.bashrc"
 fi
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:bash:{{ include "modify_dot_bash_profile.tmpl" | sha256sum | substr 0 8 }}
 EOF

--- a/src/chezmoi/modify_dot_bashrc.tmpl
+++ b/src/chezmoi/modify_dot_bashrc.tmpl
@@ -9,7 +9,7 @@ sed -i.bak '/.*modify_dot_bashrc\.tmpl:BEGIN:chezmoi:bash/,/.*modify_dot_bashrc\
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section

--- a/src/chezmoi/modify_dot_gitconfig.tmpl
+++ b/src/chezmoi/modify_dot_gitconfig.tmpl
@@ -9,14 +9,14 @@ sed -i.bak '/.*modify_dot_gitconfig\.tmpl:BEGIN:chezmoi:git/,/.*modify_dot_gitco
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:git:{{ include "modify_dot_gitconfig.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
 [include]
-  path = {{ .chezmoi.destDir }}/.dotfiles/git/config
+path = {{ .chezmoi.destDir }}/.dotfiles/git/config
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:git:{{ include "modify_dot_gitconfig.tmpl" | sha256sum | substr 0 8 }}
 EOF
 

--- a/src/chezmoi/modify_dot_tmux.conf.tmpl
+++ b/src/chezmoi/modify_dot_tmux.conf.tmpl
@@ -9,7 +9,7 @@ sed -i.bak '/.*modify_dot_tmux\.conf\.tmpl:BEGIN:chezmoi:tmux/,/.*modify_dot_tmu
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section

--- a/src/chezmoi/modify_dot_vimrc.tmpl
+++ b/src/chezmoi/modify_dot_vimrc.tmpl
@@ -9,7 +9,7 @@ sed -i.bak '/.*modify_dot_vimrc\.tmpl:BEGIN:chezmoi:vim/,/.*modify_dot_vimrc\.tm
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section

--- a/src/chezmoi/modify_dot_zprofile.tmpl
+++ b/src/chezmoi/modify_dot_zprofile.tmpl
@@ -9,7 +9,7 @@ sed -i.bak '/.*modify_dot_zprofile\.tmpl:BEGIN:chezmoi:zsh/,/.*modify_dot_zprofi
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section

--- a/src/chezmoi/modify_dot_zshrc.tmpl
+++ b/src/chezmoi/modify_dot_zshrc.tmpl
@@ -9,7 +9,7 @@ sed -i.bak '/.*modify_dot_zshrc\.tmpl:BEGIN:chezmoi:zsh/,/.*modify_dot_zshrc\.tm
 
 # Check if file ends with newline, if not add one
 if [ -s "${tempfile}" ] && [ "$(tail -c1 "${tempfile}")" != "" ]; then
-  echo >> "${tempfile}"
+echo >> "${tempfile}"
 fi
 
 # Add our managed section

--- a/src/chezmoi/run_once_install-claude.sh.tmpl
+++ b/src/chezmoi/run_once_install-claude.sh.tmpl
@@ -6,11 +6,11 @@ set -euo pipefail
 
 # Check if claude is already installed and at the right version
 if command -v claude &> /dev/null; then
-    current_version=$(claude --version 2>/dev/null | head -n1 | awk '{print $NF}' || echo "unknown")
-    if [[ "$current_version" == "{{ .claude_code.version }}" ]]; then
-        echo "Claude Code {{ .claude_code.version }} already installed"
-        exit 0
-    fi
+current_version=$(claude --version 2>/dev/null | head -n1 | awk '{print $NF}' || echo "unknown")
+if [[ "$current_version" == "{{ .claude_code.version }}" ]]; then
+echo "Claude Code {{ .claude_code.version }} already installed"
+exit 0
+fi
 fi
 
 echo "Installing Claude Code {{ .claude_code.version }}..."

--- a/src/chezmoi/run_onchange_after_wslconfig.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_wslconfig.sh.tmpl
@@ -10,8 +10,8 @@ set -euo pipefail
 
 WIN_PROFILE=$(/mnt/c/Windows/System32/cmd.exe /c "echo %USERPROFILE%" 2>/dev/null | tr -d '\r')
 if [[ -z "${WIN_PROFILE}" ]]; then
-  echo "ERROR: Could not determine Windows user profile path via cmd.exe" >&2
-  exit 1
+echo "ERROR: Could not determine Windows user profile path via cmd.exe" >&2
+exit 1
 fi
 WSLCONFIG_PATH="$(wslpath -u "${WIN_PROFILE}")/.wslconfig"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-03-31T00:07:59.891212625Z"
-exclude-newer-span = "P14D"
-
 [manifest]
 members = [
     "claude-statusline",
@@ -159,6 +155,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "claude-statusline"
 version = "0.0.0"
 source = { editable = "src/python/claude_statusline" }
@@ -211,6 +216,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cssbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "jsbeautifier" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/01/fdf41c1e5f93d359681976ba10410a04b299d248e28ecce1d4e88588dde4/cssbeautifier-1.15.4.tar.gz", hash = "sha256:9bb08dc3f64c101a01677f128acf01905914cf406baf87434dcde05b74c0acf5", size = 25376, upload-time = "2025-02-27T17:53:51.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/51/ef6c5628e46092f0a54c7cee69acc827adc6b6aab57b55d344fefbdf28f1/cssbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:78c84d5e5378df7d08622bbd0477a1abdbd209680e95480bf22f12d5701efc98", size = 123667, upload-time = "2025-02-27T17:53:43.594Z" },
+]
+
+[[package]]
 name = "ctranslate2"
 version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -233,6 +252,35 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "djlint"
+version = "1.36.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama" },
+    { name = "cssbeautifier" },
+    { name = "jsbeautifier" },
+    { name = "json5" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/ecf5be9f5c59a0c53bcaa29671742c5e269cc7d0e2622e3f65f41df251bf/djlint-1.36.4.tar.gz", hash = "sha256:17254f218b46fe5a714b224c85074c099bcb74e3b2e1f15c2ddc2cf415a408a1", size = 47849, upload-time = "2024-12-24T13:06:36.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/67/f7aeea9be6fb3bd984487af8d0d80225a0b1e5f6f7126e3332d349fb13fe/djlint-1.36.4-py3-none-any.whl", hash = "sha256:e9699b8ac3057a6ed04fb90835b89bee954ed1959c01541ce4f8f729c938afdd", size = 52290, upload-time = "2024-12-24T13:06:33.76Z" },
+]
+
+[[package]]
 name = "dotfiles"
 version = "0.0.0"
 source = { virtual = "." }
@@ -244,6 +292,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "djlint" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-testinfra" },
@@ -260,11 +310,22 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "djlint", specifier = ">=1.36.4" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "pytest-testinfra", specifier = ">=10" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a10" },
+]
+
+[[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
 ]
 
 [[package]]
@@ -432,6 +493,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -459,6 +529,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
 ]
 
 [[package]]
@@ -654,12 +746,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -833,6 +959,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -856,6 +995,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752", size = 291909, upload-time = "2026-04-03T20:55:17.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f", size = 796979, upload-time = "2026-04-03T20:55:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8", size = 866744, upload-time = "2026-04-03T20:55:24.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4", size = 911613, upload-time = "2026-04-03T20:55:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9", size = 800551, upload-time = "2026-04-03T20:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83", size = 776911, upload-time = "2026-04-03T20:55:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb", size = 785751, upload-time = "2026-04-03T20:55:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465", size = 860484, upload-time = "2026-04-03T20:55:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4", size = 765939, upload-time = "2026-04-03T20:55:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566", size = 851417, upload-time = "2026-04-03T20:55:39.92Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95", size = 789056, upload-time = "2026-04-03T20:55:42.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8", size = 272130, upload-time = "2026-04-03T20:55:44.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4", size = 280992, upload-time = "2026-04-03T20:55:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f", size = 273563, upload-time = "2026-04-03T20:55:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e", size = 293877, upload-time = "2026-04-03T20:55:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359", size = 811831, upload-time = "2026-04-03T20:55:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a", size = 871199, upload-time = "2026-04-03T20:56:00.333Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55", size = 917649, upload-time = "2026-04-03T20:56:02.445Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99", size = 816388, upload-time = "2026-04-03T20:56:04.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790", size = 785746, upload-time = "2026-04-03T20:56:07.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc", size = 801483, upload-time = "2026-04-03T20:56:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f", size = 866331, upload-time = "2026-04-03T20:56:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863", size = 772673, upload-time = "2026-04-03T20:56:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a", size = 857146, upload-time = "2026-04-03T20:56:16.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81", size = 803463, upload-time = "2026-04-03T20:56:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
 ]
 
 [[package]]
@@ -912,6 +1091,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -1062,6 +1250,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/8c/bdd9f89f89e4a787ac61bb2da4d884bc45e0c287ec694dfa3170dddd5cfe/virtualenv-21.2.3.tar.gz", hash = "sha256:9bb6d1414ab55ca624371e30c7719c32f183ef44da544ef8aa44a456de7ac191", size = 5844776, upload-time = "2026-04-14T01:10:36.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/19/bc7c4e05f42532863cf2ae7e7e847beab25835934e0410160b47eeff1e35/virtualenv-21.2.3-py3-none-any.whl", hash = "sha256:486652347ea8526d91e9807c0274583cb7ba31dd4942ff10fb5621402f0fe0d8", size = 5828329, upload-time = "2026-04-14T01:10:34.809Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Added `djlint` and `pre-commit` packages to `dev` dependency group in `pyproject.toml`.
- Locked dependencies in `uv.lock`.
- Configured `djlint` to format `golang` templates, target `.tmpl` extensions, and safely ignore strict HTML rules and blocks that apply aggressively to shell scripts, TOML, and bash.
- Set up `.pre-commit-config.yaml` with a local `djlint` hook utilizing `uv run djlint`.
- Added a `Makefile` in the project root to support simple execution of `make lint` and `make lint-templates` targets.
- Pre-emptively formatted all existing `src/chezmoi/` template files to standard baseline styling.
- Augmented the GitHub CI pipeline to assert `djlint src/chezmoi/ --check` in the initial lint step.

---
*PR created automatically by Jules for task [4419880611484791342](https://jules.google.com/task/4419880611484791342) started by @mkobit*