### PR TITLE
test: expand test coverage for termtext color constraints and ansi rendering

### DIFF
--- a/src/python/termtext/tests/test_color.py
+++ b/src/python/termtext/tests/test_color.py
@@ -1,0 +1,36 @@
+import pytest
+
+from termtext import Color256, RGBColor
+
+
+def test_rgb_color_out_of_bounds() -> None:
+    with pytest.raises(ValueError, match="RGB component r=256 out of range 0-255"):
+        RGBColor(256, 0, 0)
+    with pytest.raises(ValueError, match="RGB component g=-1 out of range 0-255"):
+        RGBColor(0, -1, 0)
+
+
+def test_rgb_color_from_hex_invalid_chars() -> None:
+    with pytest.raises(ValueError, match="Invalid hex color"):
+        RGBColor.from_hex("#zzzzzz")
+
+
+def test_rgb_color_from_hex_short_length() -> None:
+    c = RGBColor.from_hex("#f80")
+    assert c == RGBColor(255, 136, 0)
+
+
+def test_rgb_color_from_hex_invalid_length() -> None:
+    with pytest.raises(ValueError, match="Invalid hex color"):
+        RGBColor.from_hex("#12")
+    with pytest.raises(ValueError, match="Invalid hex color"):
+        RGBColor.from_hex("#1234")
+    with pytest.raises(ValueError, match="Invalid hex color"):
+        RGBColor.from_hex("123456")
+
+
+def test_color256_out_of_bounds() -> None:
+    with pytest.raises(ValueError, match="256-color index 256 out of range 0-255"):
+        Color256(256)
+    with pytest.raises(ValueError, match="256-color index -1 out of range 0-255"):
+        Color256(-1)

--- a/src/python/termtext/tests/test_template.py
+++ b/src/python/termtext/tests/test_template.py
@@ -1,11 +1,17 @@
 import pytest
 
-from termtext import BG, FG, SGR, Config, Link, NamedColor, RGBColor, Style, TermText
+from termtext import BG, FG, SGR, Color256, Config, Link, NamedColor, RGBColor, Style, TermText
 
 
 def test_plain_literal() -> None:
     tt = TermText.render(t"hello world")
     assert tt.to_plain() == "hello world"
+
+
+def test_interpolation_conversions() -> None:
+    val = "hi"
+    tt = TermText.render(t"{val!r} {val!s} {val!a}")
+    assert tt.to_plain() == "'hi' hi 'hi'"
 
 
 def test_interpolation_no_style() -> None:
@@ -50,6 +56,8 @@ def test_interpolation_link() -> None:
     tt = TermText.render(t"{label:link={url}}")
     styled = tt.segments[0]
     assert Link("https://example.com") in styled.style.attributes
+    ansi = tt.to_ansi()
+    assert "\x1b]8;;https://example.com\x1b\\" in ansi
 
 
 def test_interpolation_bg_color() -> None:
@@ -59,6 +67,15 @@ def test_interpolation_bg_color() -> None:
     tt = TermText.render(t"{val:highlight}", config=config)
     styled = tt.segments[0]
     assert BG(NamedColor.CYAN) in styled.style.attributes
+
+
+def test_to_ansi_named_bg_color() -> None:
+    val = "hi"
+    highlight = Style(frozenset({BG(NamedColor.CYAN)}))
+    config = Config().with_styles({"highlight": highlight})
+    tt = TermText.render(t"{val:highlight}", config=config)
+    ansi = tt.to_ansi()
+    assert "\x1b[46m" in ansi
 
 
 def test_config_override_bold() -> None:
@@ -89,6 +106,30 @@ def test_to_ansi_bold() -> None:
     ansi = tt.to_ansi()
     assert "\x1b[" in ansi
     assert "hi" in ansi
+    assert "\x1b[0m" in ansi
+
+
+def test_to_ansi_rgb() -> None:
+    val = "x"
+    highlight = Style(frozenset({FG(RGBColor(255, 128, 0)), BG(RGBColor(0, 128, 255))}))
+    config = Config().with_styles({"custom": highlight})
+    tt = TermText.render(t"{val:custom}", config=config)
+    ansi = tt.to_ansi()
+    # 38;2;255;128;0 for FG, 48;2;0;128;255 for BG
+    assert "38;2;255;128;0" in ansi
+    assert "48;2;0;128;255" in ansi
+    assert "\x1b[0m" in ansi
+
+
+def test_to_ansi_color256() -> None:
+    val = "y"
+    highlight = Style(frozenset({FG(Color256(10)), BG(Color256(20))}))
+    config = Config().with_styles({"custom": highlight})
+    tt = TermText.render(t"{val:custom}", config=config)
+    ansi = tt.to_ansi()
+    # 38;5;10 for FG, 48;5;20 for BG
+    assert "38;5;10" in ansi
+    assert "48;5;20" in ansi
     assert "\x1b[0m" in ansi
 
 


### PR DESCRIPTION
This submission improves the automated test coverage for the `termtext` Python library in the workspace. It introduces feature-first, deterministic validation checks for ANSI color string rendering and edge-case argument parsing.

Key modifications:
- Added `test_color.py` for explicit validation tests rejecting out-of-bound `RGBColor` components, malformed `RGBColor.from_hex()` strings, and invalid `Color256` palettes.
- Appended missing coverage to `test_template.py` ensuring string template formatting (`!r`, `!s`, `!a`) safely resolves ANSI styles. 
- Integrated missing SGR escape code unit tests to verify proper escape sequence construction for named background colors, `RGBColor` combinations, and `Color256` codes within `.to_ansi()`.

---
*PR created automatically by Jules for task [3004230497518420926](https://jules.google.com/task/3004230497518420926) started by @mkobit*