### PR TITLE
🧹 Remove unused `Exceeds200kTokens` class from `models.py`

### DIFF
--- a/src/python/claude_statusline/claude_statusline/models.py
+++ b/src/python/claude_statusline/claude_statusline/models.py
@@ -43,10 +43,6 @@ class ContextWindowInfo(BaseModel):
     current_usage: CurrentUsageInfo | None = Field(default_factory=CurrentUsageInfo)
 
 
-class Exceeds200kTokens(BaseModel):
-    pass  # this is just a boolean, no need for a class
-
-
 class RateLimitWindow(BaseModel):
     used_percentage: float | None = 0.0
     resets_at: int | None = 0


### PR DESCRIPTION
🎯 **What:** Deleted the empty and unused `Exceeds200kTokens` Pydantic model from `src/python/claude_statusline/claude_statusline/models.py`.
💡 **Why:** The class had no fields, was not used anywhere in the codebase, and contained a comment explicitly stating it was unnecessary ("this is just a boolean, no need for a class"). Removing dead code improves readability and maintainability.
✅ **Verification:**
- Ran a global codebase search (`rg "Exceeds200kTokens"`) and confirmed no other usages exist.
- Executed linting (`uv tool run ruff check` and `uv run ty check`) successfully.
- Ran the `claude_statusline` test suite (`uv run pytest`) ensuring no functionality was broken.
✨ **Result:** A cleaner `models.py` file with dead code removed.

---
*PR created automatically by Jules for task [10140918696624060650](https://jules.google.com/task/10140918696624060650) started by @mkobit*