### PR TITLE
feat(claude): separate deployment config from UI preferences

### DIFF
--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -3,10 +3,18 @@ enabled = true
 version = "2.1.114"
 installation = "external-script"
 
+# Deployment config → managed via modify_settings.json.tmpl → ~/.claude/settings.json
+# These are operator/admin-level settings: permissions, env, tooling behavior.
+# See: https://docs.anthropic.com/en/docs/claude-code/settings
 [claude_code.settings]
-# https://code.claude.com/docs/en/settings
 cleanupPeriodDays = 30
 outputStyle = "concise"
+
+# UI preferences → managed via modify_dot_claude.json.tmpl → ~/.claude.json
+# Claude Code stores user-facing preferences (editorMode, etc.) in ~/.claude.json,
+# which it also uses as a mutable runtime state file (startup counts, feature flags, etc.).
+# We only inject our preferences — the rest of the file is left alone.
+[claude_code.preferences]
 editorMode = "vim"
 
 [claude_code.settings.sandbox]

--- a/src/chezmoi/dot_claude/AGENTS.md
+++ b/src/chezmoi/dot_claude/AGENTS.md
@@ -1,16 +1,25 @@
 # Claude Code configuration
 
-## Configuration files
+## Why two config files
 
-- **User settings**: `~/.claude/settings.json` (managed by `src/dot_claude/settings.json.tmpl`).
-- **Project settings**: `~/.claude/settings.local.json` (personal overrides).
+Claude Code splits configuration across two files for no obvious reason:
 
-## Configuration structure
+- `~/.claude/settings.json` — deployment config: permissions, env vars, sandbox, MCP servers, hooks.
+- `~/.claude.json` — UI preferences AND mutable runtime state: editor mode, startup counts, seen-tips history, feature flags.
 
-- **Source**: `src/.chezmoidata/claude_code.toml` under `[claude_code.settings]`.
-- **Render**: Uses `toPrettyJson` in the template.
+These are managed separately because Claude Code itself writes to `~/.claude.json` constantly.
+Injecting only preferences while leaving runtime state alone requires a modify script.
+
+## Managed files
+
+| Target | Chezmoi source | Data key |
+|---|---|---|
+| `~/.claude/settings.json` | `dot_claude/modify_settings.json.tmpl` | `claude_code.settings` |
+| `~/.claude.json` | `modify_dot_claude.json.tmpl` | `claude_code.preferences` |
+
+Both sources live in `src/.chezmoidata/claude_code.toml`.
 
 ## Feature control
 
-- Controlled by `claude_code.enabled` in `.chezmoidata/`.
-- If disabled, no Claude Code files are installed.
+Controlled by `claude_code.enabled` in `.chezmoidata/`.
+If disabled, no Claude Code files are installed.

--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -1,5 +1,7 @@
 {{- if .claude_code.enabled -}}
 #!/usr/bin/env python3
+# Manages ~/.claude/settings.json — deployment config only.
+# UI preferences (editorMode, etc.) live in ~/.claude.json; see modify_dot_claude.json.tmpl.
 import json
 import sys
 

--- a/src/chezmoi/modify_dot_claude.json.tmpl
+++ b/src/chezmoi/modify_dot_claude.json.tmpl
@@ -1,0 +1,22 @@
+{{- if .claude_code.enabled -}}
+#!/usr/bin/env python3
+# Manages ~/.claude.json — UI preferences only.
+# Claude Code uses this file as both a preferences store AND mutable runtime state
+# (startup counts, seen-tips history, feature flags, etc.). We only inject our
+# managed preferences and leave everything else untouched.
+# Deployment config (permissions, env, sandbox) lives in ~/.claude/settings.json;
+# see dot_claude/modify_settings.json.tmpl.
+import json
+import sys
+
+try:
+    existing = json.load(sys.stdin)
+except Exception:
+    existing = {}
+
+preferences = json.loads("""{{ .claude_code.preferences | toPrettyJson }}""")
+
+merged = {**existing, **preferences}
+
+print(json.dumps(merged, indent=2))
+{{- end }}


### PR DESCRIPTION
Claude Code splits its config across two files with no obvious reason:
- ~/.claude/settings.json: deployment config (permissions, env, sandbox)
- ~/.claude.json: UI preferences + mutable runtime state (editorMode, etc.)

Move editorMode to a new modify_dot_claude.json.tmpl targeting ~/.claude.json and add comments in both scripts and the data file explaining the split. Remove no-op editorMode from settings block.


Committed-By-Agent: claude