### PR TITLE
feat(jules-cli): use positive messaging for auto-approve flag

### DIFF
--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -413,7 +413,7 @@ def create(
         True,
         "--auto-approve/--no-auto-approve",
         help=(
-            "Enables Jules to automatically approve generated plans. "
+            "Enables Jules to automatically approve generated plans. Enabled by default. "
             "When disabled (--no-auto-approve), manual approval is required before Jules starts the task."
         ),
     ),

--- a/src/python/jules_cli/jules_cli/main.py
+++ b/src/python/jules_cli/jules_cli/main.py
@@ -407,14 +407,14 @@ def create(
     auto_pr: bool = typer.Option(
         True,
         "--auto-pr/--no-auto-pr",
-        help=("Enables Jules to automatically create a pull request upon completion of the task"),
+        help=("Enables Jules to automatically create a pull request upon completion of the task. Enabled by default."),
     ),
-    approve: bool = typer.Option(
-        False,
-        "--require-approval/--no-require-approval",
+    auto_approve: bool = typer.Option(
+        True,
+        "--auto-approve/--no-auto-approve",
         help=(
-            "Require manual plan approval. Default is false (auto-approve), but when required "
-            "manual approval and sometimes discussion and clarification will be required before Jules starts the task."
+            "Enables Jules to automatically approve generated plans. "
+            "When disabled (--no-auto-approve), manual approval is required before Jules starts the task."
         ),
     ),
     interactive: bool = typer.Option(
@@ -463,7 +463,7 @@ def create(
             source_context=source_context,
             automation_mode=AutomationMode.AUTO_CREATE_PR if auto_pr else None,
             title=title,
-            require_plan_approval=approve,
+            require_plan_approval=not auto_approve,
         )
 
         async with JulesClient(api_key=api_key) as client:


### PR DESCRIPTION
This commit updates the CLI arguments in `jules_cli/main.py` for session creation to consistently use positive messaging for automatic features.

- The `approve` argument (with flag `--require-approval`) was inverted to `auto_approve` (with flag `--auto-approve`).
- The default value remains functionally identical (auto-approve by default) but is now more intuitively represented as `True`.
- Help text strings for both `--auto-approve` and `--auto-pr` were updated for better clarity and alignment.

---
*PR created automatically by Jules for task [4396600799010007408](https://jules.google.com/task/4396600799010007408) started by @mkobit*