### PR TITLE
chore(fonts): remove meslo font completely

### DIFF
--- a/src/chezmoi/.chezmoidata/fonts.toml
+++ b/src/chezmoi/.chezmoidata/fonts.toml
@@ -1,8 +1,3 @@
-# Font configuration
-# Supported fonts:
-# - fira_mono: Fira Mono Nerd Font
-# - jetbrains_mono: JetBrains Mono Nerd Font
-
 [fonts.fira_mono]
 name = "FiraMono"
 version = "v3.4.0"

--- a/src/chezmoi/.chezmoidata/fonts.toml
+++ b/src/chezmoi/.chezmoidata/fonts.toml
@@ -1,14 +1,7 @@
 # Font configuration
 # Supported fonts:
-# - meslo: Standard Nerd Font (MesloLG)
 # - fira_mono: Fira Mono Nerd Font
 # - jetbrains_mono: JetBrains Mono Nerd Font
-
-[fonts.meslo]
-name = "Meslo"
-version = "v3.3.0"
-sha256 = "6ad716ed719e2c97794abd5856a90c6131c406606b249debdc83b04ae11f4cb7"
-installation = "external-sources"
 
 [fonts.fira_mono]
 name = "FiraMono"

--- a/src/chezmoi/dot_config/ghostty/conf.d/font.conf
+++ b/src/chezmoi/dot_config/ghostty/conf.d/font.conf
@@ -1,4 +1,4 @@
 # Font configuration for Ghostty
 # See: https://ghostty.org/docs/config/reference#font-family
-# Uses MesloLGS Nerd Font Mono (Nerd Font) for powerline/icon support
-font-family = MesloLGS Nerd Font Mono
+# Uses JetBrainsMono Nerd Font Mono (Nerd Font) for powerline/icon support
+font-family = JetBrainsMono Nerd Font Mono

--- a/src/chezmoi/dot_config/ghostty/conf.d/font.conf
+++ b/src/chezmoi/dot_config/ghostty/conf.d/font.conf
@@ -1,4 +1,3 @@
 # Font configuration for Ghostty
 # See: https://ghostty.org/docs/config/reference#font-family
-# Uses JetBrainsMono Nerd Font Mono (Nerd Font) for powerline/icon support
 font-family = JetBrainsMono Nerd Font Mono

--- a/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
+++ b/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
@@ -11,4 +11,4 @@
 
 ## Font automation
 
-- **JetBrainsMono NF**: Automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.dotfiles/external/fonts/`.
+- Fonts specified in `.chezmoidata/fonts.toml` are automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.local/share/fonts/NerdFonts/`.

--- a/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
+++ b/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
@@ -11,4 +11,4 @@
 
 ## Font automation
 
-- Fonts specified in `.chezmoidata/fonts.toml` are automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.local/share/fonts/NerdFonts/`.
+- Fonts specified in `.chezmoidata/fonts.toml` are automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.local/share/fonts/`.

--- a/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
+++ b/src/chezmoi/dot_dotfiles/zsh/AGENTS.md
@@ -11,4 +11,4 @@
 
 ## Font automation
 
-- **MesloLGS NF**: Automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.dotfiles/external/fonts/`.
+- **JetBrainsMono NF**: Automatically downloaded via `.chezmoiexternals/` to `{{ .chezmoi.destDir }}/.dotfiles/external/fonts/`.

--- a/src/chezmoi/dot_local/share/fonts/.chezmoidelete
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoidelete
@@ -1,0 +1,1 @@
+exact_NerdFonts/Meslo


### PR DESCRIPTION
This PR addresses the request to completely remove the "Meslo" font from the dotfiles setup.
    
    Key changes:
    - Removed `meslo` font block from `src/chezmoi/.chezmoidata/fonts.toml` to prevent chezmoi from downloading it via `.chezmoiexternals/fonts.toml.tmpl`.
    - Created `src/chezmoi/dot_local/share/fonts/.chezmoidelete` with `exact_NerdFonts/Meslo` or `NerdFonts/Meslo` to instruct chezmoi to delete the font from users' machines.
    - Updated `src/chezmoi/dot_config/ghostty/conf.d/font.conf` to use JetBrains Mono Nerd Font instead of MesloLGS.
    - Updated `src/chezmoi/dot_dotfiles/zsh/AGENTS.md` to reference JetBrains Mono instead of MesloLGS.
    - Confirmed that Windows configuration `windows_terminal.toml` is already using JetBrainsMono NF.

---
*PR created automatically by Jules for task [6561901973204252688](https://jules.google.com/task/6561901973204252688) started by @mkobit*