### PR TITLE
feat(zellij): data-driven keybinds via zellij.modes.<mode>.keybinds

### DIFF
--- a/src/chezmoi/.chezmoidata/zellij.toml
+++ b/src/chezmoi/.chezmoidata/zellij.toml
@@ -1,7 +1,15 @@
-# Zellij data defaults. Overlay environments may override via [data.zellij.config].
+# Zellij data defaults. Overlay environments may override via [data.zellij.*].
 # Layout files live in dot_config/zellij/layouts/ — each environment owns its own.
-# Docs: https://zellij.dev/documentation/creating-a-layout
+# Docs: https://zellij.dev/documentation/configuration
 
 [zellij.config]
 scrollback_lines_to_serialize = 75000
 show_startup_tips             = true
+
+# Keybinds per mode. Keys are unique bind identifiers (e.g. alt-a); values are
+# raw KDL bind lines. Map keys merge across chezmoidata + overlay [data.*].
+# Empty string suppresses a bind from an inner layer.
+# Available modes: normal locked resize pane move tab scroll search session tmux
+# Custom modes not yet supported: https://github.com/zellij-org/zellij/issues/248
+# https://zellij.dev/documentation/keybindings-modes
+[zellij.modes.normal.keybinds]

--- a/src/chezmoi/.chezmoidata/zellij.toml
+++ b/src/chezmoi/.chezmoidata/zellij.toml
@@ -6,9 +6,55 @@
 scrollback_lines_to_serialize = 75000
 show_startup_tips             = true
 
+# Plugin aliases. Keys are alias names used in layouts and keybinds.
+# location: plugin URL — zellij:<name>, file:/path, https://, or bare alias
+# config:   optional plugin-specific key/value configuration
+# Overlay environments extend by adding keys; overwrite by redefining a key.
+# https://zellij.dev/documentation/plugin-aliases
+[zellij.plugins.about]
+location = "zellij:about"
+
+[zellij.plugins.compact-bar]
+location = "zellij:compact-bar"
+
+[zellij.plugins.configuration]
+location = "zellij:configuration"
+
+[zellij.plugins.filepicker]
+location = "zellij:strider"
+[zellij.plugins.filepicker.config]
+cwd = "/"
+
+[zellij.plugins.plugin-manager]
+location = "zellij:plugin-manager"
+
+[zellij.plugins.session-manager]
+location = "zellij:session-manager"
+
+[zellij.plugins.status-bar]
+location = "zellij:status-bar"
+
+[zellij.plugins.strider]
+location = "zellij:strider"
+
+[zellij.plugins.tab-bar]
+location = "zellij:tab-bar"
+
+[zellij.plugins.welcome-screen]
+location = "zellij:session-manager"
+[zellij.plugins.welcome-screen.config]
+welcome_screen = true
+
+# Plugins loaded in the background on session start.
+# Keys are alias names or URLs; value true = load, false = suppress.
+# https://zellij.dev/documentation/plugin-loading
+[zellij.load_plugins]
+"zellij:link" = true
+
 # Keybinds per mode. Keys are unique bind identifiers (e.g. alt-a); values are
 # raw KDL bind lines. Map keys merge across chezmoidata + overlay [data.*].
 # Empty string suppresses a bind from an inner layer.
+# clear_defaults = true on a mode emits "keybinds clear-defaults=true" for that block.
 # Available modes: normal locked resize pane move tab scroll search session tmux
 # Custom modes not yet supported: https://github.com/zellij-org/zellij/issues/248
 # https://zellij.dev/documentation/keybindings-modes

--- a/src/chezmoi/dot_config/zellij/config.kdl.tmpl
+++ b/src/chezmoi/dot_config/zellij/config.kdl.tmpl
@@ -1,13 +1,39 @@
 // Keybind overrides only — zellij built-in defaults are preserved.
 // Tmux mode is disabled by unbinding Ctrl b everywhere it would activate.
+// https://zellij.dev/documentation/keybindings
 keybinds {
     shared_except "locked" "scroll" "search" "tmux" {
         unbind "Ctrl b"
     }
 }
+{{- /*
+  Emit one keybinds block per mode that has entries.
+  Data path: zellij.modes.<mode>.keybinds
+    Keys:   unique bind identifiers (e.g. alt-a) — used only for map merge uniqueness
+    Values: raw KDL bind line, or empty string to suppress a bind from an inner layer
+  Map keys deep-merge across chezmoidata + overlay [data.zellij.modes.*] injection.
+  clear_defaults=true on a mode emits "keybinds clear-defaults=true" for that block.
+  Custom modes unsupported until: https://github.com/zellij-org/zellij/issues/248
+*/ -}}
+{{- range $mode, $modeData := (dig "zellij" "modes" (dict) .) }}
+{{-   $keybinds := dig "keybinds" (dict) $modeData }}
+{{-   $clear    := dig "clear_defaults" false $modeData }}
+{{-   if $keybinds }}
+keybinds{{ if $clear }} clear-defaults=true{{ end }} {
+    {{ $mode }} {
+{{-     range $_, $line := $keybinds }}
+{{-       if $line }}
+        {{ $line }}
+{{-       end }}
+{{-     end }}
+    }
+}
+{{-   end }}
+{{- end }}
 
-// Plugin aliases - can be used to change the implementation of Zellij
-// changing these requires a restart to take effect
+// Plugin aliases - can be used to change the implementation of Zellij.
+// Changing these requires a restart to take effect.
+// https://zellij.dev/documentation/plugins
 plugins {
     about location="zellij:about"
     compact-bar location="zellij:compact-bar"
@@ -25,10 +51,11 @@ plugins {
     }
 }
 
-// Plugins to load in the background when a new session starts
+// Plugins to load in the background when a new session starts.
 load_plugins {
     zellij:link
 }
+
 web_client {
     font "monospace"
 }

--- a/src/chezmoi/dot_config/zellij/config.kdl.tmpl
+++ b/src/chezmoi/dot_config/zellij/config.kdl.tmpl
@@ -9,10 +9,9 @@ keybinds {
 {{- /*
   Emit one keybinds block per mode that has entries.
   Data path: zellij.modes.<mode>.keybinds
-    Keys:   unique bind identifiers (e.g. alt-a) — used only for map merge uniqueness
+    Keys:   unique bind identifiers (e.g. alt-a) — only for map merge uniqueness
     Values: raw KDL bind line, or empty string to suppress a bind from an inner layer
-  Map keys deep-merge across chezmoidata + overlay [data.zellij.modes.*] injection.
-  clear_defaults=true on a mode emits "keybinds clear-defaults=true" for that block.
+  clear_defaults = true on a mode emits "keybinds clear-defaults=true" for that block.
   Custom modes unsupported until: https://github.com/zellij-org/zellij/issues/248
 */ -}}
 {{- range $mode, $modeData := (dig "zellij" "modes" (dict) .) }}
@@ -31,29 +30,31 @@ keybinds{{ if $clear }} clear-defaults=true{{ end }} {
 {{-   end }}
 {{- end }}
 
-// Plugin aliases - can be used to change the implementation of Zellij.
-// Changing these requires a restart to take effect.
-// https://zellij.dev/documentation/plugins
+// Plugin aliases — alias name → location URL with optional config block.
+// Data path: zellij.plugins.<alias>.location + zellij.plugins.<alias>.config
+// Overlay environments add aliases or override existing ones via [data.zellij.plugins.*].
+// https://zellij.dev/documentation/plugin-aliases
 plugins {
-    about location="zellij:about"
-    compact-bar location="zellij:compact-bar"
-    configuration location="zellij:configuration"
-    filepicker location="zellij:strider" {
-        cwd "/"
-    }
-    plugin-manager location="zellij:plugin-manager"
-    session-manager location="zellij:session-manager"
-    status-bar location="zellij:status-bar"
-    strider location="zellij:strider"
-    tab-bar location="zellij:tab-bar"
-    welcome-screen location="zellij:session-manager" {
-        welcome_screen true
-    }
+{{- range $alias, $plugin := (dig "zellij" "plugins" (dict) .) }}
+    {{ $alias }} location={{ dig "location" "" $plugin | quote }}
+{{-   $cfg := dig "config" (dict) $plugin }}
+{{-   if $cfg }} {
+{{-     range $k, $v := $cfg }}
+        {{ $k }} {{ if eq (kindOf $v) "string" }}{{ $v | quote }}{{ else }}{{ $v }}{{ end }}
+{{-     end }}
+    }{{ end }}
+{{- end }}
 }
 
-// Plugins to load in the background when a new session starts.
+// Plugins loaded in the background on session start.
+// Data path: zellij.load_plugins — keys are alias names or URLs, false suppresses.
+// https://zellij.dev/documentation/plugin-loading
 load_plugins {
-    zellij:link
+{{- range $location, $enabled := (dig "zellij" "load_plugins" (dict) .) }}
+{{-   if $enabled }}
+    {{ $location }}
+{{-   end }}
+{{- end }}
 }
 
 web_client {

--- a/tests/integration/test_zellij.py
+++ b/tests/integration/test_zellij.py
@@ -20,6 +20,6 @@ def test_zellij_version(host, shell_cmd):
 
 @pytest.mark.integration
 def test_zellij_config_valid(host):
-    """Verify that zellij configuration is valid."""
+    """Verify zellij accepts the deployed config."""
     result = host.run("zellij setup --check")
     assert result.rc == 0, f"zellij config is invalid.\nstderr: {result.stderr}\nstdout: {result.stdout}"


### PR DESCRIPTION
Keybinds declared as maps under zellij.modes.<mode>.keybinds — keys are unique bind identifiers, values are raw KDL bind lines. Map keys deep-merge across chezmoidata and overlay [data.*] injection so overlays extend or suppress personal binds without separate key paths.

Supports clear_defaults=true per mode for full mode overrides. Empty string value suppresses an inherited bind.