### PR TITLE
Update mise cache prune age

### DIFF
--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -10,7 +10,7 @@ linux_arm64 = "b0cee25b0405113ed6fe2a54cf21d49720ee571d3d5b4a9c695721cd123d24f8"
 
 [mise.settings]
 # Configuration settings: https://mise.jdx.dev/configuration/settings.html
-cache_prune_age = "30d"
+cache_prune_age = "60d"
 disable_hints = ["self_update"]
 [mise.settings.npm]
 package_manager = "bun"


### PR DESCRIPTION
Updated mise cache_prune_age in mise.toml to 60 days.

---
*PR created automatically by Jules for task [3060879311613362941](https://jules.google.com/task/3060879311613362941) started by @mkobit*