### PR TITLE
feat: improve context window and add line impact to statusline

### DIFF
--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -16,6 +16,7 @@ from claude_statusline.render import render_lines
 from claude_statusline.segments.claude import (
     format_context_usage,
     format_cost,
+    format_lines_impact,
     format_model_info,
     format_session_info,
 )
@@ -206,6 +207,7 @@ def main(generator: tuple[str, ...], show_errors: bool) -> None:  # noqa: C901
             format_obsidian_vault(cwd),
             format_context_usage(payload.context_window),
             format_cost(payload),
+            format_lines_impact(payload),
         ]
         for r in internal_results:
             if r:

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -5,17 +5,28 @@ from claude_statusline.models import (
     StatusLineStdIn,
 )
 from claude_statusline.segments.constants import (
+    BG_DIM,
+    BG_RESET,
     BLUE,
     BOLD,
+    BRIGHT_GREEN,
+    BRIGHT_RED,
     CYAN,
     DIM,
     GREEN,
     MAGENTA,
+    ORANGE,
     RED,
     RESET,
     YELLOW,
     get_icon,
 )
+
+
+def format_tokens(tokens: int) -> str:
+    if tokens < 1000:
+        return str(tokens)
+    return f"{tokens / 1000:.1f}k".replace(".0k", "k")
 
 
 def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | None:
@@ -25,32 +36,50 @@ def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | Non
     color = GREEN
     if used_pct >= 90:
         color = RED
+    elif used_pct >= 75:
+        color = ORANGE
     elif used_pct >= 50:
         color = YELLOW
 
-    width = 10
-    blocks = [" ", " ", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+    width = 8
+    blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
 
     total_eighths = int((used_pct / 100.0) * width * 8)
     full_blocks = total_eighths // 8
     remainder = total_eighths % 8
 
-    visual_bar = "".join(
-        blocks[8]
-        if i < full_blocks
-        else blocks[remainder]
-        if i == full_blocks
-        else blocks[0]
-        for i in range(width)
-    )
+    bar_parts = []
+    for i in range(width):
+        if i < full_blocks:
+            bar_parts.append(f"{color}{BG_DIM}{blocks[8]}{BG_RESET}{RESET}")
+        elif i == full_blocks and remainder > 0:
+            bar_parts.append(f"{color}{BG_DIM}{blocks[remainder]}{BG_RESET}{RESET}")
+        else:
+            bar_parts.append(f"{color}{BG_DIM}{blocks[0]}{BG_RESET}{RESET}")
+
+    visual_bar = "".join(bar_parts)
+
+    total_used = (cw.total_input_tokens or 0) + (cw.total_output_tokens or 0)
+    window_size = cw.context_window_size or 0
+
+    if window_size > 0:
+        used_str = format_tokens(total_used)
+        window_str = format_tokens(window_size)
+        # Justify to a typical max width to prevent jitter (e.g. "  5.5k/200k")
+        token_str = f"{used_str:>5}/{window_str:<4}"
+    else:
+        token_str = ""
+
+    text = f"{DIM}ctx:{RESET} {visual_bar}"
+    if token_str:
+        text += f" {DIM}{token_str}{RESET}"
+    text += f" {color}{int(used_pct):>3}%{RESET}"
 
     return SegmentGenerationResult(
         line=2,
         index=10,
         generator="internal.claude",
-        segment=Segment(
-            text=f"{DIM}ctx:{RESET} {color}{visual_bar}{RESET} {int(used_pct)}%"
-        ),
+        segment=Segment(text=text),
     )
 
 
@@ -73,6 +102,10 @@ def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | N
         parts.append(f"{CYAN}#{payload.session_name}{RESET}")
     elif payload.session_id:
         parts.append(f"{DIM}#{payload.session_id[:8]}{RESET}")
+
+    if payload.output_style and payload.output_style.name:
+        # e.g., default, concise, quiet
+        parts.append(f"{DIM}[{payload.output_style.name}]{RESET}")
 
     if payload.cost.total_duration_ms:
         elapsed_seconds = payload.cost.total_duration_ms // 1000
@@ -106,4 +139,25 @@ def format_cost(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
         segment=Segment(
             text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"
         ),
+    )
+
+
+def format_lines_impact(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
+    added = payload.cost.total_lines_added or 0
+    removed = payload.cost.total_lines_removed or 0
+
+    if added == 0 and removed == 0:
+        return None
+
+    parts = []
+    if added > 0:
+        parts.append(f"{BRIGHT_GREEN}+{added}{RESET}")
+    if removed > 0:
+        parts.append(f"{BRIGHT_RED}-{removed}{RESET}")
+
+    return SegmentGenerationResult(
+        line=2,
+        index=30,
+        generator="internal.claude",
+        segment=Segment(text=" ".join(parts)),
     )

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -23,10 +23,21 @@ from claude_statusline.segments.constants import (
 )
 
 
-def format_tokens(tokens: int) -> str:
+def format_tokens(tokens: int, max_tokens: int = 0) -> str:
+    if max_tokens >= 1_000_000:
+        width = 4
+    elif max_tokens >= 100_000:
+        width = 4
+    elif max_tokens >= 10_000:
+        width = 3
+    else:
+        width = 5
+
     if tokens < 1000:
-        return str(tokens)
-    return f"{tokens / 1000:.1f}k".replace(".0k", "k")
+        val = str(tokens)
+    else:
+        val = f"{tokens / 1000:.1f}k".replace(".0k", "k")
+    return f"{val:>{width}}"
 
 
 def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | None:
@@ -48,38 +59,36 @@ def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | Non
     full_blocks = total_eighths // 8
     remainder = total_eighths % 8
 
-    bar_parts = []
-    for i in range(width):
-        if i < full_blocks:
-            bar_parts.append(f"{color}{BG_DIM}{blocks[8]}{BG_RESET}{RESET}")
-        elif i == full_blocks and remainder > 0:
-            bar_parts.append(f"{color}{BG_DIM}{blocks[remainder]}{BG_RESET}{RESET}")
-        else:
-            bar_parts.append(f"{color}{BG_DIM}{blocks[0]}{BG_RESET}{RESET}")
-
-    visual_bar = "".join(bar_parts)
+    visual_bar = "".join(
+        f"{color}{BG_DIM}{blocks[8]}{BG_RESET}{RESET}"
+        if i < full_blocks
+        else f"{color}{BG_DIM}{blocks[remainder]}{BG_RESET}{RESET}"
+        if i == full_blocks and remainder > 0
+        else f"{color}{BG_DIM}{blocks[0]}{BG_RESET}{RESET}"
+        for i in range(width)
+    )
 
     total_used = (cw.total_input_tokens or 0) + (cw.total_output_tokens or 0)
     window_size = cw.context_window_size or 0
 
+    token_str = None
     if window_size > 0:
-        used_str = format_tokens(total_used)
-        window_str = format_tokens(window_size)
-        # Justify to a typical max width to prevent jitter (e.g. "  5.5k/200k")
-        token_str = f"{used_str:>5}/{window_str:<4}"
-    else:
-        token_str = ""
+        used_str = format_tokens(total_used, window_size)
+        window_str = format_tokens(window_size, window_size).strip()
+        token_str = f"{DIM}{used_str}/{window_str}{RESET}"
 
-    text = f"{DIM}ctx:{RESET} {visual_bar}"
-    if token_str:
-        text += f" {DIM}{token_str}{RESET}"
-    text += f" {color}{int(used_pct):>3}%{RESET}"
+    parts = [
+        f"{DIM}ctx:{RESET}",
+        visual_bar,
+        token_str,
+        f"{color}{int(used_pct):>3}%{RESET}",
+    ]
 
     return SegmentGenerationResult(
         line=2,
         index=10,
         generator="internal.claude",
-        segment=Segment(text=text),
+        segment=Segment(text=" ".join(filter(None, parts))),
     )
 
 
@@ -149,15 +158,14 @@ def format_lines_impact(payload: StatusLineStdIn) -> SegmentGenerationResult | N
     if added == 0 and removed == 0:
         return None
 
-    parts = []
-    if added > 0:
-        parts.append(f"{BRIGHT_GREEN}+{added}{RESET}")
-    if removed > 0:
-        parts.append(f"{BRIGHT_RED}-{removed}{RESET}")
+    parts = [
+        f"{BRIGHT_GREEN}+{added}{RESET}" if added > 0 else None,
+        f"{BRIGHT_RED}-{removed}{RESET}" if removed > 0 else None,
+    ]
 
     return SegmentGenerationResult(
         line=2,
         index=30,
         generator="internal.claude",
-        segment=Segment(text=" ".join(parts)),
+        segment=Segment(text=" ".join(filter(None, parts))),
     )

--- a/src/python/claude_statusline/claude_statusline/segments/constants.py
+++ b/src/python/claude_statusline/claude_statusline/segments/constants.py
@@ -23,6 +23,13 @@ MAGENTA = "\033[35m"
 CYAN = "\033[36m"
 WHITE = "\033[37m"
 
+BRIGHT_RED = "\033[91m"
+BRIGHT_GREEN = "\033[92m"
+ORANGE = "\033[38;5;208m"
+
+BG_DIM = "\033[48;5;236m"
+BG_RESET = "\033[49m"
+
 
 @functools.cache
 def use_icons() -> bool:

--- a/src/python/claude_statusline/tests/test_main.py
+++ b/src/python/claude_statusline/tests/test_main.py
@@ -42,7 +42,7 @@ class TestStatusLine(unittest.TestCase):
         res_none = format_context_usage(cw_none)
         self.assertIsNotNone(res_none)
         assert res_none is not None
-        self.assertIn("0%", res_none.segment.text)
+        self.assertIn("  0%", res_none.segment.text)
         self.assertIn(GREEN, res_none.segment.text)
 
     def test_format_git_full(self) -> None:
@@ -265,11 +265,14 @@ class TestStatusLine(unittest.TestCase):
             self.assertIn("security-reviewer", line1)
 
             self.assertIn("my-session", line1)
+            self.assertIn("[default]", line1)
 
             line3 = mock_print.call_args_list[2][0][0]
             self.assertIn("feature-branch", line3)
             self.assertIn("0.01", line3)
-            self.assertIn("8%", line3)
+            self.assertIn("  8%", line3)
+            self.assertIn("+156", line3)
+            self.assertIn("-23", line3)
 
     def test_shorten_path(self) -> None:
         home = Path("/home/user")


### PR DESCRIPTION
- Updated `constants.py` with new bright red, bright green, orange, and background colors.
- Refactored `format_context_usage` in `claude.py` to use horizontal block chunks (`▏` to `█`) for a smoother visual progress bar.
- Modified the context bar width to 8 characters and added absolute token usage (`used/total_window`).
- Rendered background blocks with `BG_DIM` so the "empty" portion of the bar is still visible.
- Added `format_lines_impact` to display total lines added and removed using Github-like PR colors (`+XX`, `-YY`).
- Added the `output_style` from `StatusLineStdIn` to the session info block.
- Updated `test_main.py` tests to ensure correct strings are generated under these new conditions.

---
*PR created automatically by Jules for task [13347308150603337802](https://jules.google.com/task/13347308150603337802) started by @mkobit*