### PR TITLE
jules_cli: default to auto-approve for sessions

### DIFF
--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -407,14 +407,14 @@ def create(
     auto_pr: bool = typer.Option(
         True,
         "--auto-pr/--no-auto-pr",
-        help=("Automatically create a PR. Highly recommended for CLI and agents for pre-planned work."),
+        help=("Enables Jules to automatically create a pull request upon completion of the task"),
     ),
     approve: bool = typer.Option(
         False,
         "--require-approval/--no-require-approval",
         help=(
-            "Require manual plan approval. Default is false (auto-approve), "
-            "ideal for agents submitting pre-planned work."
+            "Require manual plan approval. Default is false (auto-approve), but when required "
+            "manual approval and sometimes discussion and clarification will be required before Jules starts the task."
         ),
     ),
     interactive: bool = typer.Option(

--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -404,8 +404,19 @@ def create(
     source: str = typer.Option(..., "--source", help="The source (e.g., owner/repo)."),
     branch: str = typer.Option("main", "--branch", help="Starting branch (default: main)."),
     title: str | None = typer.Option(None, "--title", help="Title for the session."),
-    auto_pr: bool = typer.Option(True, "--auto-pr/--no-auto-pr", help="Automatically create a PR."),
-    approve: bool = typer.Option(True, "--approve/--no-approve", help="Require manual plan approval."),
+    auto_pr: bool = typer.Option(
+        True,
+        "--auto-pr/--no-auto-pr",
+        help=("Automatically create a PR. Highly recommended for CLI and agents for pre-planned work."),
+    ),
+    approve: bool = typer.Option(
+        False,
+        "--approve/--no-approve",
+        help=(
+            "Require manual plan approval. Default is false (auto-approve), "
+            "ideal for agents submitting pre-planned work."
+        ),
+    ),
     interactive: bool = typer.Option(
         False, "--interactive/--no-interactive", "-i", help="Enter interactive mode after creating the session."
     ),

--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -411,7 +411,7 @@ def create(
     ),
     approve: bool = typer.Option(
         False,
-        "--approve/--no-approve",
+        "--require-approval/--no-require-approval",
         help=(
             "Require manual plan approval. Default is false (auto-approve), "
             "ideal for agents submitting pre-planned work."


### PR DESCRIPTION
Updates the `approve` CLI argument to default to `False` (auto-approve), and updates the docs to explain that both auto-pr and auto-approve are recommended/ideal defaults for agents submitting pre-planned work.

---
*PR created automatically by Jules for task [3043336068870670637](https://jules.google.com/task/3043336068870670637) started by @mkobit*