### PR TITLE
Add GitHub CLI telemetry opt-out

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/telemetry.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/telemetry.sh
@@ -1,0 +1,4 @@
+# Opt out of GitHub CLI telemetry and other tracking
+# https://cli.github.com/telemetry#how-to-opt-out
+export DO_NOT_TRACK=true
+export GH_TELEMETRY=false

--- a/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
+++ b/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
@@ -6,6 +6,7 @@
 {{ template "shell/editor.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/less.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/disable_bell.sh" (merge (dict "shell" "bash") .) }}
+{{ template "shell/telemetry.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/mise.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/chezmoi.sh" (merge (dict "shell" "bash") .) }}
 {{ template "shell/zellij.sh" (merge (dict "shell" "bash") .) }}

--- a/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
+++ b/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
@@ -6,6 +6,7 @@
 {{ template "shell/editor.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/less.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/disable_bell.sh" (merge (dict "shell" "zsh") .) }}
+{{ template "shell/telemetry.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/zsh_defaults.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/mise.sh" (merge (dict "shell" "zsh") .) }}
 {{ template "shell/chezmoi.sh" (merge (dict "shell" "zsh") .) }}

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-04-15T12:43:19.026153645Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "claude-statusline",


### PR DESCRIPTION
Added `src/chezmoi/.chezmoitemplates/shell/telemetry.sh` with `DO_NOT_TRACK` and `GH_TELEMETRY` set to disable GitHub CLI telemetry. Included this template in both the `zsh` and `bash` dotfile shell configurations.

---
*PR created automatically by Jules for task [2024452748999686724](https://jules.google.com/task/2024452748999686724) started by @mkobit*