### PR TITLE
fix(shell): move zoxide init to end of rc modification scripts

### DIFF
--- a/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
+++ b/src/chezmoi/dot_dotfiles/bash/config.bash.tmpl
@@ -17,5 +17,3 @@
 {{ template "shell/starship.sh" $ctx }}
 {{ template "shell/keybindings.sh" $ctx }}
 {{ template "shell/eza.sh" $ctx }}
-{{- /* zoxide must be loaded last to ensure alias overrides and path precedence are correct */}}
-{{ template "shell/zoxide.sh" $ctx }}

--- a/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
+++ b/src/chezmoi/dot_dotfiles/zsh/config.zsh.tmpl
@@ -19,5 +19,3 @@
 {{ template "shell/starship.sh" $ctx }}
 {{ template "shell/keybindings.sh" $ctx }}
 {{ template "shell/eza.sh" $ctx }}
-{{- /* zoxide must be loaded last to ensure alias overrides and path precedence are correct */}}
-{{ template "shell/zoxide.sh" $ctx }}

--- a/src/chezmoi/modify_dot_bashrc.tmpl
+++ b/src/chezmoi/modify_dot_bashrc.tmpl
@@ -16,6 +16,9 @@ fi
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:bash:{{ include "modify_dot_bashrc.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
 source "{{ .chezmoi.destDir }}/.dotfiles/bash/config.bash"
+{{- $ctx := merge (dict "shell" "bash") . -}}
+{{- /* zoxide must be loaded last to ensure alias overrides and path precedence are correct */}}
+{{ template "shell/zoxide.sh" $ctx }}
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:bash:{{ include "modify_dot_bashrc.tmpl" | sha256sum | substr 0 8 }}
 EOF
 

--- a/src/chezmoi/modify_dot_zshrc.tmpl
+++ b/src/chezmoi/modify_dot_zshrc.tmpl
@@ -16,6 +16,9 @@ fi
 cat >> "${tempfile}" << 'EOF'
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:BEGIN:chezmoi:zsh:{{ include "modify_dot_zshrc.tmpl" | sha256sum | substr 0 8 }} - WARNING: managed by chezmoi, do not edit
 source {{ .chezmoi.destDir }}/.dotfiles/zsh/config.zsh
+{{- $ctx := merge (dict "shell" "zsh") . -}}
+{{- /* zoxide must be loaded last to ensure alias overrides and path precedence are correct */}}
+{{ template "shell/zoxide.sh" $ctx }}
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:zsh:{{ include "modify_dot_zshrc.tmpl" | sha256sum | substr 0 8 }}
 EOF
 


### PR DESCRIPTION
Move zoxide generation out of the sourced `config.zsh` and `config.bash` files and into the outermost layer of the `~/.bashrc` and `~/.zshrc` append scripts, guaranteeing that it loads completely last and retains alias priority (like `cd`) across the user's shell environments.

---
*PR created automatically by Jules for task [7728870385640864134](https://jules.google.com/task/7728870385640864134) started by @mkobit*