### PR TITLE
Fix poor edits in AGENTS.md and mise.toml

### DIFF
--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -10,7 +10,7 @@ linux_arm64 = "b0cee25b0405113ed6fe2a54cf21d49720ee571d3d5b4a9c695721cd123d24f8"
 
 [mise.settings]
 # Configuration settings: https://mise.jdx.dev/configuration/settings.html
-cache_prune_age = "30d"
+cache_prune_age = "60 days"
 disable_hints = ["self_update"]
 [mise.settings.npm]
 package_manager = "bun"

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -144,9 +144,9 @@ parts = ["Hello", ", User" if condition else ", Guest"]
 message = "".join(parts)
 ```
 
-### Anti-Pattern: Imperative List Deduplication
+### Anti-pattern: imperative list deduplication
 Avoid using mutable sets and `list.append()` inside loops for deduplication.
-**Anti-Pattern:**
+**Anti-pattern:**
 ```python
 seen = set()
 ordered = []


### PR DESCRIPTION
Fixes poor edits previously made:
- Changes "Anti-Pattern: Imperative List Deduplication" to sentence case in `src/python/AGENTS.md`.
- Changes `cache_prune_age = "30d"` to `cache_prune_age = "60 days"` in `src/chezmoi/.chezmoidata/mise.toml`.

---
*PR created automatically by Jules for task [12501638970677130426](https://jules.google.com/task/12501638970677130426) started by @mkobit*