### PR TITLE
feat: add get_activity and get_source methods to JulesClient and CLI

### DIFF
--- a/src/python/jules_cli/jules_cli/client.py
+++ b/src/python/jules_cli/jules_cli/client.py
@@ -59,6 +59,10 @@ class JulesClient:
                 raise Exception(f"API Error {response.status}: {error_body}")
             return await response.json()
 
+    async def get_source(self, source_name: str) -> Source:
+        data = await self._get(f"/{source_name}")
+        return Source(**data)
+
     async def list_sources(self) -> AsyncGenerator[Source, None]:
         next_page_token = None
         while True:
@@ -120,6 +124,10 @@ class JulesClient:
             next_page_token = response.next_page_token
             if not next_page_token:
                 break
+
+    async def get_activity(self, activity_name: str) -> Activity:
+        data = await self._get(f"/{activity_name}")
+        return Activity(**data)
 
     async def send_message(self, session_id: str, message: str) -> Any:
         payload = {"prompt": message}

--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -478,3 +478,130 @@ def create(
 
 if __name__ == "__main__":
     cli()
+
+activity_app = typer.Typer(add_completion=False, help="Manage activities.")
+cli.add_typer(activity_app, name="activity")
+
+
+@activity_app.command(name="show")
+def show_activity(
+    ctx: typer.Context,
+    activity_name: str = typer.Argument(
+        ..., help="The unique identifier of the activity (e.g., 'sessions/123/activities/456')."
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Output in JSON format."),
+) -> None:
+    """Show details for a specific activity.
+
+    Example:
+    $ jules activity show sessions/123/activities/456
+    """
+
+    async def _show() -> None:
+        jules_ctx: JulesContext = ctx.obj
+        api_key = get_api_key(jules_ctx.api_key)
+        async with JulesClient(api_key=api_key) as client:
+            try:
+                activity = await client.get_activity(activity_name)
+                if as_json:
+                    typer.echo(json.dumps(activity.model_dump(mode="json", by_alias=True), indent=2))
+                else:
+                    typer.echo(f"Activity: {activity.name}")
+                    typer.echo(f"Originator: {activity.originator}")
+                    typer.echo(f"Created: {activity.create_time}")
+                    if activity.description:
+                        typer.echo(f"Description: {activity.description}")
+            except Exception as e:
+                typer.echo(f"Error: {e}", err=True)
+
+    asyncio.run(_show())
+
+
+@activity_app.command(name="list")
+def list_activities(
+    ctx: typer.Context,
+    session_id: str = typer.Argument(..., help="The session ID to list activities for (e.g., 'sessions/123')."),
+    as_json: bool = typer.Option(False, "--json", help="Output in JSON format."),
+) -> None:
+    """List activities for a specific session.
+
+    Example:
+    $ jules activity list sessions/123
+    """
+
+    async def _list() -> None:
+        jules_ctx: JulesContext = ctx.obj
+        api_key = get_api_key(jules_ctx.api_key)
+        async with JulesClient(api_key=api_key) as client:
+            if as_json:
+                activities = [
+                    a.model_dump(mode="json", by_alias=True) async for a in client.list_activities(session_id)
+                ]
+                typer.echo(json.dumps(activities, indent=2))
+            else:
+                async for act in client.list_activities(session_id):
+                    typer.echo(f"{act.name}: {act.originator} - {act.description or 'No description'}")
+
+    asyncio.run(_list())
+
+
+source_app = typer.Typer(add_completion=False, help="Manage sources.")
+cli.add_typer(source_app, name="source")
+
+
+@source_app.command(name="show")
+def show_source(
+    ctx: typer.Context,
+    source_name: str = typer.Argument(
+        ..., help="The unique identifier of the source (e.g., 'sources/github/owner/repo')."
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Output in JSON format."),
+) -> None:
+    """Show details for a specific source.
+
+    Example:
+    $ jules source show sources/github/owner/repo
+    """
+
+    async def _show() -> None:
+        jules_ctx: JulesContext = ctx.obj
+        api_key = get_api_key(jules_ctx.api_key)
+        async with JulesClient(api_key=api_key) as client:
+            try:
+                source = await client.get_source(source_name)
+                if as_json:
+                    typer.echo(json.dumps(source.model_dump(mode="json", by_alias=True), indent=2))
+                else:
+                    typer.echo(f"Source: {source.name}")
+                    typer.echo(f"ID: {source.id}")
+                    if source.github_repo:
+                        typer.echo(f"GitHub Repo: {source.github_repo.owner}/{source.github_repo.repo}")
+            except Exception as e:
+                typer.echo(f"Error: {e}", err=True)
+
+    asyncio.run(_show())
+
+
+@source_app.command(name="list")
+def list_sources(
+    ctx: typer.Context,
+    as_json: bool = typer.Option(False, "--json", help="Output in JSON format."),
+) -> None:
+    """List available sources.
+
+    Example:
+    $ jules source list
+    """
+
+    async def _list() -> None:
+        jules_ctx: JulesContext = ctx.obj
+        api_key = get_api_key(jules_ctx.api_key)
+        async with JulesClient(api_key=api_key) as client:
+            if as_json:
+                sources = [s.model_dump(mode="json", by_alias=True) async for s in client.list_sources()]
+                typer.echo(json.dumps(sources, indent=2))
+            else:
+                async for s in client.list_sources():
+                    typer.echo(f"{s.name}")
+
+    asyncio.run(_list())

--- a/src/python/jules_cli/test_jules.py
+++ b/src/python/jules_cli/test_jules.py
@@ -223,3 +223,36 @@ async def test_client_approve_plan() -> None:
 
     response = await client.approve_plan("123")
     assert response.get("status") == "approved"
+
+
+@pytest.mark.asyncio
+async def test_client_get_activity() -> None:
+    client = JulesClient(api_key="test_key")
+
+    async def mock_get(endpoint: str, params: dict | None = None) -> dict:
+        if "sessions/123/activities/456" in endpoint:
+            return MOCK_ACTIVITY_DATA
+        return {}
+
+    client._get = mock_get  # type: ignore
+
+    activity = await client.get_activity("sessions/123/activities/456")
+    assert activity.id == "456"
+    assert activity.originator == "agent"
+
+
+@pytest.mark.asyncio
+async def test_client_get_source() -> None:
+    client = JulesClient(api_key="test_key")
+
+    async def mock_get(endpoint: str, params: dict | None = None) -> dict:
+        if "sources/123" in endpoint:
+            return MOCK_SOURCE_DATA_1
+        return {}
+
+    client._get = mock_get  # type: ignore
+
+    source = await client.get_source("sources/123")
+    assert source.id == "123"
+    assert source.github_repo is not None
+    assert source.github_repo.owner == "test-owner"

--- a/src/python/jules_cli/test_main.py
+++ b/src/python/jules_cli/test_main.py
@@ -8,10 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import typer
 from typer.testing import CliRunner
+from whenever import Instant
 
 from jules_cli.config import JulesConfig
 from jules_cli.main import cli, get_api_key
-from jules_cli.models import JulesContext, Session, SourceContext
+from jules_cli.models import Activity, GitHubRepo, JulesContext, Session, Source, SourceContext
 
 
 def test_get_api_key_ignores_env_var() -> None:
@@ -263,3 +264,79 @@ def test_approve_session_cli_json() -> None:
         instance.approve_plan.assert_called_once_with("sessions/1")
         data = json.loads(result.output)
         assert data["status"] == "approved"
+
+
+def test_activity_show_cli() -> None:
+    runner = CliRunner()
+    with patch("jules_cli.main.JulesClient") as mock_client:
+        instance = mock_client.return_value
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=None)
+
+        mock_activity = Activity(
+            name="sessions/1/activities/1", id="1", originator="agent", create_time=Instant.from_utc(2023, 1, 1)
+        )
+        instance.get_activity = AsyncMock(return_value=mock_activity)
+
+        result = runner.invoke(cli, ["--api-key", "key", "activity", "show", "sessions/1/activities/1"])
+
+        assert result.exit_code == 0
+        instance.get_activity.assert_called_once_with("sessions/1/activities/1")
+        assert "Activity: sessions/1/activities/1" in result.output
+        assert "Originator: agent" in result.output
+
+
+def test_activity_list_cli() -> None:
+    runner = CliRunner()
+    with patch("jules_cli.main.JulesClient") as mock_client:
+        instance = mock_client.return_value
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=None)
+
+        async def mock_activities() -> AsyncGenerator[Activity, None]:
+            yield Activity(
+                name="sessions/1/activities/1", id="1", originator="agent", create_time=Instant.from_utc(2023, 1, 1)
+            )
+
+        instance.list_activities.return_value = mock_activities()
+
+        result = runner.invoke(cli, ["--api-key", "key", "activity", "list", "sessions/1"])
+
+        assert result.exit_code == 0
+        assert "sessions/1/activities/1: agent" in result.output
+
+
+def test_source_show_cli() -> None:
+    runner = CliRunner()
+    with patch("jules_cli.main.JulesClient") as mock_client:
+        instance = mock_client.return_value
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=None)
+
+        mock_source = Source(name="sources/1", id="1", github_repo=GitHubRepo(owner="owner", repo="repo"))
+        instance.get_source = AsyncMock(return_value=mock_source)
+
+        result = runner.invoke(cli, ["--api-key", "key", "source", "show", "sources/1"])
+
+        assert result.exit_code == 0
+        instance.get_source.assert_called_once_with("sources/1")
+        assert "Source: sources/1" in result.output
+        assert "GitHub Repo: owner/repo" in result.output
+
+
+def test_source_list_cli() -> None:
+    runner = CliRunner()
+    with patch("jules_cli.main.JulesClient") as mock_client:
+        instance = mock_client.return_value
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=None)
+
+        async def mock_sources() -> AsyncGenerator[Source, None]:
+            yield Source(name="sources/1", id="1")
+
+        instance.list_sources.return_value = mock_sources()
+
+        result = runner.invoke(cli, ["--api-key", "key", "source", "list"])
+
+        assert result.exit_code == 0
+        assert "sources/1" in result.output


### PR DESCRIPTION
This adds support for the remaining methods defined in the API spec:
- `v1alpha.sessions.activities.get`
- `v1alpha.sources.get`

Corresponding tests and new `jules activity show/list` and `jules source show/list` CLI subcommands were also implemented.

---
*PR created automatically by Jules for task [10761762261740017615](https://jules.google.com/task/10761762261740017615) started by @mkobit*