### PR TITLE
fix(.jules): exclude scripts from chezmoi apply in sandbox

### DIFF
--- a/.jules/env_setup.sh
+++ b/.jules/env_setup.sh
@@ -56,7 +56,7 @@ else
 fi
 
 echo "Applying chezmoi..."
-chezmoi apply --source="$(pwd)/src/chezmoi" --destination="$HOME"
+chezmoi apply --source="$(pwd)/src/chezmoi" --destination="$HOME" --exclude=scripts
 
 # Step 3: Install python dependencies
 echo "Installing python dependencies..."


### PR DESCRIPTION
## Summary

- `chezmoi apply` was running install scripts (e.g. `install-ghostty.sh`) that require system tools like `snap` not available in the Jules sandbox
- Add `--exclude=scripts` so only config files are written, which is all Jules needs to get the global mise config in place