### PR TITLE
fix(cli): change default of auto-pr to False

### DIFF
--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -405,7 +405,7 @@ def create(
     branch: str = typer.Option("main", "--branch", help="Starting branch (default: main)."),
     title: str | None = typer.Option(None, "--title", help="Title for the session."),
     auto_pr: bool = typer.Option(
-        True,
+        False,
         "--auto-pr/--no-auto-pr",
         help=("Enables Jules to automatically create a pull request upon completion of the task"),
     ),

--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -461,7 +461,7 @@ def create(
         req = CreateSessionRequest(
             prompt=prompt,
             source_context=source_context,
-            automation_mode=AutomationMode.AUTO_CREATE_PR if auto_pr else None,
+            automation_mode=AutomationMode.AUTO_CREATE_PR if auto_pr else AutomationMode.AUTOMATION_MODE_UNSPECIFIED,
             title=title,
             require_plan_approval=approve,
         )


### PR DESCRIPTION
The `--auto-pr` option in `jules session create` was defaulting to `True` but documented as an option to *enable* auto-pr, leading to confusing behavior. Changed the default to `False` to align with the documentation and provide a clear opt-in experience.

---
*PR created automatically by Jules for task [15820209839010540361](https://jules.google.com/task/15820209839010540361) started by @mkobit*