### PR TITLE
🔒 Fix Command Injection via fzf execute-silent in termbud

### DIFF
--- a/src/python/termbud/termbud/tmux.py
+++ b/src/python/termbud/termbud/tmux.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -57,20 +58,42 @@ def open_url(
     open_cmd = open_cmd or default_open_cmd
 
     fzf_env = os.environ.copy()
-    fzf_env["FZF_DEFAULT_COMMAND"] = f"cat {urls_file_name}"
+    fzf_env["FZF_DEFAULT_COMMAND"] = f"cat {shlex.quote(urls_file_name)}"
 
     fzf_args = [
         "fzf",
         "--prompt=Open URL: ",
-        "--bind",
-        f"enter:execute-silent({open_cmd} {{}})+abort",
-        "--bind",
-        f"ctrl-c:execute-silent(echo -n {{}} | {copy_cmd})+abort",
+        "--expect=enter,ctrl-c",
     ]
 
     try:
-        os.execvpe("fzf", fzf_args, fzf_env)
+        try:
+            result = subprocess.run(
+                fzf_args,
+                env=fzf_env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            if os.path.exists(urls_file_name):
+                os.remove(urls_file_name)
+
+        if not result.stdout:
+            sys.exit(0)
+
+        lines = result.stdout.splitlines()
+        if len(lines) < 2:
+            sys.exit(0)
+
+        key_pressed = lines[0]
+        url = lines[1]
+
+        if key_pressed == "enter":
+            subprocess.run([*shlex.split(open_cmd), url], check=False)
+        elif key_pressed == "ctrl-c":
+            subprocess.run(shlex.split(copy_cmd), input=url, text=True, check=False)
+
     except OSError:
         print("Failed to execute fzf", file=sys.stderr)
-        os.remove(urls_file_name)
         sys.exit(1)

--- a/src/python/termbud/termbud/zellij.py
+++ b/src/python/termbud/termbud/zellij.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -67,20 +68,42 @@ def open_url(
     open_cmd = open_cmd or default_open_cmd
 
     fzf_env = os.environ.copy()
-    fzf_env["FZF_DEFAULT_COMMAND"] = f"cat {urls_file_name}"
+    fzf_env["FZF_DEFAULT_COMMAND"] = f"cat {shlex.quote(urls_file_name)}"
 
     fzf_args = [
         "fzf",
         "--prompt=Open URL: ",
-        "--bind",
-        f"enter:execute-silent({open_cmd} {{}})+abort",
-        "--bind",
-        f"ctrl-c:execute-silent(echo -n {{}} | {copy_cmd})+abort",
+        "--expect=enter,ctrl-c",
     ]
 
     try:
-        os.execvpe("fzf", fzf_args, fzf_env)
+        try:
+            result = subprocess.run(
+                fzf_args,
+                env=fzf_env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            if os.path.exists(urls_file_name):
+                os.remove(urls_file_name)
+
+        if not result.stdout:
+            sys.exit(0)
+
+        lines = result.stdout.splitlines()
+        if len(lines) < 2:
+            sys.exit(0)
+
+        key_pressed = lines[0]
+        url = lines[1]
+
+        if key_pressed == "enter":
+            subprocess.run([*shlex.split(open_cmd), url], check=False)
+        elif key_pressed == "ctrl-c":
+            subprocess.run(shlex.split(copy_cmd), input=url, text=True, check=False)
+
     except OSError:
         print("Failed to execute fzf", file=sys.stderr)
-        os.remove(urls_file_name)
         sys.exit(1)

--- a/src/python/termbud/tests/test_tmux.py
+++ b/src/python/termbud/tests/test_tmux.py
@@ -15,74 +15,104 @@ def mock_subprocess_run():
         yield mock
 
 
-@pytest.fixture
-def mock_os_execvpe():
-    with patch("os.execvpe") as mock:
-        yield mock
+def test_tmux_open_url_success_linux(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "tmux":
+            if cmd[1] == "capture-pane":
+                mock = MagicMock()
+                mock.stdout = "Some text with https://example.com inside"
+                return mock
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://example.com\n"
+            return mock
+        return MagicMock()
 
-
-def test_tmux_open_url_success_linux(mock_subprocess_run, mock_os_execvpe):
-    mock_subprocess_run.return_value = MagicMock(stdout="Some text with https://example.com inside")
+    mock_subprocess_run.side_effect = side_effect_run
     with patch("sys.platform", "linux"), patch("os.uname") as mock_uname:
         mock_uname.return_value = MagicMock(release="5.15.0-generic")
         result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 0
-    mock_subprocess_run.assert_any_call(
-        ["tmux", "capture-pane", "-J", "-S", "-", "-t", "%1", "-p"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("xdg-open" in str(arg) for arg in args)
+    # capture-pane, fzf, xdg-open
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["xdg-open", "https://example.com"]
 
 
-def test_tmux_open_url_success_darwin(mock_subprocess_run, mock_os_execvpe):
-    mock_subprocess_run.return_value = MagicMock(stdout="https://apple.com")
+def test_tmux_open_url_success_darwin(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "tmux":
+            mock = MagicMock()
+            mock.stdout = "https://apple.com"
+            return mock
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://apple.com\n"
+            return mock
+        return MagicMock()
+
+    mock_subprocess_run.side_effect = side_effect_run
     with patch("sys.platform", "darwin"):
         result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 0
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("open " in str(arg) or arg == "open" for arg in args)
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["open", "https://apple.com"]
 
 
-def test_tmux_open_url_success_wsl(mock_subprocess_run, mock_os_execvpe):
-    mock_subprocess_run.return_value = MagicMock(stdout="https://microsoft.com")
+def test_tmux_open_url_success_wsl(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "tmux":
+            mock = MagicMock()
+            mock.stdout = "https://microsoft.com"
+            return mock
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://microsoft.com\n"
+            return mock
+        return MagicMock()
+
+    mock_subprocess_run.side_effect = side_effect_run
     with patch("sys.platform", "linux"), patch("os.uname") as mock_uname:
         mock_uname.return_value = MagicMock(release="5.15.90.1-microsoft-standard-WSL2")
         result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 0
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("wslview" in str(arg) for arg in args)
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["wslview", "https://microsoft.com"]
 
 
-def test_tmux_open_url_capture_fail(mock_subprocess_run, mock_os_execvpe):
+def test_tmux_open_url_capture_fail(mock_subprocess_run):
     mock_subprocess_run.side_effect = [subprocess.CalledProcessError(1, "tmux"), MagicMock()]
     result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 1
     mock_subprocess_run.assert_called_with(["tmux", "display-message", "Failed to capture pane"], check=False)
-    mock_os_execvpe.assert_not_called()
 
 
-def test_tmux_open_url_no_urls(mock_subprocess_run, mock_os_execvpe):
+def test_tmux_open_url_no_urls(mock_subprocess_run):
     mock_subprocess_run.return_value = MagicMock(stdout="No links here")
     result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 0
     mock_subprocess_run.assert_called_with(["tmux", "display-message", "No URLs found."], check=False)
-    mock_os_execvpe.assert_not_called()
 
 
-def test_tmux_open_url_fzf_fail(mock_subprocess_run, mock_os_execvpe):
-    mock_subprocess_run.return_value = MagicMock(stdout="https://example.com")
-    mock_os_execvpe.side_effect = OSError("fzf failed")
+def test_tmux_open_url_fzf_fail(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "tmux":
+            mock = MagicMock()
+            mock.stdout = "https://example.com"
+            return mock
+        if cmd[0] == "fzf":
+            raise OSError("fzf failed")
+        return MagicMock()
+
+    mock_subprocess_run.side_effect = side_effect_run
     result = runner.invoke(app, ["tmux", "open-url", "--pane-id", "%1"])
 
     assert result.exit_code == 1

--- a/src/python/termbud/tests/test_zellij_parser.py
+++ b/src/python/termbud/tests/test_zellij_parser.py
@@ -15,18 +15,17 @@ def mock_subprocess_run():
         yield mock
 
 
-@pytest.fixture
-def mock_os_execvpe():
-    with patch("os.execvpe") as mock:
-        yield mock
-
-
-def test_zellij_open_url_success_linux(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_success_linux(mock_subprocess_run):
     def side_effect_run(cmd, *args, **kwargs):
         if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
             file_path = cmd[3]
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write("Here is a url: https://example.com")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://example.com\n"
+            return mock
         return MagicMock()
 
     mock_subprocess_run.side_effect = side_effect_run
@@ -36,18 +35,24 @@ def test_zellij_open_url_success_linux(mock_subprocess_run, mock_os_execvpe):
         result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 0
-    mock_subprocess_run.assert_called_once()
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("xdg-open" in str(arg) for arg in args)
+    # One for dump-screen, one for fzf, one for xdg-open
+    assert mock_subprocess_run.call_count == 3
+    # Check that xdg-open was called with the URL
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["xdg-open", "https://example.com"]
 
 
-def test_zellij_open_url_success_darwin(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_success_darwin(mock_subprocess_run):
     def side_effect_run(cmd, *args, **kwargs):
         if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
             file_path = cmd[3]
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write("https://apple.com")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://apple.com\n"
+            return mock
         return MagicMock()
 
     mock_subprocess_run.side_effect = side_effect_run
@@ -56,17 +61,22 @@ def test_zellij_open_url_success_darwin(mock_subprocess_run, mock_os_execvpe):
         result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 0
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("open " in str(arg) or arg == "open" for arg in args)
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["open", "https://apple.com"]
 
 
-def test_zellij_open_url_success_wsl(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_success_wsl(mock_subprocess_run):
     def side_effect_run(cmd, *args, **kwargs):
         if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
             file_path = cmd[3]
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write("https://microsoft.com")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://microsoft.com\n"
+            return mock
         return MagicMock()
 
     mock_subprocess_run.side_effect = side_effect_run
@@ -76,12 +86,12 @@ def test_zellij_open_url_success_wsl(mock_subprocess_run, mock_os_execvpe):
         result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 0
-    mock_os_execvpe.assert_called_once()
-    args = mock_os_execvpe.call_args[0][1]
-    assert any("wslview" in str(arg) for arg in args)
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    assert last_call[0][0] == ["wslview", "https://microsoft.com"]
 
 
-def test_zellij_open_url_no_urls(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_no_urls(mock_subprocess_run):
     def side_effect_run(cmd, *args, **kwargs):
         if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
             file_path = cmd[3]
@@ -95,39 +105,93 @@ def test_zellij_open_url_no_urls(mock_subprocess_run, mock_os_execvpe):
 
     assert result.exit_code == 0
     assert "No URLs found." in result.stderr
-    mock_os_execvpe.assert_not_called()
+    # Only zellij call
+    assert mock_subprocess_run.call_count == 1
 
 
-def test_zellij_open_url_dump_fail(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_dump_fail(mock_subprocess_run):
     mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "zellij")
     result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 1
     assert "Failed to capture Zellij pane" in result.stderr
-    mock_os_execvpe.assert_not_called()
 
 
-def test_zellij_open_url_not_found(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_not_found(mock_subprocess_run):
     mock_subprocess_run.side_effect = FileNotFoundError("zellij")
     result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 1
     assert "Zellij command not found. Are you running inside Zellij?" in result.stderr
-    mock_os_execvpe.assert_not_called()
 
 
-def test_zellij_open_url_fzf_fail(mock_subprocess_run, mock_os_execvpe):
+def test_zellij_open_url_fzf_fail(mock_subprocess_run):
     def side_effect_run(cmd, *args, **kwargs):
         if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
             file_path = cmd[3]
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write("https://example.com")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            raise OSError("fzf failed")
         return MagicMock()
 
     mock_subprocess_run.side_effect = side_effect_run
-    mock_os_execvpe.side_effect = OSError("fzf failed")
 
     result = runner.invoke(app, ["zellij", "open-url"])
 
     assert result.exit_code == 1
     assert "Failed to execute fzf" in result.stderr
+
+
+def test_zellij_open_url_copy(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
+            file_path = cmd[3]
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write("https://example.com")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "ctrl-c\nhttps://example.com\n"
+            return mock
+        return MagicMock()
+
+    mock_subprocess_run.side_effect = side_effect_run
+
+    with patch("sys.platform", "linux"), patch("os.uname") as mock_uname:
+        mock_uname.return_value = MagicMock(release="5.15.0-generic")
+        result = runner.invoke(app, ["zellij", "open-url"])
+
+    assert result.exit_code == 0
+    assert mock_subprocess_run.call_count == 3
+    last_call = mock_subprocess_run.call_args_list[-1]
+    # xclip -selection clipboard
+    assert last_call[0][0] == ["xclip", "-selection", "clipboard"]
+    assert last_call[1]["input"] == "https://example.com"
+
+
+def test_zellij_open_url_injection_prevention(mock_subprocess_run):
+    def side_effect_run(cmd, *args, **kwargs):
+        if cmd[0] == "zellij" and cmd[1] == "action" and cmd[2] == "dump-screen":
+            file_path = cmd[3]
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write("https://example.com/$(id)")
+            return MagicMock()
+        if cmd[0] == "fzf":
+            mock = MagicMock()
+            mock.stdout = "enter\nhttps://example.com/$(id)\n"
+            return mock
+        return MagicMock()
+
+    mock_subprocess_run.side_effect = side_effect_run
+
+    with patch("sys.platform", "linux"), patch("os.uname") as mock_uname:
+        mock_uname.return_value = MagicMock(release="5.15.0-generic")
+        result = runner.invoke(app, ["zellij", "open-url"])
+
+    assert result.exit_code == 0
+    last_call = mock_subprocess_run.call_args_list[-1]
+    # It should be a single argument, not split by shell
+    assert last_call[0][0] == ["xdg-open", "https://example.com/$(id)"]
+    assert last_call[1].get("shell", False) is False


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in the `open-url` command of `termbud` (for both Zellij and Tmux).

⚠️ **Risk:** URLs extracted from the terminal scrollback were interpolated into `fzf` binding strings, which are executed via a shell. A malicious URL (e.g., one containing `$(command)`) could execute arbitrary commands on the user's system.

🛡️ **Solution:**
- Replaced `os.execvpe` and `fzf --bind` with `subprocess.run` and `fzf --expect`.
- The selection and key press are now returned to Python and processed safely.
- User-provided commands (`open_cmd`, `copy_cmd`) are parsed using `shlex.split()`.
- Commands are executed via `subprocess.run(..., shell=False)`, passing the URL as a direct argument.
- Improved temporary file cleanup using `try...finally`.
- Updated test suite to verify the fix and prevent regressions.

*Note: Due to missing dependencies in the sandbox environment (specifically `typer`), the full test suite could not be executed. However, the fix logic was verified with a standalone script and the modified files were checked for syntax and linting errors.*

---
*PR created automatically by Jules for task [14094158738251878890](https://jules.google.com/task/14094158738251878890) started by @mkobit*