### PR TITLE
Remove shebang from sourced shell library logging.sh

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/logging.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/logging.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Shared logging utilities for chezmoi scripts
 
 # Colors


### PR DESCRIPTION
Removed the `#!/bin/bash` shebang from `src/chezmoi/.chezmoitemplates/shell/logging.sh` because it is explicitly designed as a shared library intended to be sourced by other scripts, rather than executed directly as a standalone script.

---
*PR created automatically by Jules for task [14988109392246716212](https://jules.google.com/task/14988109392246716212) started by @mkobit*