### PR TITLE
feat(tmux): refactor python module into termbud with typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "dotfiles"
 version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
+    "termbud",
     "jules-cli",
     "transcribe",
     "claude-statusline",
@@ -19,12 +20,14 @@ dev = [
 
 [tool.uv.workspace]
 members = [
+    "src/python/termbud",
     "src/python/jules_cli",
     "src/python/claude_statusline",
     "src/python/transcribe",
 ]
 
 [tool.uv.sources]
+termbud = { workspace = true }
 jules-cli = { workspace = true }
 transcribe = { workspace = true }
 claude-statusline = { workspace = true }
@@ -52,7 +55,7 @@ ignore = [
 max-complexity = 15
 
 [tool.ruff.lint.isort]
-known-first-party = ["jules_cli", "claude_statusline", "transcribe"]
+known-first-party = ["termbud", "jules_cli", "claude_statusline", "transcribe"]
 
 [tool.ty.environment]
 python = ".venv"

--- a/src/chezmoi/.chezmoidata/local_bin_tools.toml
+++ b/src/chezmoi/.chezmoidata/local_bin_tools.toml
@@ -9,3 +9,6 @@ installation = "uv"
 
 [local_bin_tools.transcribe]
 installation = "uv"
+
+[local_bin_tools.termbud]
+installation = "uv"

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+{{ template "managed_by_chezmoi.tmpl" . }}
+
+set -euo pipefail
+
+{{ if index . "python" "uv" }}
+echo "Installing termbud..."
+uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"
+{{ else }}
+echo "Uninstalling termbud (uv disabled)..."
+uv tool uninstall termbud || true
+{{ end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -2,10 +2,5 @@
 
 set -euo pipefail
 
-{{- if index . "python" "uv" }}
 echo "Installing termbud..."
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"
-{{- else }}
-echo "Uninstalling termbud (uv disabled)..."
-uv tool uninstall termbud || true
-{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-echo "Installing termbud..."
-uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-{{ template "managed_by_chezmoi.tmpl" . }}
 
 set -euo pipefail
 

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-{{ if index . "python" "uv" }}
+{{- if index . "python" "uv" }}
 echo "Installing termbud..."
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"
-{{ else }}
+{{- else }}
 echo "Uninstalling termbud (uv disabled)..."
 uv tool uninstall termbud || true
-{{ end }}
+{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+{{ template "managed_by_chezmoi.tmpl" . }}
+
+set -euo pipefail
+
+{{ if index . "python" "uv" }}
+echo "Cleaning up legacy tmux python tools..."
+uv tool uninstall tmux-helper || true
+uv tool uninstall tmux-runtime-tools || true
+{{ end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-{{- if index . "python" "uv" }}
 echo "Cleaning up legacy tmux python tools..."
 uv tool uninstall tmux-helper || true
 uv tool uninstall tmux-runtime-tools || true
-{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-{{ if index . "python" "uv" }}
+{{- if index . "python" "uv" }}
 echo "Cleaning up legacy tmux python tools..."
 uv tool uninstall tmux-helper || true
 uv tool uninstall tmux-runtime-tools || true
-{{ end }}
+{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_uninstall_tmux_helper.sh.tmpl
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-{{ template "managed_by_chezmoi.tmpl" . }}
 
 set -euo pipefail
 

--- a/src/chezmoi/.chezmoitemplates/uv/tool_install.sh.tmpl
+++ b/src/chezmoi/.chezmoitemplates/uv/tool_install.sh.tmpl
@@ -1,0 +1,16 @@
+{{- define "uv_tool_install" -}}
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TOOL_NAME="{{ .name }}"
+TOOL_PATH="{{ .path }}"
+
+if uv tool list | grep -q "$TOOL_NAME"; then
+    echo "Updating $TOOL_NAME..."
+else
+    echo "Installing $TOOL_NAME..."
+fi
+
+uv tool install --force "$TOOL_PATH"
+{{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_termbud.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_termbud.tmpl
@@ -1,0 +1,4 @@
+{{- if eq .local_bin_tools.termbud.installation "uv" -}}
+#!/usr/bin/env bash
+exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/termbud -m termbud.main "$@"
+{{- end -}}

--- a/src/python/termbud/pyproject.toml
+++ b/src/python/termbud/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "termbud"
+version = "0.0.0"
+description = "Terminal caddy tool"
+requires-python = ">=3.14"
+dependencies = [
+    "typer>=0.12.0",
+]
+
+[project.scripts]
+termbud = "termbud.main:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/src/python/termbud/termbud/main.py
+++ b/src/python/termbud/termbud/main.py
@@ -1,0 +1,84 @@
+import os
+import re
+import subprocess
+import sys
+
+import typer
+
+app = typer.Typer(help="Terminal caddy tool")
+tmux_app = typer.Typer(help="Tmux subcommands")
+
+app.add_typer(tmux_app, name="tmux")
+
+
+@tmux_app.command("open-url")
+def open_url(
+    pane_id: str = typer.Option(..., "--pane-id", help="The tmux pane ID to capture"),
+    open_cmd: str | None = typer.Option(
+        None,
+        "--open-cmd",
+        help="Command to use to open the URL. Defaults to guessing based on OS.",
+    ),
+) -> None:
+    """Open a URL from a tmux pane's scrollback."""
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-J", "-S", "-", "-t", pane_id, "-p"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        scrollback = result.stdout
+    except subprocess.CalledProcessError:
+        subprocess.run(["tmux", "display-message", "Failed to capture pane"])
+        sys.exit(1)
+
+    url_pattern = re.compile(
+        r"[a-zA-Z][a-zA-Z0-9+.-]*://[a-zA-Z0-9_.~!*'();:@&=+$,/?%#-]+"
+    )
+    urls = url_pattern.findall(scrollback)
+
+    if not urls:
+        subprocess.run(["tmux", "display-message", "No URLs found."])
+        sys.exit(0)
+
+    seen: set[str] = set()
+    ordered_urls: list[str] = []
+    for url in reversed(urls):
+        if url not in seen:
+            seen.add(url)
+            ordered_urls.append(url)
+
+    try:
+        fzf = subprocess.Popen(
+            ["fzf-tmux", "-p", "80%,80%", "--prompt=Open URL: "],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        selected_url_bytes, _ = fzf.communicate(input="\n".join(ordered_urls))
+        selected_url = selected_url_bytes.strip()
+    except FileNotFoundError:
+        subprocess.run(["tmux", "display-message", "fzf-tmux not found."])
+        sys.exit(1)
+
+    if not selected_url:
+        sys.exit(0)
+
+    if not open_cmd:
+        if sys.platform == "darwin":
+            open_cmd = "open"
+        elif "microsoft" in os.uname().release.lower():
+            open_cmd = "wslview"
+        else:
+            open_cmd = "xdg-open"
+
+    try:
+        os.execvp(open_cmd, [open_cmd, selected_url])
+    except OSError:
+        subprocess.run(["tmux", "display-message", f"Failed to execute {open_cmd}"])
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ members = [
     "claude-statusline",
     "dotfiles",
     "jules-cli",
+    "termbud",
     "transcribe",
 ]
 
@@ -235,6 +236,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "claude-statusline" },
     { name = "jules-cli" },
+    { name = "termbud" },
     { name = "transcribe" },
 ]
 
@@ -251,6 +253,7 @@ dev = [
 requires-dist = [
     { name = "claude-statusline", editable = "src/python/claude_statusline" },
     { name = "jules-cli", editable = "src/python/jules_cli" },
+    { name = "termbud", editable = "src/python/termbud" },
     { name = "transcribe", editable = "src/python/transcribe" },
 ]
 
@@ -921,6 +924,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
+
+[[package]]
+name = "termbud"
+version = "0.0.0"
+source = { editable = "src/python/termbud" }
+dependencies = [
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "typer", specifier = ">=0.12.0" }]
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
This PR refactors the previous tmux helper commands into a new Python CLI app called `termbud`, built natively with `typer` instead of `click`. 

It includes:
- Porting the `open-url` tmux command logic to `termbud tmux open-url` using Typer options.
- Integrating `termbud` as a new `uv` workspace member.
- Adding a `.chezmoitemplate` (`uv_tool_install`) and a setup script to install `termbud` globally on end user machines.
- Adding a smart fallback script (`run_once_after_uninstall_tmux_helper.sh.tmpl`) to safely uninstall the legacy `tmux-helper` and `tmux-runtime-tools` so users retain smooth transition.

---
*PR created automatically by Jules for task [12348227820258345002](https://jules.google.com/task/12348227820258345002) started by @mkobit*