### PR TITLE
fix(termbud): disable automatic typer completion installation

### DIFF
--- a/src/python/termbud/termbud/main.py
+++ b/src/python/termbud/termbud/main.py
@@ -5,7 +5,7 @@ import sys
 
 import typer
 
-app = typer.Typer(help="Terminal caddy tool")
+app = typer.Typer(help="Terminal caddy tool", add_completion=False)
 tmux_app = typer.Typer(help="Tmux subcommands")
 
 app.add_typer(tmux_app, name="tmux")


### PR DESCRIPTION
Sets `add_completion=False` on the termbud Typer app to disable the automatic completion commands. This prevents accidental use of `--install-completion` which can mutate shell dotfiles and interfere with chezmoi management.

---
*PR created automatically by Jules for task [18344234856176208673](https://jules.google.com/task/18344234856176208673) started by @mkobit*