### PR TITLE
fix(mise): pair trust+install per scope, trust global config, drop MISE_LOCKED=0 from bootstrap

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -19,6 +19,8 @@ mise trust "{{ .chezmoi.workingTree }}/.mise.toml"
 log_success "Mise config trusted: {{ .chezmoi.workingTree }}/.mise.toml"
 
 log_info "Installing mise tools in {{ .chezmoi.workingTree }}..."
+# MISE_GLOBAL_CONFIG_FILE=/dev/null: mise install always merges the global config on top of -C,
+# which would install all global tools here. Suppress it so only this working tree's tools install.
 if MISE_GLOBAL_CONFIG_FILE=/dev/null mise install -C "{{ .chezmoi.workingTree }}"; then
     log_success "Mise tools installed in {{ .chezmoi.workingTree }}."
 else

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -10,11 +10,19 @@ source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 
 if ! command -v mise &>/dev/null; then
-    log_warn "mise not found in PATH. Skipping trust."
+    log_warn "mise not found in PATH. Skipping personal dotfiles trust and install."
     exit 0
 fi
 
-log_info "Trusting mise config in working tree..."
+log_info "Trusting personal dotfiles mise config..."
 mise trust "{{ .chezmoi.workingTree }}/.mise.toml"
-log_success "mise config trusted."
+log_success "Personal dotfiles mise config trusted."
+
+log_info "Installing personal dotfiles mise tools..."
+if mise install -C "{{ .chezmoi.workingTree }}"; then
+    log_success "Personal dotfiles mise tools installed."
+else
+    log_error "Failed to install personal dotfiles mise tools."
+    exit 1
+fi
 {{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -19,7 +19,7 @@ mise trust "{{ .chezmoi.workingTree }}/.mise.toml"
 log_success "Mise config trusted: {{ .chezmoi.workingTree }}/.mise.toml"
 
 log_info "Installing mise tools in {{ .chezmoi.workingTree }}..."
-if mise install -C "{{ .chezmoi.workingTree }}"; then
+if MISE_GLOBAL_CONFIG_FILE=/dev/null mise install -C "{{ .chezmoi.workingTree }}"; then
     log_success "Mise tools installed in {{ .chezmoi.workingTree }}."
 else
     log_error "Failed to install mise tools in {{ .chezmoi.workingTree }}."

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -16,11 +16,11 @@ fi
 
 log_info "Trusting mise config: {{ .chezmoi.workingTree }}/.mise.toml"
 mise trust "{{ .chezmoi.workingTree }}/.mise.toml"
-log_success "Mise config trusted."
+log_success "Mise config trusted: {{ .chezmoi.workingTree }}/.mise.toml"
 
 log_info "Installing mise tools in {{ .chezmoi.workingTree }}..."
 if mise install -C "{{ .chezmoi.workingTree }}"; then
-    log_success "Mise tools installed."
+    log_success "Mise tools installed in {{ .chezmoi.workingTree }}."
 else
     log_error "Failed to install mise tools in {{ .chezmoi.workingTree }}."
     exit 1

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_05_trust-mise-config.sh.tmpl
@@ -10,19 +10,19 @@ source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 
 if ! command -v mise &>/dev/null; then
-    log_warn "mise not found in PATH. Skipping personal dotfiles trust and install."
+    log_warn "mise not found in PATH. Skipping trust and install for {{ .chezmoi.workingTree }}."
     exit 0
 fi
 
-log_info "Trusting personal dotfiles mise config..."
+log_info "Trusting mise config: {{ .chezmoi.workingTree }}/.mise.toml"
 mise trust "{{ .chezmoi.workingTree }}/.mise.toml"
-log_success "Personal dotfiles mise config trusted."
+log_success "Mise config trusted."
 
-log_info "Installing personal dotfiles mise tools..."
+log_info "Installing mise tools in {{ .chezmoi.workingTree }}..."
 if mise install -C "{{ .chezmoi.workingTree }}"; then
-    log_success "Personal dotfiles mise tools installed."
+    log_success "Mise tools installed."
 else
-    log_error "Failed to install personal dotfiles mise tools."
+    log_error "Failed to install mise tools in {{ .chezmoi.workingTree }}."
     exit 1
 fi
 {{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -16,23 +16,23 @@ if [[ ! -x "$MISE" ]]; then
     exit 0
 fi
 
-log_info "Trusting deployed global mise config..."
+log_info "Trusting global mise config: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 "$MISE" trust "{{ .chezmoi.destDir }}/.config/mise/config.toml"
-log_success "Global mise config trusted."
+log_success "Global mise config trusted: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 
-log_info "Running 'mise install' for global tools..."
+log_info "Installing global mise tools in {{ .chezmoi.destDir }}..."
 if MISE_INSTALL_BEFORE=0d "$MISE" install -C "{{ .chezmoi.destDir }}"; then
-    log_success "Mise global tools installation complete."
+    log_success "Global mise tools installed in {{ .chezmoi.destDir }}."
 else
-    log_error "Failed to install mise global tools."
+    log_error "Failed to install global mise tools in {{ .chezmoi.destDir }}."
     exit 1
 fi
 
-log_info "Pruning unused global mise tools..."
+log_info "Pruning unused global mise tools in {{ .chezmoi.destDir }}..."
 if "$MISE" prune -y -C "{{ .chezmoi.destDir }}"; then
-    log_success "Global mise tools pruned."
+    log_success "Global mise tools pruned in {{ .chezmoi.destDir }}."
 else
-    log_warn "Failed to prune global mise tools."
+    log_warn "Failed to prune global mise tools in {{ .chezmoi.destDir }}."
     # We don't exit 1 here, as prune failure shouldn't fail the whole install process
 fi
 

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -11,12 +11,14 @@ source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 MISE="{{ .chezmoi.destDir }}/.local/bin/mise"
 export PATH="{{ .chezmoi.destDir }}/.local/bin:${PATH}"
 
-log_info "Ensuring mise global tools are installed..."
-
 if [[ ! -x "$MISE" ]]; then
     log_warn "mise not found at $MISE. Skipping global tool installation."
     exit 0
 fi
+
+log_info "Trusting deployed global mise config..."
+"$MISE" trust "{{ .chezmoi.destDir }}/.config/mise/config.toml"
+log_success "Global mise config trusted."
 
 log_info "Running 'mise install' for global tools..."
 if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C "{{ .chezmoi.destDir }}"; then
@@ -26,20 +28,19 @@ else
     exit 1
 fi
 
-
-log_info "Pruning unused mise tools..."
+log_info "Pruning unused global mise tools..."
 if "$MISE" prune -y -C "{{ .chezmoi.destDir }}"; then
-    log_success "Mise prune complete."
+    log_success "Global mise tools pruned."
 else
-    log_warn "Failed to prune mise tools."
+    log_warn "Failed to prune global mise tools."
     # We don't exit 1 here, as prune failure shouldn't fail the whole install process
 fi
 
-log_info "Reshimming mise tools..."
+log_info "Reshimming global mise tools..."
 if "$MISE" reshim; then
-    log_success "Mise reshim complete."
+    log_success "Global mise tools reshimmed."
 else
-    log_error "Failed to reshim mise tools."
+    log_error "Failed to reshim global mise tools."
     exit 1
 fi
 {{- end -}}

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -16,6 +16,8 @@ if [[ ! -x "$MISE" ]]; then
     exit 0
 fi
 
+# Trust the deployed global config explicitly — on first apply (fresh machine) chezmoi
+# deploys this file but mise won't read it until it's trusted. On re-apply it's a no-op.
 log_info "Trusting global mise config: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 "$MISE" trust "{{ .chezmoi.destDir }}/.config/mise/config.toml"
 log_success "Global mise config trusted: {{ .chezmoi.destDir }}/.config/mise/config.toml"

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_10_install-mise-tools.sh.tmpl
@@ -21,7 +21,7 @@ log_info "Trusting deployed global mise config..."
 log_success "Global mise config trusted."
 
 log_info "Running 'mise install' for global tools..."
-if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C "{{ .chezmoi.destDir }}"; then
+if MISE_INSTALL_BEFORE=0d "$MISE" install -C "{{ .chezmoi.destDir }}"; then
     log_success "Mise global tools installation complete."
 else
     log_error "Failed to install mise global tools."


### PR DESCRIPTION
## Summary

- **Script 05** now trusts and installs personal dotfiles source tree tools
  (uv etc.) together — previously it only trusted, leaving source tree tools
  uninstalled until script 10 ran in the wrong scope
- **Script 10** now trusts `~/.config/mise/config.toml` before running
  `mise install`, fixing a bootstrap failure where the deployed global config
  was untrusted at install time
- **Drop `MISE_LOCKED=0`** from the bootstrap install — lock enforcement
  should be active during normal apply; bypassing it is only appropriate when
  intentionally updating the lockfile
- Log messages updated throughout to clearly label `personal dotfiles` vs
  `global` context in both scripts
