### PR TITLE
Refactor local bin tools to use uv tool install with additive wrappers

### DIFF
--- a/src/chezmoi/.chezmoiremove
+++ b/src/chezmoi/.chezmoiremove
@@ -32,3 +32,9 @@ install-asdf.sh
 {{ end }}
 .dotfiles/zsh/scripts
 .dotfiles/bash/snippets
+
+# Old uv shell wrappers (these were moved or changed behavior but paths may have been cached)
+.local/bin/tools/jules
+.local/bin/tools/termbud
+.local/bin/tools/transcribe
+.local/bin/claude_statusline

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_claude_statusline.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_claude_statusline.sh.tmpl
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
+
 {{- if eq .local_bin_tools.claude_statusline.installation "uv" }}
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/claude_statusline"
 {{- else }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_claude_statusline.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_claude_statusline.sh.tmpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+{{- if eq .local_bin_tools.claude_statusline.installation "uv" }}
+uv tool install --force "{{ .chezmoi.sourceDir }}/../python/claude_statusline"
+{{- else }}
+uv tool uninstall claude-statusline || true
+{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_jules.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_jules.sh.tmpl
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
+
 {{- if eq .local_bin_tools.jules.installation "uv" }}
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/jules_cli"
 {{- else }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_jules.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_jules.sh.tmpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+{{- if eq .local_bin_tools.jules.installation "uv" }}
+uv tool install --force "{{ .chezmoi.sourceDir }}/../python/jules_cli"
+{{- else }}
+uv tool uninstall jules || true
+{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+{{- if eq .local_bin_tools.termbud.installation "uv" }}
+uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"
+{{- else }}
+uv tool uninstall termbud || true
+{{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_termbud.sh.tmpl
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
+
 {{- if eq .local_bin_tools.termbud.installation "uv" }}
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/termbud"
 {{- else }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_transcribe.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_transcribe.sh.tmpl
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
+
 {{- if eq .local_bin_tools.transcribe.installation "uv" }}
 uv tool install --force "{{ .chezmoi.sourceDir }}/../python/transcribe"
 {{- else }}

--- a/src/chezmoi/.chezmoiscripts/run_once_after_install_transcribe.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_after_install_transcribe.sh.tmpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+{{- if eq .local_bin_tools.transcribe.installation "uv" }}
+uv tool install --force "{{ .chezmoi.sourceDir }}/../python/transcribe"
+{{- else }}
+uv tool uninstall transcribe || true
+{{- end }}

--- a/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
+++ b/src/chezmoi/dot_local/bin/executable_claude_statusline.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.claude_statusline.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/claude_statusline -m claude_statusline.main{{ range (dig "claude_code" "settings" "statusLine" "generators" list .) }} --generator {{ . | quote }}{{ end }} "$@"
+exec mise exec -- claude-statusline{{ range (dig "claude_code" "settings" "statusLine" "generators" list .) }} --generator {{ . | quote }}{{ end }} "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_jules.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.jules.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/jules_cli -m jules_cli.main "$@"
+exec mise exec -- jules "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_termbud.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_termbud.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.termbud.installation "uv" -}}
 #!/usr/bin/env bash
-exec mise exec -- uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/termbud -m termbud.main "$@"
+exec mise exec -- termbud "$@"
 {{- end -}}

--- a/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
+++ b/src/chezmoi/dot_local/bin/tools/executable_transcribe.tmpl
@@ -1,4 +1,4 @@
 {{- if eq .local_bin_tools.transcribe.installation "uv" -}}
 #!/usr/bin/env bash
-exec uv run --frozen --project {{ .chezmoi.workingTree }}/src/python/transcribe -m transcribe.main "$@"
+exec mise exec -- transcribe "$@"
 {{- end -}}

--- a/tests/integration/test_local_bin_tools.py
+++ b/tests/integration/test_local_bin_tools.py
@@ -1,6 +1,8 @@
-import subprocess
-import pytest
 import os
+import subprocess
+
+import pytest
+
 
 def run_chezmoi_template(template_content: str) -> str:
     source_dir = os.path.abspath("src/chezmoi")
@@ -8,47 +10,58 @@ def run_chezmoi_template(template_content: str) -> str:
         ["chezmoi", "execute-template", "--source", source_dir, "-i", template_content],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         print(f"Error: {result.stderr}")
     return result.stdout.strip()
 
+
 @pytest.mark.integration
 def test_claude_statusline_template_generation():
     """Verify additive configurations are injected correctly into the shell wrapper."""
-    template_content = """
-{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "uv")) "claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) -}}
-{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}
-"""
+    template_content = (
+        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "uv")) '
+        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
+        "-}}\n"
+        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
+    )
     output = run_chezmoi_template(template_content)
-    assert "exec mise exec -- claude-statusline --generator \"test1\" --generator \"test2\" \"$@\"" in output
+    assert 'exec mise exec -- claude-statusline --generator "test1" --generator "test2" "$@"' in output
+
 
 @pytest.mark.integration
 def test_claude_statusline_template_disabled():
     """Verify subtractive configuration correctly outputs nothing when disabled."""
-    template_content = """
-{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "disabled")) "claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) -}}
-{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}
-"""
+    template_content = (
+        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "disabled")) '
+        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
+        "-}}\n"
+        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
+    )
     output = run_chezmoi_template(template_content)
     assert output == ""
+
 
 @pytest.mark.integration
 def test_install_script_generation_enabled():
     """Verify install script correctly generates uv tool install when enabled."""
-    template_content = """
-{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "uv")) "chezmoi" (dict "sourceDir" "/fake/source") -}}
-{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}
-"""
+    template_content = (
+        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "uv")) '
+        '"chezmoi" (dict "sourceDir" "/fake/source") -}}\n'
+        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
+    )
     output = run_chezmoi_template(template_content)
-    assert "uv tool install --force \"/fake/source/../python/jules_cli\"" in output
+    assert 'uv tool install --force "/fake/source/../python/jules_cli"' in output
+
 
 @pytest.mark.integration
 def test_install_script_generation_disabled():
     """Verify install script correctly generates uv tool uninstall when disabled."""
-    template_content = """
-{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "disabled")) "chezmoi" (dict "sourceDir" "/fake/source") -}}
-{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}
-"""
+    template_content = (
+        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "disabled")) '
+        '"chezmoi" (dict "sourceDir" "/fake/source") -}}\n'
+        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
+    )
     output = run_chezmoi_template(template_content)
     assert "uv tool uninstall jules || true" in output

--- a/tests/integration/test_local_bin_tools.py
+++ b/tests/integration/test_local_bin_tools.py
@@ -21,23 +21,23 @@ def run_chezmoi_template(template_content: str) -> str:
 def test_claude_statusline_template_generation():
     """Verify additive configurations are injected correctly into the shell wrapper."""
     template_content = (
-        "{{- $data := dict \"local_bin_tools\" (dict \"claude_statusline\" (dict \"installation\" \"uv\")) "
-        "\"claude_code\" (dict \"settings\" (dict \"statusLine\" (dict \"generators\" (list \"test1\" \"test2\")))) "
+        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "uv")) '
+        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
         "-}}\n"
-        "{{- includeTemplate \".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl\" $data -}}"
+        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
     )
     output = run_chezmoi_template(template_content)
-    assert "exec mise exec -- claude-statusline --generator \"test1\" --generator \"test2\" \"$@\"" in output
+    assert 'exec mise exec -- claude-statusline --generator "test1" --generator "test2" "$@"' in output
 
 
 @pytest.mark.integration
 def test_claude_statusline_template_disabled():
     """Verify subtractive configuration correctly outputs nothing when disabled."""
     template_content = (
-        "{{- $data := dict \"local_bin_tools\" (dict \"claude_statusline\" (dict \"installation\" \"disabled\")) "
-        "\"claude_code\" (dict \"settings\" (dict \"statusLine\" (dict \"generators\" (list \"test1\" \"test2\")))) "
+        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "disabled")) '
+        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
         "-}}\n"
-        "{{- includeTemplate \".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl\" $data -}}"
+        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
     )
     output = run_chezmoi_template(template_content)
     assert output == ""
@@ -47,22 +47,22 @@ def test_claude_statusline_template_disabled():
 def test_install_script_generation_enabled():
     """Verify install script correctly generates uv tool install when enabled."""
     template_content = (
-        "{{- $data := dict \"local_bin_tools\" (dict \"jules\" (dict \"installation\" \"uv\")) "
-        "\"chezmoi\" (dict \"sourceDir\" \"/fake/source\" \"destDir\" \"/fake/dest\") -}}\n"
-        "{{- includeTemplate \".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl\" $data -}}"
+        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "uv")) '
+        '"chezmoi" (dict "sourceDir" "/fake/source" "destDir" "/fake/dest") -}}\n'
+        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
     )
     output = run_chezmoi_template(template_content)
-    assert "uv tool install --force \"/fake/source/../python/jules_cli\"" in output
-    assert "export PATH=\"/fake/dest/.local/bin:${PATH}\"" in output
+    assert 'uv tool install --force "/fake/source/../python/jules_cli"' in output
+    assert 'export PATH="/fake/dest/.local/bin:${PATH}"' in output
 
 
 @pytest.mark.integration
 def test_install_script_generation_disabled():
     """Verify install script correctly generates uv tool uninstall when disabled."""
     template_content = (
-        "{{- $data := dict \"local_bin_tools\" (dict \"jules\" (dict \"installation\" \"disabled\")) "
-        "\"chezmoi\" (dict \"sourceDir\" \"/fake/source\" \"destDir\" \"/fake/dest\") -}}\n"
-        "{{- includeTemplate \".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl\" $data -}}"
+        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "disabled")) '
+        '"chezmoi" (dict "sourceDir" "/fake/source" "destDir" "/fake/dest") -}}\n'
+        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
     )
     output = run_chezmoi_template(template_content)
     assert "uv tool uninstall jules || true" in output

--- a/tests/integration/test_local_bin_tools.py
+++ b/tests/integration/test_local_bin_tools.py
@@ -1,0 +1,54 @@
+import subprocess
+import pytest
+import os
+
+def run_chezmoi_template(template_content: str) -> str:
+    source_dir = os.path.abspath("src/chezmoi")
+    result = subprocess.run(
+        ["chezmoi", "execute-template", "--source", source_dir, "-i", template_content],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+    return result.stdout.strip()
+
+@pytest.mark.integration
+def test_claude_statusline_template_generation():
+    """Verify additive configurations are injected correctly into the shell wrapper."""
+    template_content = """
+{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "uv")) "claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) -}}
+{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}
+"""
+    output = run_chezmoi_template(template_content)
+    assert "exec mise exec -- claude-statusline --generator \"test1\" --generator \"test2\" \"$@\"" in output
+
+@pytest.mark.integration
+def test_claude_statusline_template_disabled():
+    """Verify subtractive configuration correctly outputs nothing when disabled."""
+    template_content = """
+{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "disabled")) "claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) -}}
+{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}
+"""
+    output = run_chezmoi_template(template_content)
+    assert output == ""
+
+@pytest.mark.integration
+def test_install_script_generation_enabled():
+    """Verify install script correctly generates uv tool install when enabled."""
+    template_content = """
+{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "uv")) "chezmoi" (dict "sourceDir" "/fake/source") -}}
+{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}
+"""
+    output = run_chezmoi_template(template_content)
+    assert "uv tool install --force \"/fake/source/../python/jules_cli\"" in output
+
+@pytest.mark.integration
+def test_install_script_generation_disabled():
+    """Verify install script correctly generates uv tool uninstall when disabled."""
+    template_content = """
+{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "disabled")) "chezmoi" (dict "sourceDir" "/fake/source") -}}
+{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}
+"""
+    output = run_chezmoi_template(template_content)
+    assert "uv tool uninstall jules || true" in output

--- a/tests/integration/test_local_bin_tools.py
+++ b/tests/integration/test_local_bin_tools.py
@@ -21,23 +21,23 @@ def run_chezmoi_template(template_content: str) -> str:
 def test_claude_statusline_template_generation():
     """Verify additive configurations are injected correctly into the shell wrapper."""
     template_content = (
-        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "uv")) '
-        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
+        "{{- $data := dict \"local_bin_tools\" (dict \"claude_statusline\" (dict \"installation\" \"uv\")) "
+        "\"claude_code\" (dict \"settings\" (dict \"statusLine\" (dict \"generators\" (list \"test1\" \"test2\")))) "
         "-}}\n"
-        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
+        "{{- includeTemplate \".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl\" $data -}}"
     )
     output = run_chezmoi_template(template_content)
-    assert 'exec mise exec -- claude-statusline --generator "test1" --generator "test2" "$@"' in output
+    assert "exec mise exec -- claude-statusline --generator \"test1\" --generator \"test2\" \"$@\"" in output
 
 
 @pytest.mark.integration
 def test_claude_statusline_template_disabled():
     """Verify subtractive configuration correctly outputs nothing when disabled."""
     template_content = (
-        '{{- $data := dict "local_bin_tools" (dict "claude_statusline" (dict "installation" "disabled")) '
-        '"claude_code" (dict "settings" (dict "statusLine" (dict "generators" (list "test1" "test2")))) '
+        "{{- $data := dict \"local_bin_tools\" (dict \"claude_statusline\" (dict \"installation\" \"disabled\")) "
+        "\"claude_code\" (dict \"settings\" (dict \"statusLine\" (dict \"generators\" (list \"test1\" \"test2\")))) "
         "-}}\n"
-        '{{- includeTemplate ".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl" $data -}}'
+        "{{- includeTemplate \".chezmoitemplates/../dot_local/bin/executable_claude_statusline.tmpl\" $data -}}"
     )
     output = run_chezmoi_template(template_content)
     assert output == ""
@@ -47,21 +47,22 @@ def test_claude_statusline_template_disabled():
 def test_install_script_generation_enabled():
     """Verify install script correctly generates uv tool install when enabled."""
     template_content = (
-        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "uv")) '
-        '"chezmoi" (dict "sourceDir" "/fake/source") -}}\n'
-        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
+        "{{- $data := dict \"local_bin_tools\" (dict \"jules\" (dict \"installation\" \"uv\")) "
+        "\"chezmoi\" (dict \"sourceDir\" \"/fake/source\" \"destDir\" \"/fake/dest\") -}}\n"
+        "{{- includeTemplate \".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl\" $data -}}"
     )
     output = run_chezmoi_template(template_content)
-    assert 'uv tool install --force "/fake/source/../python/jules_cli"' in output
+    assert "uv tool install --force \"/fake/source/../python/jules_cli\"" in output
+    assert "export PATH=\"/fake/dest/.local/bin:${PATH}\"" in output
 
 
 @pytest.mark.integration
 def test_install_script_generation_disabled():
     """Verify install script correctly generates uv tool uninstall when disabled."""
     template_content = (
-        '{{- $data := dict "local_bin_tools" (dict "jules" (dict "installation" "disabled")) '
-        '"chezmoi" (dict "sourceDir" "/fake/source") -}}\n'
-        '{{- includeTemplate ".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl" $data -}}'
+        "{{- $data := dict \"local_bin_tools\" (dict \"jules\" (dict \"installation\" \"disabled\")) "
+        "\"chezmoi\" (dict \"sourceDir\" \"/fake/source\" \"destDir\" \"/fake/dest\") -}}\n"
+        "{{- includeTemplate \".chezmoitemplates/../.chezmoiscripts/run_once_after_install_jules.sh.tmpl\" $data -}}"
     )
     output = run_chezmoi_template(template_content)
     assert "uv tool uninstall jules || true" in output


### PR DESCRIPTION
This PR refactors the management of local Python CLI tools (`jules_cli`, `termbud`, `transcribe`, `claude_statusline`) to align with the core directives of deterministic environment shaping and subtractive/additive configuration. 

Changes include:
- Removing the old `uv run` wrappers from `dot_local/bin/tools`.
- Introducing `run_once_after_install_<tool>.sh.tmpl` scripts in `.chezmoiscripts` to properly execute `uv tool install --force` against the local workspace (or `uv tool uninstall` if the tool is disabled via `.local_bin_tools.<tool>.installation != "uv"`).
- Restoring the wrapper scripts to inject dynamic, additive configurations (like `--generator` flags for `claude-statusline`) and the necessary `mise exec` execution context for the globally installed tool binaries.
- Updating `.chezmoiremove` to purge outdated paths.
- Adding integration tests in `tests/integration/test_local_bin_tools.py` using `chezmoi execute-template` to ensure correctness.

---
*PR created automatically by Jules for task [1618608242663685737](https://jules.google.com/task/1618608242663685737) started by @mkobit*