### PR TITLE
fix: disable git optional locks to prevent index.lock contention

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/git_alias.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/git_alias.sh
@@ -1,2 +1,8 @@
 # Git alias
 alias g='git'
+
+# Prevent prompt tools (Starship, claude-statusline, etc.) from acquiring the
+# advisory index.lock during read-only operations like `git status`.
+# Safe with fsmonitor active — change tracking is handled by the daemon,
+# so the stat cache write-back that optional locks normally perform is redundant.
+export GIT_OPTIONAL_LOCKS=0


### PR DESCRIPTION
Prompt tools (Starship git_status, claude-statusline) run `git status` on every prompt render / Claude event, acquiring the advisory index.lock to write back the stat cache. In large repos with multiple concurrent callers this causes frequent lock conflicts.

Setting GIT_OPTIONAL_LOCKS=0 skips the advisory lock for read-only operations. The stat cache penalty is negligible where fsmonitor is active (change tracking is daemon-handled anyway).


Committed-By-Agent: claude