### PR TITLE
chore(wsl): update wsl memory to 16GB

### DIFF
--- a/src/chezmoi/.chezmoidata/wsl.toml
+++ b/src/chezmoi/.chezmoidata/wsl.toml
@@ -1,7 +1,7 @@
 [wsl]
 
 [wsl.wsl2]
-memory = "6GB"
+memory = "16GB"
 swap = "2GB"
 processors = 4
 


### PR DESCRIPTION
Increases the WSL memory limit from 6GB to 16GB.

**Heads up:** To avoid going out of memory (OOM) and crashing under heavy workloads, you can also increase the system swap. This is done by modifying the `swap` value (currently `"2GB"`) under the `[wsl.wsl2]` section in `src/chezmoi/.chezmoidata/wsl.toml`. Updating this file will automatically regenerate your Windows `.wslconfig` with the new swap limits.

---
*PR created automatically by Jules for task [3391309565896211102](https://jules.google.com/task/3391309565896211102) started by @mkobit*