### PR TITLE
feat: Automatically prune old and unused mise global tools

### DIFF
--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -9,6 +9,7 @@ linux_amd64 = "84636e19a0e5001d7499f58ae5a868cec8f6ba4f52f9028680bb7cd802564229"
 linux_arm64 = "b0cee25b0405113ed6fe2a54cf21d49720ee571d3d5b4a9c695721cd123d24f8"
 
 [mise.settings]
+# Configuration settings: https://mise.jdx.dev/configuration/settings.html
 cache_prune_age = "30d"
 disable_hints = ["self_update"]
 [mise.settings.npm]

--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -9,6 +9,7 @@ linux_amd64 = "84636e19a0e5001d7499f58ae5a868cec8f6ba4f52f9028680bb7cd802564229"
 linux_arm64 = "b0cee25b0405113ed6fe2a54cf21d49720ee571d3d5b4a9c695721cd123d24f8"
 
 [mise.settings]
+cache_prune_age = "30d"
 disable_hints = ["self_update"]
 [mise.settings.npm]
 package_manager = "bun"

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -33,7 +33,7 @@ log_info "Pruning unused mise tools..."
 if "$MISE" prune -y; then
     log_success "Mise prune complete."
 else
-    log_error "Failed to prune mise tools."
+    log_warn "Failed to prune mise tools."
     # We don't exit 1 here, as prune failure shouldn't fail the whole install process
 fi
 

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -28,6 +28,15 @@ else
     exit 1
 fi
 
+
+log_info "Pruning unused mise tools..."
+if "$MISE" prune -y; then
+    log_success "Mise prune complete."
+else
+    log_error "Failed to prune mise tools."
+    # We don't exit 1 here, as prune failure shouldn't fail the whole install process
+fi
+
 log_info "Reshimming mise tools..."
 if "$MISE" reshim; then
     log_success "Mise reshim complete."


### PR DESCRIPTION
This commit configures mise to prune unused global tool versions by explicitly running `mise prune -y` during the chezmoi apply cycle (`run_after_onchange_10_install-mise-tools.sh.tmpl`). It also sets `cache_prune_age = "30d"` in `mise.toml` to automatically clean up old download caches.

---
*PR created automatically by Jules for task [1641214331097803439](https://jules.google.com/task/1641214331097803439) started by @mkobit*