### PR TITLE
feat(starship): disable nodejs, ruby, and git_status on remote machines

### DIFF
--- a/src/chezmoi/.chezmoidata/starship.toml
+++ b/src/chezmoi/.chezmoidata/starship.toml
@@ -1,2 +1,0 @@
-[starship]
-ignore_branches = ["main", "master"]

--- a/src/chezmoi/dot_config/.chezmoidata/starship.toml
+++ b/src/chezmoi/dot_config/.chezmoidata/starship.toml
@@ -1,0 +1,11 @@
+[starship]
+ignore_branches = ["main", "master"]
+
+[starship.modules.nodejs]
+enabled = true
+
+[starship.modules.ruby]
+enabled = true
+
+[starship.modules.git_status]
+enabled = true

--- a/src/chezmoi/dot_config/starship.toml.tmpl
+++ b/src/chezmoi/dot_config/starship.toml.tmpl
@@ -24,5 +24,14 @@ detect_folders = [".obsidian"]
 format = "on [\uf039 Obsidian]($style) "
 style = "bold #8B5CF6"
 
+[nodejs]
+disabled = {{ not (dig "starship" "modules" "nodejs" "enabled" true .) }}
+
+[ruby]
+disabled = {{ not (dig "starship" "modules" "ruby" "enabled" true .) }}
+
+[git_status]
+disabled = {{ not (dig "starship" "modules" "git_status" "enabled" true .) }}
+
 [git_branch]
 ignore_branches = {{ dig "starship" "ignore_branches" list . | toToml }}


### PR DESCRIPTION
Move starship data to dot_config/.chezmoidata/starship.toml, co-located with the template. Add enabled flags (default true) for nodejs, ruby, and git_status modules; overlay sets these to false for non-local environments.


Committed-By-Agent: claude