### PR TITLE
test(claude_statusline): Add unit tests for SegmentCache

### DIFF
--- a/src/python/claude_statusline/tests/test_cache.py
+++ b/src/python/claude_statusline/tests/test_cache.py
@@ -23,12 +23,21 @@ def test_cache_miss_when_empty(cache: SegmentCache) -> None:
     assert cache.get("nonexistent") is None
 
 
-def test_cache_set_and_get(cache: SegmentCache, cache_file: Path) -> None:
+def test_cache_set_and_get(cache: SegmentCache, cache_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Goals: Cache persists and retrieves data in bi-directional flows."""
     results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
-    expires = Instant.now() + hours(1)
+
+    fixed_now = Instant.from_utc(2024, 1, 1, 12, 0, 0)
+    expires = fixed_now + hours(1)
 
     cache.set("key1", results, expires)
+
+    class MockInstant:
+        @classmethod
+        def now(cls):
+            return fixed_now
+
+    monkeypatch.setattr("claude_statusline.cache.Instant", MockInstant)
 
     cached = cache.get("key1")
     assert cached is not None
@@ -36,27 +45,45 @@ def test_cache_set_and_get(cache: SegmentCache, cache_file: Path) -> None:
     assert cached[0].segment.text == "hello"
 
 
-def test_cache_expires(cache: SegmentCache) -> None:
+def test_cache_expires(cache: SegmentCache, monkeypatch: pytest.MonkeyPatch) -> None:
     """Goals: Ensure expired cache state subtracts correctly."""
     results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
-    expires = Instant.now() - hours(1)
+
+    fixed_now = Instant.from_utc(2024, 1, 1, 12, 0, 0)
+    expires = fixed_now - hours(1)
 
     cache.set("key1", results, expires)
+
+    class MockInstant:
+        @classmethod
+        def now(cls):
+            return fixed_now
+
+    monkeypatch.setattr("claude_statusline.cache.Instant", MockInstant)
 
     assert cache.get("key1") is None
     assert "key1" not in cache._cache
 
 
-def test_cache_load_valid(cache_file: Path) -> None:
+def test_cache_load_valid(cache_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Goals: Verify data loads from disk reliably."""
     results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
-    expires = Instant.now() + hours(1)
+
+    fixed_now = Instant.from_utc(2024, 1, 1, 12, 0, 0)
+    expires = fixed_now + hours(1)
 
     initial_cache = SegmentCache(cache_file)
     initial_cache.set("key1", results, expires)
 
     new_cache = SegmentCache(cache_file)
     new_cache.load()
+
+    class MockInstant:
+        @classmethod
+        def now(cls):
+            return fixed_now
+
+    monkeypatch.setattr("claude_statusline.cache.Instant", MockInstant)
 
     cached = new_cache.get("key1")
     assert cached is not None
@@ -91,8 +118,9 @@ def test_cache_save_io_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -
     bad_cache = SegmentCache(readonly_dir)
     results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
 
+    fixed_now = Instant.from_utc(2024, 1, 1, 12, 0, 0)
     with caplog.at_level(logging.WARNING):
-        bad_cache.set("key1", results, Instant.now() + hours(1))
+        bad_cache.set("key1", results, fixed_now + hours(1))
 
     assert "Failed to save cache to" in caplog.text
 

--- a/src/python/claude_statusline/tests/test_cache.py
+++ b/src/python/claude_statusline/tests/test_cache.py
@@ -1,0 +1,111 @@
+import logging
+from pathlib import Path
+
+import pytest
+from whenever import Instant, hours
+
+from claude_statusline.cache import SegmentCache
+from claude_statusline.models import Segment, SegmentGenerationResult
+
+
+@pytest.fixture
+def cache_file(tmp_path: Path) -> Path:
+    return tmp_path / "cache.json"
+
+
+@pytest.fixture
+def cache(cache_file: Path) -> SegmentCache:
+    return SegmentCache(cache_file)
+
+
+def test_cache_miss_when_empty(cache: SegmentCache) -> None:
+    """Goals: Missing keys return None without error."""
+    assert cache.get("nonexistent") is None
+
+
+def test_cache_set_and_get(cache: SegmentCache, cache_file: Path) -> None:
+    """Goals: Cache persists and retrieves data in bi-directional flows."""
+    results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
+    expires = Instant.now() + hours(1)
+
+    cache.set("key1", results, expires)
+
+    cached = cache.get("key1")
+    assert cached is not None
+    assert len(cached) == 1
+    assert cached[0].segment.text == "hello"
+
+
+def test_cache_expires(cache: SegmentCache) -> None:
+    """Goals: Ensure expired cache state subtracts correctly."""
+    results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
+    expires = Instant.now() - hours(1)
+
+    cache.set("key1", results, expires)
+
+    assert cache.get("key1") is None
+    assert "key1" not in cache._cache
+
+
+def test_cache_load_valid(cache_file: Path) -> None:
+    """Goals: Verify data loads from disk reliably."""
+    results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
+    expires = Instant.now() + hours(1)
+
+    initial_cache = SegmentCache(cache_file)
+    initial_cache.set("key1", results, expires)
+
+    new_cache = SegmentCache(cache_file)
+    new_cache.load()
+
+    cached = new_cache.get("key1")
+    assert cached is not None
+    assert cached[0].segment.text == "hello"
+
+
+def test_cache_load_invalid(cache_file: Path) -> None:
+    """Goals: Invalid cache data clears state automatically."""
+    cache_file.write_text('{"bad": "json"')
+
+    cache = SegmentCache(cache_file)
+    cache.load()
+
+    assert cache._cache == {}
+
+
+def test_cache_load_empty(cache_file: Path) -> None:
+    """Goals: Empty cache files handle safely without fault."""
+    cache_file.write_text("   \n")
+
+    cache = SegmentCache(cache_file)
+    cache.load()
+
+    assert cache._cache == {}
+
+
+def test_cache_save_io_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Goals: Gracefully degrade if the file system prevents cache saving."""
+    readonly_dir = tmp_path / "dir_cannot_be_file"
+    readonly_dir.mkdir()
+
+    bad_cache = SegmentCache(readonly_dir)
+    results = [SegmentGenerationResult(line=0, index=0, generator="test", segment=Segment(text="hello"))]
+
+    with caplog.at_level(logging.WARNING):
+        bad_cache.set("key1", results, Instant.now() + hours(1))
+
+    assert "Failed to save cache to" in caplog.text
+
+
+def test_cache_load_io_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Goals: Gracefully reset if the cache file is unreadable."""
+    readonly_dir = tmp_path / "dir_cannot_be_file"
+    readonly_dir.mkdir()
+
+    bad_cache = SegmentCache(readonly_dir)
+
+    with caplog.at_level(logging.WARNING):
+        bad_cache.load()
+
+    assert bad_cache._cache == {}
+    assert "Failed to load cache from" in caplog.text


### PR DESCRIPTION
Adds hermetic unit tests for the internal utility `SegmentCache` in `claude_statusline`.
Tests were designed per core directives:
- **Feature-first**: Assertions clearly validate the cache contract (persistence, expiration).
- **Data-aware**: Accounts for setting, expiring (subtractive), invalidating corrupted payloads, and IO failures.
- **Deterministic**: Utilizes `pytest` tmp_path fixtures to maintain isolation.
- **Minimalist**: Comments are used exclusively to describe the goals of individual test functions rather than verbatim line-by-line narrations.
  
All tests run locally via `uv run pytest claude_statusline` successfully and linting checks passed.

---
*PR created automatically by Jules for task [12312093665554832422](https://jules.google.com/task/12312093665554832422) started by @mkobit*