### PR TITLE
chore: update @google/gemini-cli to v0.36.0

### DIFF
--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -42,5 +42,5 @@ package_manager = "bun"
   installation = "mise"
 
   [mise.global_tools."npm:@google/gemini-cli"]
-  version = "0.35.3"
+  version = "0.36.0"
   installation = "mise"


### PR DESCRIPTION
This pull request updates `@google/gemini-cli` from v0.35.3 to v0.36.0 in the `mise.toml` chezmoi data template. The previous version was not compliant with the bun minimum-release-age settings. The new version falls securely outside the 14-day minimum-release-age window (as of the current run date, April 18, 2026, version 0.36.0 was released on April 1, 2026).

---
*PR created automatically by Jules for task [1026739492197594574](https://jules.google.com/task/1026739492197594574) started by @mkobit*