### PR TITLE
feat(chezmoi): add global .rgignore with default exclusions

### DIFF
--- a/src/chezmoi/dot_rgignore
+++ b/src/chezmoi/dot_rgignore
@@ -1,0 +1,28 @@
+# General build directories
+build/
+dist/
+out/
+target/
+
+# Node
+node_modules/
+.next/
+
+# Python
+.venv/
+venv/
+env/
+.env/
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+
+# OS/IDE
+.DS_Store
+.idea/
+.vscode/
+
+# Other caches
+.cache/


### PR DESCRIPTION
Added `src/chezmoi/dot_rgignore` to manage global ripgrep configurations and ignore noisy build and cache output.

---
*PR created automatically by Jules for task [4004516584253053139](https://jules.google.com/task/4004516584253053139) started by @mkobit*