### PR TITLE
feat(wsl): enable systemd in wsl.conf

### DIFF
--- a/src/chezmoi/.chezmoidata/wsl.toml
+++ b/src/chezmoi/.chezmoidata/wsl.toml
@@ -8,3 +8,6 @@ processors = 4
 [wsl.experimental]
 autoMemoryReclaim = "gradual"
 sparseVhd = true
+
+[wsl.boot]
+systemd = true

--- a/src/chezmoi/.chezmoitemplates/wsl/wsl.conf
+++ b/src/chezmoi/.chezmoitemplates/wsl/wsl.conf
@@ -1,2 +1,5 @@
+# Official Microsoft Documentation for .wsl.conf settings:
+# https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconf
+
 [boot]
 systemd={{ .wsl.boot.systemd }}

--- a/src/chezmoi/.chezmoitemplates/wsl/wsl.conf
+++ b/src/chezmoi/.chezmoitemplates/wsl/wsl.conf
@@ -1,0 +1,2 @@
+[boot]
+systemd={{ .wsl.boot.systemd }}

--- a/src/chezmoi/run_onchange_after_wslconf.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_wslconf.sh.tmpl
@@ -1,0 +1,15 @@
+{{- if and (eq .chezmoi.os "linux") (contains "microsoft" (lower .chezmoi.kernel.osrelease)) -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+# wsl.conf hash: {{ includeTemplate "wsl/wsl.conf" . | sha256sum }}
+
+# wsl.conf must reside in /etc/wsl.conf to configure WSL system settings.
+# This script templates and copies the configuration using sudo.
+
+cat << 'CONFIG_EOF' | sudo tee /etc/wsl.conf > /dev/null
+{{ template "wsl/wsl.conf" . }}
+CONFIG_EOF
+
+echo "Updated wsl.conf: /etc/wsl.conf"
+{{- end -}}

--- a/tests/integration/test_wsl.py
+++ b/tests/integration/test_wsl.py
@@ -22,3 +22,13 @@ def test_wslconfig_deployed_to_windows_profile(host):
     unix_profile = subprocess.check_output(["wslpath", "-u", win_profile], text=True).strip()
     wslconfig = host.file(os.path.join(unix_profile, ".wslconfig"))
     assert wslconfig.exists
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _is_wsl, reason="WSL-only: verifies /etc/wsl.conf was deployed")
+def test_wslconf_deployed(host):
+    """Verify /etc/wsl.conf was deployed and contains expected settings."""
+    wslconf = host.file("/etc/wsl.conf")
+    assert wslconf.exists
+    assert "[boot]" in wslconf.content_string
+    assert "systemd=true" in wslconf.content_string


### PR DESCRIPTION
Enables systemd by default in WSL instances by adding the `systemd=true` option under the `[boot]` section of `/etc/wsl.conf`. This is managed via chezmoi by generating the config file and writing it directly to `/etc/wsl.conf` with a `run_onchange_after_` script. Integrates with the existing `test_wsl.py` framework to confirm the configuration state.

---
*PR created automatically by Jules for task [10677636391439376180](https://jules.google.com/task/10677636391439376180) started by @mkobit*