### PR TITLE
feat(wsl): deterministic Windows font and terminal font setup

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -1,0 +1,12 @@
+{{- $isWsl := and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) -}}
+
+[data.os]
+{{- if $isWsl }}
+    environment = "wsl"
+{{- else if eq .chezmoi.os "linux" }}
+    environment = "linux"
+{{- else if eq .chezmoi.os "darwin" }}
+    environment = "macos"
+{{- else }}
+    environment = "unknown"
+{{- end }}

--- a/src/chezmoi/.chezmoidata/windows_terminal.toml
+++ b/src/chezmoi/.chezmoidata/windows_terminal.toml
@@ -1,0 +1,3 @@
+[windows_terminal]
+font_face = "JetBrainsMono NF"
+font_size = 12

--- a/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_install-wsl-windows-fonts.sh.tmpl
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_install-wsl-windows-fonts.sh.tmpl
@@ -1,0 +1,33 @@
+{{- if and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fonts data hash: {{ .fonts | toToml | sha256sum }}
+
+LINUX_SRC_FOLDER="{{ .chezmoi.destDir }}/.local/share/fonts/NerdFonts"
+WINDOWS_SRC_FOLDER=$(wslpath -w "$LINUX_SRC_FOLDER")
+
+powershell.exe -NoProfile -Command "
+\$srcFolder = '${WINDOWS_SRC_FOLDER}'
+\$destFolder = \"\$env:LOCALAPPDATA\Microsoft\Windows\Fonts\"
+
+if (!(Test-Path \$destFolder)) { New-Item -Path \$destFolder -ItemType Directory }
+
+\$shell = New-Object -ComObject Shell.Application
+\$fontsFolder = \$shell.Namespace(\$destFolder)
+\$srcFiles = Get-ChildItem -Path \$srcFolder -Include '*.ttf', '*.otf' -Recurse
+\$srcNames = \$srcFiles | ForEach-Object { \$_.Name }
+
+# Remove fonts no longer in source
+Get-ChildItem -Path \$destFolder -Include '*.ttf', '*.otf' |
+    Where-Object { \$srcNames -notcontains \$_.Name } |
+    ForEach-Object { Remove-Item \$_.FullName -Force }
+
+# Install/overwrite all source fonts
+\$srcFiles | ForEach-Object {
+    \$destFile = Join-Path \$destFolder \$_.Name
+    if (Test-Path \$destFile) { Remove-Item \$destFile -Force }
+    \$fontsFolder.CopyHere(\$_.FullName, 0x14)
+}
+"
+{{- end }}

--- a/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_update-wsl-windows-terminal-font.sh.tmpl
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_update-wsl-windows-terminal-font.sh.tmpl
@@ -1,0 +1,32 @@
+{{- if and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Font face: {{ .windows_terminal.font_face }}, size: {{ .windows_terminal.font_size }}
+
+WIN_LOCALAPPDATA=$(/mnt/c/Windows/System32/cmd.exe /c "echo %LOCALAPPDATA%" 2>/dev/null | tr -d '\r')
+if [[ -z "${WIN_LOCALAPPDATA}" ]]; then
+    echo "ERROR: Could not determine Windows LOCALAPPDATA path" >&2
+    exit 1
+fi
+
+WINDOWS_SETTINGS_PATH="${WIN_LOCALAPPDATA}\\Packages\\Microsoft.WindowsTerminal_8wekyb3d8bbwe\\LocalState\\settings.json"
+
+powershell.exe -NoProfile -Command "
+\$settingsPath = '${WINDOWS_SETTINGS_PATH}'
+if (!(Test-Path \$settingsPath)) {
+    \$settingsPath = '${WIN_LOCALAPPDATA}\\Packages\\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\\LocalState\\settings.json'
+}
+if (!(Test-Path \$settingsPath)) {
+    Write-Warning 'Windows Terminal settings.json not found, skipping font configuration'
+    exit 0
+}
+\$settings = Get-Content \$settingsPath -Raw | ConvertFrom-Json
+if (!\$settings.profiles.defaults.font) {
+    \$settings.profiles.defaults | Add-Member -NotePropertyName font -NotePropertyValue ([PSCustomObject]@{}) -Force
+}
+\$settings.profiles.defaults.font | Add-Member -NotePropertyName face -NotePropertyValue '{{ .windows_terminal.font_face }}' -Force
+\$settings.profiles.defaults.font | Add-Member -NotePropertyName size -NotePropertyValue {{ .windows_terminal.font_size }} -Force
+\$settings | ConvertTo-Json -Depth 20 | Set-Content \$settingsPath -Encoding UTF8
+"
+{{- end }}

--- a/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_update-wsl-windows-terminal-font.sh.tmpl
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoiscripts/run_onchange_after_update-wsl-windows-terminal-font.sh.tmpl
@@ -27,6 +27,7 @@ if (!\$settings.profiles.defaults.font) {
 }
 \$settings.profiles.defaults.font | Add-Member -NotePropertyName face -NotePropertyValue '{{ .windows_terminal.font_face }}' -Force
 \$settings.profiles.defaults.font | Add-Member -NotePropertyName size -NotePropertyValue {{ .windows_terminal.font_size }} -Force
-\$settings | ConvertTo-Json -Depth 20 | Set-Content \$settingsPath -Encoding UTF8
+\$json = \$settings | ConvertTo-Json -Depth 20
+[System.IO.File]::WriteAllText(\$settingsPath, \$json, [System.Text.UTF8Encoding]::new(\$false))
 "
 {{- end }}


### PR DESCRIPTION
## Summary

- Add `.chezmoi.toml.tmpl` for OS environment detection (`wsl`/`linux`/`macos`) — no PowerShell at template evaluation time
- Add `.chezmoidata/windows_terminal.toml` with `font_face` and `font_size` as config data
- Add font scripts co-located with font externals in `dot_local/share/fonts/.chezmoiscripts/`:
  - `run_onchange_after_install-wsl-windows-fonts.sh.tmpl` — syncs NerdFonts to Windows per-user fonts dir via `Shell.Application.CopyHere`, removes stale fonts; re-triggers on `.fonts` data hash changes
  - `run_onchange_after_update-wsl-windows-terminal-font.sh.tmpl` — sets `font.face` and `font.size` in Windows Terminal `settings.json` via PowerShell; discovers settings path at runtime with `cmd.exe` + `wslpath`

All scripts are WSL-only no-ops on other platforms. Closes #386.

## Test plan

- [x] `chezmoi execute-template` evaluates both scripts without errors on WSL
- [x] Fonts appear in Windows per-user fonts dir after apply
- [x] Windows Terminal picks up correct font face and size after restart
- [x] Re-running apply is idempotent
- [x] Bumping a font version in `fonts.toml` re-triggers the install script

🤖 Generated with [Claude Code](https://claude.com/claude-code)