### PR TITLE
Configure editor to nvim and update shell VISUAL variable

### DIFF
--- a/src/chezmoi/.chezmoidata/zellij.toml
+++ b/src/chezmoi/.chezmoidata/zellij.toml
@@ -5,7 +5,6 @@
 [zellij.config]
 scrollback_lines_to_serialize = 75000
 show_startup_tips             = true
-scrollback_editor             = "nvim"
 
 # Plugin aliases. Keys are alias names used in layouts and keybinds.
 # location: plugin URL — zellij:<name>, file:/path, https://, or bare alias

--- a/src/chezmoi/.chezmoidata/zellij.toml
+++ b/src/chezmoi/.chezmoidata/zellij.toml
@@ -5,6 +5,7 @@
 [zellij.config]
 scrollback_lines_to_serialize = 75000
 show_startup_tips             = true
+scrollback_editor             = "nvim"
 
 # Plugin aliases. Keys are alias names used in layouts and keybinds.
 # location: plugin URL — zellij:<name>, file:/path, https://, or bare alias

--- a/src/chezmoi/.chezmoitemplates/shell/editor.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/editor.sh
@@ -4,3 +4,14 @@ if command -v nvim >/dev/null 2>&1; then
 elif command -v vim >/dev/null 2>&1; then
     export EDITOR=vim
 fi
+
+# Set VISUAL to a GUI editor if available, otherwise fallback to EDITOR
+if command -v cursor >/dev/null 2>&1; then
+    export VISUAL=cursor
+elif command -v code >/dev/null 2>&1; then
+    export VISUAL=code
+elif command -v idea >/dev/null 2>&1; then
+    export VISUAL=idea
+else
+    export VISUAL="$EDITOR"
+fi

--- a/src/chezmoi/dot_config/zellij/config.kdl.tmpl
+++ b/src/chezmoi/dot_config/zellij/config.kdl.tmpl
@@ -81,8 +81,3 @@ scrollback_lines_to_serialize {{ .zellij.config.scrollback_lines_to_serialize }}
 
 // https://zellij.dev/documentation/options#show_startup_tips
 show_startup_tips {{ .zellij.config.show_startup_tips }}
-
-// https://zellij.dev/documentation/options#scrollback_editor
-{{- if hasKey .zellij.config "scrollback_editor" }}
-scrollback_editor "{{ .zellij.config.scrollback_editor }}"
-{{- end }}

--- a/src/chezmoi/dot_config/zellij/config.kdl.tmpl
+++ b/src/chezmoi/dot_config/zellij/config.kdl.tmpl
@@ -81,3 +81,8 @@ scrollback_lines_to_serialize {{ .zellij.config.scrollback_lines_to_serialize }}
 
 // https://zellij.dev/documentation/options#show_startup_tips
 show_startup_tips {{ .zellij.config.show_startup_tips }}
+
+// https://zellij.dev/documentation/options#scrollback_editor
+{{- if hasKey .zellij.config "scrollback_editor" }}
+scrollback_editor "{{ .zellij.config.scrollback_editor }}"
+{{- end }}


### PR DESCRIPTION
This PR updates the system editor variables and explicit configurations for Zellij to improve the terminal scrolling experience.

Changes:
1. `src/chezmoi/.chezmoitemplates/shell/editor.sh`:
   - Kept `$EDITOR` priority: `nvim` -> `vim`.
   - Added logic to set `$VISUAL` to prefer a GUI editor (`cursor`, `code`, `idea`) if available, otherwise it falls back to `$EDITOR`.

2. `src/chezmoi/.chezmoidata/zellij.toml`:
   - Configured `scrollback_editor = "nvim"` under `[zellij.config]`. This ensures Zellij pane scrollbacks always open in a terminal editor instead of defaulting to a GUI editor.

3. `src/chezmoi/dot_config/zellij/config.kdl.tmpl`:
   - Added KDL templating logic to conditionally render `scrollback_editor` if it is present in the `zellij.config` dot data object.

---
*PR created automatically by Jules for task [3809846742715703112](https://jules.google.com/task/3809846742715703112) started by @mkobit*