### PR TITLE
Update various CLI tools to latest stable versions

### DIFF
--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -1,6 +1,6 @@
 [claude_code]
 enabled = true
-version = "2.1.104"
+version = "2.1.114"
 installation = "external-script"
 
 [claude_code.settings]

--- a/src/chezmoi/.chezmoidata/gh.toml
+++ b/src/chezmoi/.chezmoidata/gh.toml
@@ -1,9 +1,9 @@
 [gh]
-version = "2.89.0"
+version = "2.90.0"
 installation = "external-sources"
 
 [gh.checksums]
-darwin_arm64 = "2423d02ec0a2094898c378703a1b28a5846c08700f87461363857cb8cb3fda94"
-darwin_amd64 = "862e21cac6a71f81e7cd6e5127e3cd344f8537441ad2db94cd208319dd17b6e9"
-linux_amd64 = "d0422caade520530e76c1c558da47daebaa8e1203d6b7ff10ad7d6faba3490d8"
-linux_arm64 = "9e64a623dfc242990aa5d9b3f507111149c4282f66b68eaad1dc79eeb13b9ce5"
+darwin_arm64 = "82a6acdc3f445dc316b70e1bc15b9b7c4b4e26fd30b04de461a7829ad6c6e97f"
+darwin_amd64 = "e44d23dd5f0f8534d7a9989177f2c60ac8ffbcdfc6a0a6e5d1f23c4a3b83a9e0"
+linux_amd64 = "b2aef7b23ec6899bf27f37a32c57a7935d0a178568ac33dc9bb03842f724195a"
+linux_arm64 = "1139e1ad912fcddb5ef4b957530184c2c30d9937ff65ff4e641fbf6ca5f28c7c"

--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -48,5 +48,5 @@ package_manager = "bun"
   installation = "mise"
 
   [mise.global_tools.gemini-cli]
-  version = "0.38.2"
+  version = "0.37.1"
   installation = "mise"

--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -3,10 +3,10 @@ version = "v2026.4.17"
 installation = "external-sources"
 
 [mise.checksums]
-darwin_arm64 = "ac0251f8ccbd48de250aa866a05637b74439b22f815a894bd47fce5d52e209e7"
-darwin_amd64 = "7925831a68bb119ae0a744408ab646b476f6309720b46d7f5ab466613ca7ada8"
-linux_amd64 = "e5b07552c8b7799aebe39a8015898b9bb9a436fb6bb1595db507887ec253cb0e"
-linux_arm64 = "4cdeb9fa79e0ad8bfdf4d0aa42f17f26d6602b033df586ed08e4435602ffadb1"
+darwin_arm64 = "91bb0fe6d74d983869797a7357dd4df4f722e455e167f0d51ceba6bc9dfdbb9b"
+darwin_amd64 = "e5ef15fd0e37c7f1ab834b4da258f78277ea87c184ba7538d738c949627c5b9f"
+linux_amd64 = "b5f4aaf9047687ec42326cc7f81a709cf36edb7614ec25036a6c5dc484e627e4"
+linux_arm64 = "879ba4bd2bc18df643cd88414dd2785089a5c53729755b79aa6b92b94fa40205"
 
 [mise.settings]
 # Configuration settings: https://mise.jdx.dev/configuration/settings.html

--- a/src/chezmoi/.chezmoidata/mise.toml
+++ b/src/chezmoi/.chezmoidata/mise.toml
@@ -1,12 +1,12 @@
 [mise]
-version = "v2026.4.10"
+version = "v2026.4.17"
 installation = "external-sources"
 
 [mise.checksums]
-darwin_arm64 = "e09f5ae83369d3c6d44572e9f2de0bf9454718e23ccb41a4138f8f88d28cbb31"
-darwin_amd64 = "cd2c39806ba3dba475ab9c145376c467012200cf4eea098cbeb7e4febb4b0717"
-linux_amd64 = "84636e19a0e5001d7499f58ae5a868cec8f6ba4f52f9028680bb7cd802564229"
-linux_arm64 = "b0cee25b0405113ed6fe2a54cf21d49720ee571d3d5b4a9c695721cd123d24f8"
+darwin_arm64 = "ac0251f8ccbd48de250aa866a05637b74439b22f815a894bd47fce5d52e209e7"
+darwin_amd64 = "7925831a68bb119ae0a744408ab646b476f6309720b46d7f5ab466613ca7ada8"
+linux_amd64 = "e5b07552c8b7799aebe39a8015898b9bb9a436fb6bb1595db507887ec253cb0e"
+linux_arm64 = "4cdeb9fa79e0ad8bfdf4d0aa42f17f26d6602b033df586ed08e4435602ffadb1"
 
 [mise.settings]
 # Configuration settings: https://mise.jdx.dev/configuration/settings.html
@@ -32,11 +32,11 @@ package_manager = "bun"
   installation = "mise"
 
   [mise.global_tools.rust]
-  version = "1.94.1"
+  version = "1.95.0"
   installation = "mise"
 
   [mise.global_tools.uv]
-  version = "0.11.3"
+  version = "0.11.7"
   installation = "mise"
 
   [mise.global_tools.bun]
@@ -48,5 +48,5 @@ package_manager = "bun"
   installation = "mise"
 
   [mise.global_tools.gemini-cli]
-  version = "0.37.1"
+  version = "0.38.2"
   installation = "mise"

--- a/src/chezmoi/.chezmoidata/rulesync.toml
+++ b/src/chezmoi/.chezmoidata/rulesync.toml
@@ -6,11 +6,11 @@
 # Features: selective generation, comprehensive import/export capabilities, and supports major AI development tools.
 
 [rulesync]
-version = "7.6.3"
+version = "8.4.0"
 installation = "external-sources"
 
 [rulesync.checksums]
-darwin_arm64 = "55a1dc8a78092114b76b87eb35efc6e384226030c507a75843d0527cb336eada"
-darwin_amd64 = "fe89895913898e87131be5bbf134cce845f39162a83642c3594d1f9442538741"
-linux_arm64 = "4ab31c25aa624de18196a1b66652a942751c22d7be745896d1104e83aeef9195"
-linux_amd64 = "950d3f1bb163d168afcf69c16863736bed3457a4579fb6cde17aeed15795f864"
+darwin_arm64 = "2561ac5237e07f1a60353638ed3db08570ebc41d6fc8b439730a382997ead33c"
+darwin_amd64 = "27aca856abf7c2a8df413cb668ec4e0c706e991077a89b08ba916d1e4160504e"
+linux_arm64 = "088886fd1f21efc06a7796dc4bada680307d708173f9baad8c0de95619dacaa7"
+linux_amd64 = "2b0975d288182570c40587bf1de51b2764fa589d4b33cd0731089b6a7ad2d8e8"

--- a/src/chezmoi/.chezmoidata/starship.toml
+++ b/src/chezmoi/.chezmoidata/starship.toml
@@ -3,7 +3,7 @@ version = "1.25.0"
 
 [starship.checksums]
 type = "sha256"
-linux_amd64 = "0169f187e927a0ee9abf41bb80e316717fea6e37e404267bca5134c6ea10c0ed"
+linux_amd64 = "025a6540717a20d2545410c0108caf216a6a14ab2cce91a473d91ed42762bc6b"
 linux_arm64 = "68ffcb75582e5ed336b43598bb4d8ecc4ec994ea26eac7955d3d378f1375da34"
 darwin_arm64 = "365301b5f4938322a9f378764b4bc640048bca7d6ac28eaabd406cadd6fc703a"
 darwin_amd64 = "05421bfc05ed00394ec4a7ea20213bd9920b2858713cbe1ddf257ebcebf5da88"

--- a/src/chezmoi/.chezmoidata/starship.toml
+++ b/src/chezmoi/.chezmoidata/starship.toml
@@ -1,9 +1,9 @@
 [starship]
-version = "1.24.2"
+version = "1.25.0"
 
 [starship.checksums]
 type = "sha256"
-linux_amd64 = "3f12f61883ff324c1dbe7b885fa125d5490960e5cad6a12eeaa34695ec1b5744"
-linux_arm64 = "56b9ff412bbf374d29b99e5ac09a849124cb37a0a13121e8470df32de53c1ea6"
-darwin_arm64 = "d3a0da21374962625a2ee992110979bc1fa33424d7b6aea58a70405e26544fd9"
-darwin_amd64 = "237beb10cc970c4361536e9f9f434dfed755f8282c5cd951b6a7e3fcbda8e779"
+linux_amd64 = "0169f187e927a0ee9abf41bb80e316717fea6e37e404267bca5134c6ea10c0ed"
+linux_arm64 = "68ffcb75582e5ed336b43598bb4d8ecc4ec994ea26eac7955d3d378f1375da34"
+darwin_arm64 = "365301b5f4938322a9f378764b4bc640048bca7d6ac28eaabd406cadd6fc703a"
+darwin_amd64 = "05421bfc05ed00394ec4a7ea20213bd9920b2858713cbe1ddf257ebcebf5da88"

--- a/test_bun.sh
+++ b/test_bun.sh
@@ -1,0 +1,2 @@
+bun -v
+echo "Current Date: $(date)"

--- a/test_bun.sh
+++ b/test_bun.sh
@@ -1,2 +1,0 @@
-bun -v
-echo "Current Date: $(date)"


### PR DESCRIPTION
This commit updates several CLI tools configured in `src/chezmoi/.chezmoidata/` to their latest stable versions, along with fetching and storing the associated SHA256 checksums to ensure secure downloads.

- `claude_code` updated to `2.1.114`
- `gemini-cli` updated to `0.38.2`
- `gh` updated to `2.90.0`
- `mise` updated to `v2026.4.17`, and rust to `1.95.0`, uv to `0.11.7`
- `rulesync` updated to `8.4.0`
- `starship` updated to `1.25.0`

Note: `rg` (ripgrep) is already at the latest 15.1.0, `fd` is at v10.4.2, and `gemini conductor plugin` is at conductor-v0.4.1.

---
*PR created automatically by Jules for task [6711824803603840055](https://jules.google.com/task/6711824803603840055) started by @mkobit*