### PR TITLE
style(starship): fix unicode typo and trim space in obsidian prompt

### DIFF
--- a/src/chezmoi/dot_config/starship.toml
+++ b/src/chezmoi/dot_config/starship.toml
@@ -21,5 +21,5 @@ disabled = true # Disables the package version module (e.g. Node.js/Rust version
 
 [custom.obsidian]
 detect_folders = [".obsidian"]
-format = "on [\uf039a Obsidian vault]($style) "
+format = "on [\uf039 Obsidian]($style) "
 style = "bold #8B5CF6"


### PR DESCRIPTION
This patch fixes a formatting typo where the Unicode escape sequence for the custom Obsidian prompt icon inadvertently had a trailing `a` (`\uf039a` -> `\uf039`). It also shortens the text from "Obsidian vault" to "Obsidian" to trim terminal space per the user's request.

---
*PR created automatically by Jules for task [8765003244025845460](https://jules.google.com/task/8765003244025845460) started by @mkobit*