### PR TITLE
feat: migrate claude-statusline to use rich.Table

### DIFF
--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -1,5 +1,8 @@
-from collections import defaultdict
 from collections.abc import Iterable
+
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
 
 from claude_statusline.models import GitInfo, SegmentGenerationResult, StatusLineStdIn
 from claude_statusline.segments.constants import get_icon
@@ -13,16 +16,55 @@ def render_lines(
     """Renders the statusline as a list of strings."""
     sep = f" {get_icon('dot')} "
 
-    lines_map = defaultdict(list)
-    for seg in segments:
-        if seg.line <= 3:
-            lines_map[seg.line].append(seg)
+    # Extract segments to a list for multiple passes
+    segments_list = list(segments)
+    if not segments_list:
+        return []
 
-    result_lines = []
-    for line_num in sorted(lines_map.keys()):
-        line_segments = sorted(lines_map[line_num], key=lambda s: (s.index, s.generator))
-        text = sep.join(s.segment.text for s in line_segments)
-        if text:
-            result_lines.append(text)
+    # Find unique columns (indices) and rows (lines)
+    all_indices = sorted({seg.index for seg in segments_list})
+    all_lines = sorted({seg.line for seg in segments_list})
 
-    return result_lines
+    # Group segments by line then by index
+    # We might have multiple segments with the same line and index, though
+    # ideally we wouldn't. We'll join them with sep if they exist.
+    grid_data = {}
+    for line in all_lines:
+        grid_data[line] = {}
+        for index in all_indices:
+            grid_data[line][index] = []
+
+    for seg in segments_list:
+        grid_data[seg.line][seg.index].append(seg)
+
+    # Build the rich table
+    table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 2))
+
+    # Add columns for each unique index
+    for _ in all_indices:
+        table.add_column()
+
+    for line in all_lines:
+        row_cells = []
+        for index in all_indices:
+            segs = grid_data[line][index]
+            # Multiple segments in the same cell get joined
+            text_str = sep.join(s.segment.text for s in sorted(segs, key=lambda x: x.generator))
+
+            if text_str:
+                row_cells.append(Text.from_ansi(text_str))
+            else:
+                row_cells.append(Text.from_ansi(""))
+
+        table.add_row(*row_cells)
+
+    # Use a wide console to prevent line wrapping during string extraction
+    console = Console(width=2000, force_terminal=True, color_system="truecolor", highlight=False)
+    with console.capture() as capture:
+        console.print(table)
+
+    output_lines = capture.get().splitlines()
+
+    # Strip any extra completely empty lines at the end that Rich might add,
+    # but keep lines with content (even just spaces if they were formatted)
+    return [line.rstrip() for line in output_lines if line.strip()]

--- a/src/python/claude_statusline/pyproject.toml
+++ b/src/python/claude_statusline/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.12.5",
+    "rich>=15.0.0",
     "typer>=0.15.1",
     "whenever>=0.9.5",
 ]

--- a/src/python/claude_statusline/tests/test_render.py
+++ b/src/python/claude_statusline/tests/test_render.py
@@ -1,0 +1,33 @@
+import unittest
+
+from claude_statusline.models import Segment, SegmentGenerationResult, StatusLineStdIn
+from claude_statusline.render import render_lines
+
+
+class TestRenderLines(unittest.TestCase):
+    def test_render_lines_groups_by_line_and_aligns_columns(self):
+        payload = StatusLineStdIn()
+
+        segments = [
+            SegmentGenerationResult(line=0, index=0, segment=Segment(text="A0")),
+            SegmentGenerationResult(line=0, index=10, segment=Segment(text="A10")),
+            SegmentGenerationResult(line=1, index=0, segment=Segment(text="B0")),
+            # Missing index 10 in line 1
+            SegmentGenerationResult(line=2, index=0, segment=Segment(text="C0")),
+            SegmentGenerationResult(line=2, index=10, segment=Segment(text="C10")),
+        ]
+
+        lines = render_lines(payload, None, segments)
+
+        # We should have 3 lines of output.
+        # Line 0: "A0   A10"
+        # Line 1: "B0      "
+        # Line 2: "C0   C10"
+
+        self.assertEqual(len(lines), 3)
+        # Because we're using Rich, exact whitespace might differ depending on padding,
+        # but the order and alignment should be there.
+        self.assertTrue("A0" in lines[0] and "A10" in lines[0])
+        self.assertTrue("B0" in lines[1])
+        self.assertFalse("B10" in lines[1])
+        self.assertTrue("C0" in lines[2] and "C10" in lines[2])

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-17T20:25:27.209891793Z"
+exclude-newer = "2026-04-22T17:54:55.708831838Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -166,6 +166,7 @@ version = "0.0.0"
 source = { editable = "src/python/claude_statusline" }
 dependencies = [
     { name = "pydantic" },
+    { name = "rich" },
     { name = "typer" },
     { name = "whenever" },
 ]
@@ -181,6 +182,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "rich", specifier = ">=15.0.0" },
     { name = "typer", specifier = ">=0.15.1" },
     { name = "whenever", specifier = ">=0.9.5" },
 ]


### PR DESCRIPTION
This commit introduces the `rich` library as a dependency to the `claude-statusline` python module, and refactors `claude_statusline.render.render_lines` to lay out segments into an aligned tabular console output rather than simple string appending.

---
*PR created automatically by Jules for task [2638305695657451379](https://jules.google.com/task/2638305695657451379) started by @mkobit*