### PR TITLE
feat(claude): set editorMode to vim in global settings

### DIFF
--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -7,6 +7,7 @@ installation = "external-script"
 # https://code.claude.com/docs/en/settings
 cleanupPeriodDays = 30
 outputStyle = "concise"
+editorMode = "vim"
 
 [claude_code.settings.sandbox]
 # Disabled globally due to current complexity using existing tools like git


### PR DESCRIPTION
Updates `src/chezmoi/.chezmoidata/claude_code.toml` to include `editorMode = "vim"` under `[claude_code.settings]`. This will cause the setting to be templated into `~/.claude.json`.

---
*PR created automatically by Jules for task [11741081839215262140](https://jules.google.com/task/11741081839215262140) started by @mkobit*