### PR TITLE
fix(uv): skip exclude-newer config when min_release_age_days is 0

### DIFF
--- a/src/chezmoi/dot_config/uv/uv.toml.tmpl
+++ b/src/chezmoi/dot_config/uv/uv.toml.tmpl
@@ -1,4 +1,4 @@
-{{- if hasKey .uv "min_release_age_days" -}}
+{{- if and (hasKey .uv "min_release_age_days") (gt .uv.min_release_age_days 0) -}}
 {{- $config := dict "exclude-newer" (printf "P%dD" .uv.min_release_age_days) -}}
 {{- toToml $config -}}
 {{- end -}}


### PR DESCRIPTION
Older uv versions reject the ISO 8601 duration format (P7D). Work dotfiles can inject 0 to disable the config on remote machines.


Committed-By-Agent: claude