### PR TITLE
feat(shell): add fzf completion for zellij attach

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/zellij.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zellij.sh
@@ -1,0 +1,35 @@
+{{- $zellij := index . "zellij" | default (dict "enabled" false) -}}
+{{- if $zellij.enabled }}
+# Zellij aliases and fzf completion
+alias zj="zellij"
+alias za="zellij attach"
+
+# Custom fzf completion for zellij sessions triggered by **<TAB>
+# fzf's bash/zsh completion scripts automatically detect and use these functions
+# when the user types 'zellij attach **<TAB>' or 'za **<TAB>'
+
+_fzf_complete_zellij() {
+    local args
+    args=("$@")
+
+    # Only trigger fzf session picker for 'attach' or 'a' subcommand
+    if [[ " ${args[*]} " =~ " attach " || " ${args[*]} " =~ " a " ]]; then
+        _fzf_complete --reverse --prompt="Zellij Session> " -- "$@" < <(
+            command zellij list-sessions -n 2>/dev/null | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' | awk '{print $1}'
+        )
+    else
+        # Fall back to default file/dir completion provided by fzf for other subcommands
+        _fzf_path_completion "$@"
+    fi
+}
+
+_fzf_complete_za() {
+    _fzf_complete --reverse --prompt="Zellij Session> " -- "$@" < <(
+        command zellij list-sessions -n 2>/dev/null | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' | awk '{print $1}'
+    )
+}
+
+_fzf_complete_zj() {
+    _fzf_complete_zellij "$@"
+}
+{{- end }}

--- a/src/chezmoi/.chezmoitemplates/shell/zellij.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zellij.sh
@@ -2,11 +2,11 @@
 {{- if $zellij.enabled }}
 # Zellij aliases and fzf completion
 alias zj="zellij"
-alias za="zellij attach"
+alias zja="zellij attach"
 
 # Custom fzf completion for zellij sessions triggered by **<TAB>
 # fzf's bash/zsh completion scripts automatically detect and use these functions
-# when the user types 'zellij attach **<TAB>' or 'za **<TAB>'
+# when the user types 'zellij attach **<TAB>' or 'zja **<TAB>'
 
 _fzf_complete_zellij() {
     local args
@@ -23,7 +23,7 @@ _fzf_complete_zellij() {
     fi
 }
 
-_fzf_complete_za() {
+_fzf_complete_zja() {
     _fzf_complete --reverse --prompt="Zellij Session> " -- "$@" < <(
         command zellij list-sessions -n 2>/dev/null | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' | awk '{print $1}'
     )

--- a/src/chezmoi/.chezmoitemplates/zsh/115_zellij.zsh
+++ b/src/chezmoi/.chezmoitemplates/zsh/115_zellij.zsh
@@ -1,6 +1,0 @@
-{{- $zellij := index . "zellij" | default (dict "enabled" false) -}}
-{{- if $zellij.enabled }}
-# Zellij aliases
-alias zj="zellij"
-alias za="zellij attach"
-{{- end }}

--- a/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
+++ b/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
@@ -10,3 +10,4 @@
 {{ template "shell/zoxide.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/git_alias.sh" (merge (dict "shell" "bash") .) }}
 
+{{ template "shell/zellij.sh" (merge (dict "shell" "bash") .) }}

--- a/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
+++ b/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
@@ -9,7 +9,7 @@
 {{ template "zsh/060_zsh_defaults.zsh" . }}
 {{ template "shell/mise.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "zsh/110_chezmoi.zsh" . }}
-{{ template "zsh/115_zellij.zsh" . }}
+{{ template "shell/zellij.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/fzf.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/fzf_tab.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/zoxide.sh" (merge (dict "shell" "zsh") .) }}


### PR DESCRIPTION
- Removes the Zsh-only `115_zellij.zsh` template
- Creates a cross-shell `zellij.sh` template included in both Bash and Zsh configs
- Binds `_fzf_complete_zellij` (and aliases `za`, `zj`) to native `fzf` completion
- Triggers an interactive fzf menu when running `zellij attach **<TAB>`
- Safely falls back to `fzf` default path completion for other zellij subcommands

---
*PR created automatically by Jules for task [5902405949535873722](https://jules.google.com/task/5902405949535873722) started by @mkobit*