### PR TITLE
Fix custom Obsidian Starship segment

### DIFF
--- a/src/chezmoi/dot_config/starship.toml
+++ b/src/chezmoi/dot_config/starship.toml
@@ -21,5 +21,5 @@ disabled = true # Disables the package version module (e.g. Node.js/Rust version
 
 [custom.obsidian]
 detect_folders = [".obsidian"]
-format = "on [󰎚 Obsidian vault]($style) "
+format = "on [\uf039a Obsidian vault]($style) "
 style = "bold #8B5CF6"

--- a/src/chezmoi/dot_config/starship.toml
+++ b/src/chezmoi/dot_config/starship.toml
@@ -20,7 +20,6 @@ disabled = true # Disables the package version module (e.g. Node.js/Rust version
 
 
 [custom.obsidian]
-command = "jq -r .id .obsidian/app.json 2>/dev/null || basename \"$PWD\""
 detect_folders = [".obsidian"]
-format = "on [󰎚 $output]($style) "
-style = "bold purple"
+format = "on [󰎚 Obsidian vault]($style) "
+style = "bold #8B5CF6"


### PR DESCRIPTION
The custom Obsidian segment in the Starship configuration previously attempted to read `.id` from `.obsidian/app.json` using `jq`, which resulted in `"null"` output when the key didn't exist. 

This commit simplifies the segment to:
- Remove the `command` reliance on `jq`.
- Statically display "Obsidian vault" in the `format` string with the existing placeholder icon.
- Update the style to use the brand color `#8B5CF6`.

The segment will still only activate within directories containing an `.obsidian` folder.

---
*PR created automatically by Jules for task [4670294182632847573](https://jules.google.com/task/4670294182632847573) started by @mkobit*