### PR TITLE
Fix duplicate gemini entry in mise lockfile

### DIFF
--- a/src/chezmoi/dot_config/mise/AGENTS.md
+++ b/src/chezmoi/dot_config/mise/AGENTS.md
@@ -23,16 +23,16 @@ Follow these steps exactly when updating any mise-managed tool version.
 Do not substitute alternative commands — especially in Jules, where `mise lock` destroys the shell session permanently and irrevocably.
 
 1. Update the version in `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.global_tools.<tool>]`.
-2. Render the template to the home directory (bypassing chezmoi state issues):
+2. Apply the config to the home directory:
    ```
-   chezmoi execute-template < src/chezmoi/dot_config/mise/config.toml.tmpl > ~/.config/mise/config.toml
+   chezmoi apply ~/.config/mise/config.toml
    ```
 3. Regenerate the lockfile:
    ```
    MISE_LOCKED=0 mise -C ~ lock --global
    ```
    The `-C ~` flag is required — running from the dotfiles repo root causes global-only tools (e.g. `uv`) to be excluded because the local `.mise.toml` claims them.
-4. Copy the freshly pruned lockfile back into the source repository:
+4. Copy the lockfile back to the chezmoi source:
    ```
-   cp ~/.config/mise/mise.lock src/chezmoi/dot_config/mise/mise.lock
+   chezmoi add ~/.config/mise/mise.lock
    ```

--- a/src/chezmoi/dot_config/mise/AGENTS.md
+++ b/src/chezmoi/dot_config/mise/AGENTS.md
@@ -23,16 +23,16 @@ Follow these steps exactly when updating any mise-managed tool version.
 Do not substitute alternative commands — especially in Jules, where `mise lock` destroys the shell session permanently and irrevocably.
 
 1. Update the version in `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.global_tools.<tool>]`.
-2. Apply the config to the home directory:
+2. Render the template to the home directory (bypassing chezmoi state issues):
    ```
-   chezmoi apply ~/.config/mise/config.toml
+   chezmoi execute-template < src/chezmoi/dot_config/mise/config.toml.tmpl > ~/.config/mise/config.toml
    ```
 3. Regenerate the lockfile:
    ```
    MISE_LOCKED=0 mise -C ~ lock --global
    ```
    The `-C ~` flag is required — running from the dotfiles repo root causes global-only tools (e.g. `uv`) to be excluded because the local `.mise.toml` claims them.
-4. Copy the lockfile back to the chezmoi source:
+4. Copy the freshly pruned lockfile back into the source repository:
    ```
-   chezmoi add ~/.config/mise/mise.lock
+   cp ~/.config/mise/mise.lock src/chezmoi/dot_config/mise/mise.lock
    ```

--- a/src/chezmoi/dot_config/mise/mise.lock
+++ b/src/chezmoi/dot_config/mise/mise.lock
@@ -104,9 +104,6 @@ url = "https://nodejs.org/dist/v22.14.0/node-v22.14.0-win-x64.zip"
 checksum = "sha256:55b639295920b219bb2acbcfa00f90393a2789095b7323f79475c9f34795f217"
 url = "https://nodejs.org/dist/v22.14.0/node-v22.14.0-win-x64.zip"
 
-[[tools."npm:@google/gemini-cli"]]
-version = "0.35.3"
-backend = "npm:@google/gemini-cli"
 
 [[tools.pnpm]]
 version = "10.33.0"


### PR DESCRIPTION
This commit resolves an issue where running `mise install` or updating the configuration in one terminal would leave another terminal stuck on an older version of `gemini-cli` (e.g., `0.37.0` instead of `0.40.0`).

The root cause was a duplicate definition for the tool inside `src/chezmoi/dot_config/mise/mise.lock`. There was both a `[[tools.gemini-cli]]` and an older `[[tools."npm:@google/gemini-cli"]]` entry. This confused `mise` when operating in `--locked` mode (which is default for this repository) because the alias mapping was ambiguous or conflicted.

Removing the duplicate block ensures `mise ls` successfully resolves `gemini-cli 0.40.0` from the repository configuration without throwing lockfile sync warnings.

---
*PR created automatically by Jules for task [8176196094214841733](https://jules.google.com/task/8176196094214841733) started by @mkobit*