### PR TITLE
Fix inconsistent state error for oh-my-zsh on local updates

### DIFF
--- a/src/chezmoi/.chezmoiignore.tmpl
+++ b/src/chezmoi/.chezmoiignore.tmpl
@@ -35,3 +35,8 @@
 {{- if eq .mise.global_tools.bun.installation "disabled" }}
 .bunfig.toml
 {{- end }}
+
+{{- if ne .zsh.prompt "oh-my-zsh" }}
+.dotfiles/external/oh-my-zsh
+.dotfiles/external/oh-my-zsh/**
+{{- end }}


### PR DESCRIPTION
Added conditional ignore block for .dotfiles/external/oh-my-zsh in .chezmoiignore.tmpl to avoid inconsistent state with .chezmoiremove

---
*PR created automatically by Jules for task [14060670034344351837](https://jules.google.com/task/14060670034344351837) started by @mkobit*