### PR TITLE
🧹 Replace deprecated os.path methods with pathlib in transcribe formatter

### DIFF
--- a/src/python/transcribe/tests/test_formatter.py
+++ b/src/python/transcribe/tests/test_formatter.py
@@ -48,3 +48,20 @@ def test_formatter_jinja_with_timestamp(
     )
     expected = "00:00:00,000 -> Hello world\n00:00:01,500 -> This is a test\n"
     assert result == expected
+
+
+def test_formatter_jinja_file(
+    sample_segments: list[Any], sample_info: Any, tmp_path: Any
+) -> None:
+    template_content = (
+        "{% for seg in segments %}"
+        "{{ seg.text }}{% if not loop.last %} | {% endif %}"
+        "{% endfor %}"
+    )
+    template_file = tmp_path / "template.j2"
+    template_file.write_text(template_content)
+
+    result = Formatter.format_segments(
+        sample_segments, sample_info, template_file=str(template_file)
+    )
+    assert result == "Hello world | This is a test"

--- a/src/python/transcribe/transcribe/formatter.py
+++ b/src/python/transcribe/transcribe/formatter.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, Template
@@ -24,10 +24,9 @@ class Formatter:
         }
 
         if template_file:
-            env = Environment(
-                loader=FileSystemLoader(os.path.dirname(os.path.abspath(template_file)))
-            )
-            template = env.get_template(os.path.basename(template_file))
+            path = Path(template_file).resolve()
+            env = Environment(loader=FileSystemLoader(str(path.parent)))
+            template = env.get_template(path.name)
             return str(template.render(context))
         if template_string:
             template = Template(template_string)


### PR DESCRIPTION
🎯 **What:** Replaced deprecated `os.path` methods with `pathlib.Path` in `src/python/transcribe/transcribe/formatter.py`.
💡 **Why:** Modernizes the codebase, improves readability, and reduces technical debt by using the standard `pathlib` library.
✅ **Verification:** Added a new test `test_formatter_jinja_file` to `tests/test_formatter.py` to exercise the modified code path. Ran the full test suite (`uv run pytest tests/`) and verified that all 7 tests passed.
✨ **Result:** Cleaner path handling logic and improved maintainability.

---
*PR created automatically by Jules for task [1335005617346999762](https://jules.google.com/task/1335005617346999762) started by @mkobit*