### PR TITLE
feat(shell): auto-load zellij completions in bash and zsh

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/zellij.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zellij.sh
@@ -4,6 +4,11 @@
 alias zj="zellij"
 alias zja="zellij attach"
 
+# Initialize zellij completions
+if command -v zellij >/dev/null 2>&1; then
+    eval "$(zellij setup --generate-completion {{ .shell }})"
+fi
+
 # Custom fzf completion for zellij sessions triggered by **<TAB>
 # fzf's bash/zsh completion scripts automatically detect and use these functions
 # when the user types 'zellij attach **<TAB>' or 'zja **<TAB>'

--- a/src/chezmoi/.chezmoitemplates/shell/zellij.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zellij.sh
@@ -6,7 +6,14 @@ alias zja="zellij attach"
 
 # Initialize zellij completions
 if command -v zellij >/dev/null 2>&1; then
-    eval "$(zellij setup --generate-completion {{ .shell }})"
+    # Zellij outputs a literal call to `_zellij "$@"` at the bottom of its generated zsh completion script.
+    # Evaluating this directly in `.zshrc` throws errors (like 'command not found: _arguments').
+    # We strip out the `_zellij "$@"` execution and leave only the definitions and aliases.
+    if [[ "{{ .shell }}" == "zsh" ]]; then
+        eval "$(zellij setup --generate-completion zsh | grep -v '^_zellij "$@"$')"
+    else
+        eval "$(zellij setup --generate-completion {{ .shell }})"
+    fi
 fi
 
 # Custom fzf completion for zellij sessions triggered by **<TAB>


### PR DESCRIPTION
This commit configures shell initializations (for both bash and zsh) to dynamically load and evaluate Zellij's built-in completion logic when the `zellij` binary is found in the path. Evaluates `zellij setup --generate-completion {{ .shell }}` inside the centralized `zellij.sh` template.

---
*PR created automatically by Jules for task [12653853018763000433](https://jules.google.com/task/12653853018763000433) started by @mkobit*