### PR TITLE
feat: globally ignore `.scratch/` directories

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
@@ -8,6 +8,6 @@
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf
 	autocrlf = input
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile
-	excludesFile = ~/.gitignore_global
+	excludesFile = ~/.dotfiles/git/snippets/gitignore_global
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefsmonitor
 	fsmonitor = true

--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -5,3 +5,4 @@
 *.swp
 *~
 /bazel-*
+.scratch/


### PR DESCRIPTION
Appended `.scratch/` to the global gitignore file managed by chezmoi (`gitignore_global`) to ensure throwaway agent directories aren't tracked. Also, correctly updated `core.gitconfig.tmpl` to directly reference the deployed dotfiles location (`~/.dotfiles/git/snippets/gitignore_global`) instead of implicitly assuming a symlinked `~/.gitignore_global`.

---
*PR created automatically by Jules for task [11567691065663520448](https://jules.google.com/task/11567691065663520448) started by @mkobit*