### PR TITLE
feat(git): ignore local AI configuration and context files

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -5,3 +5,9 @@
 *.swp
 *~
 /bazel-*
+
+# AI context files
+claude.local.json
+claude.md
+gemini.local.json
+gemini.md

--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -7,7 +7,7 @@
 /bazel-*
 
 # AI context files
+CLAUDE.local.md
 claude.local.json
-claude.md
+GEMINI.local.md
 gemini.local.json
-gemini.md


### PR DESCRIPTION
This pull request adds specific local configuration files used by AI tools (Claude and Gemini) to the global `.gitignore` managed by chezmoi.

**Files added to `.gitignore_global`:**
*   `claude.local.json`
*   `claude.md`
*   `gemini.local.json`
*   `gemini.md`

These files are meant for local project context and overrides and should not be committed to version control. By adding them to the global `.gitignore`, they are automatically ignored across all repositories.

---
*PR created automatically by Jules for task [11951694091093461418](https://jules.google.com/task/11951694091093461418) started by @mkobit*