### PR TITLE
fix(ghostty): use per-OS installation_method map

### DIFF
--- a/src/chezmoi/.chezmoidata/ghostty.toml
+++ b/src/chezmoi/.chezmoidata/ghostty.toml
@@ -1,2 +1,3 @@
-[ghostty]
-installation_method = "homebrew"
+[ghostty.installation_method]
+darwin = "homebrew"
+linux  = "snap"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ghostty.sh.tmpl
@@ -1,4 +1,5 @@
-{{- if eq .ghostty.installation_method "homebrew" }}#!/usr/bin/env bash
+{{- $method := dig "installation_method" .chezmoi.os "none" .ghostty -}}
+{{- if ne $method "none" }}#!/usr/bin/env bash
 
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -1,4 +1,5 @@
-{{- if eq .ghostty.installation_method "none" }}#!/usr/bin/env bash
+{{- $method := dig "installation_method" .chezmoi.os "none" .ghostty -}}
+{{- if eq $method "none" }}#!/usr/bin/env bash
 
 # logging.sh hash: {{ includeTemplate "shell/logging.sh" | sha256sum }}
 source "${CHEZMOI_SOURCE_DIR:?}/.chezmoitemplates/shell/logging.sh"


### PR DESCRIPTION
Use the same pattern as eza — darwin=homebrew, linux=snap — so the install/uninstall scripts are gated by OS. Work config overrides linux to "none" to disable on remote devboxes.


Committed-By-Agent: claude