### PR TITLE
fix(zoxide): only initialize in interactive shells

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/zoxide.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zoxide.sh
@@ -1,5 +1,8 @@
 # Zoxide - smart directory jumping
-if command -v zoxide &> /dev/null; then
+# Only initialize in interactive shells: non-interactive shells (scripts, AI
+# agent sessions) don't benefit from directory tracking and the chpwd hook
+# will never fire, which triggers zoxide's own doctor warning spuriously.
+if [[ -o interactive ]] && command -v zoxide &> /dev/null; then
     {{- if eq .shell "zsh" }}
     eval "$(zoxide init zsh --cmd cd)"
     {{- else if eq .shell "bash" }}

--- a/tests/integration/test_zsh.py
+++ b/tests/integration/test_zsh.py
@@ -2,6 +2,25 @@ import pytest
 
 
 @pytest.mark.integration
+def test_zsh_non_interactive_no_zoxide_doctor(host):
+    """Verify that a non-interactive zsh shell does not trigger the zoxide doctor warning.
+
+    The zoxide chpwd hook only fires in interactive shells, so initializing
+    zoxide in non-interactive contexts is pointless and causes a spurious
+    doctor warning every time `cd` is called (e.g. in AI agent sessions).
+    """
+    # Source .zshrc explicitly so the zsh config is loaded but the shell is
+    # still non-interactive. Before the fix, this would trigger the zoxide
+    # doctor warning because the chpwd hook was registered in non-interactive
+    # contexts where it can never fire.
+    result = host.run("zsh -c 'source ~/.zshrc; cd /tmp; cd -'")
+
+    assert "zoxide: detected a possible configuration issue" not in result.stderr, (
+        f"zoxide doctor warning fired in non-interactive shell:\n{result.stderr}"
+    )
+
+
+@pytest.mark.integration
 def test_zsh_initialization(host):
     """Verify that zsh initializes without errors."""
 


### PR DESCRIPTION
Non-interactive shells (scripts, AI agent sessions) do not benefit from zoxide's directory tracking — the chpwd hook never fires in these contexts. Initializing unconditionally caused zoxide's own doctor check to warn on every `cd` call because `__zoxide_hook` was missing from `chpwd_functions`.

Guard the entire init block with `[[ -o interactive ]]` so non-interactive shells get the plain builtin `cd` with no spurious warnings.

Add a regression test that sources .zshrc in a non-interactive shell and verifies the doctor warning is absent.

Committed-By-Agent: claude