### PR TITLE
Update CLI tools (claude-code, gemini-cli, gh, etc)

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/gh.toml
+++ b/src/chezmoi/.chezmoidata/bin/gh.toml
@@ -1,11 +1,11 @@
 [gh]
-version             = "2.91.0"
+version             = "2.92.0"
 installation_method = "chezmoi_external"
 
 # gh uses a non-standard archive naming scheme (macOS alias, zip vs tar.gz per OS)
 # managed by its own .chezmoiexternals template rather than external/release
 [gh.checksums]
-darwin_arm64 = "20446cd714d9fa1b69fbd410deade3731f38fe09a2b980c8488aa388dd320ada"
-darwin_amd64 = "8806784f93603fe6d3f95c3583a08df38f175df9ebc123dc8b15f919329980e2"
-linux_amd64  = "304a0d2460f4a8847d2f192bad4e2a32cd9420d28716e7ae32198181b65b5f9c"
-linux_arm64  = "ccbed39c472d3dc1c501d1e164a9cffd934c5f6fce1012811a1a59d24cb7d7c6"
+darwin_arm64 = "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07"
+darwin_amd64 = "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0"
+linux_amd64  = "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4"
+linux_arm64  = "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee"

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -62,5 +62,5 @@ package_manager = "bun"
   installation_method = "mise"
 
   [mise.global_tools.gemini-cli]
-  version             = "0.40.0"
+  version             = "0.40.1"
   installation_method = "mise"

--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -1,6 +1,6 @@
 [claude_code]
 installation_method = "dotfiles.script"
-version = "2.1.119"
+version = "2.1.126"
 
 # Deployment config → managed via modify_settings.json.tmpl → ~/.claude/settings.json
 # These are operator/admin-level settings: permissions, env, tooling behavior.

--- a/src/chezmoi/dot_config/mise/mise.lock
+++ b/src/chezmoi/dot_config/mise/mise.lock
@@ -49,7 +49,7 @@ checksum = "sha256:2d3d5f88a95943563f56f3643c8f4e2422261018f6d915329bb2fb33f7256
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-x64-baseline.zip"
 
 [[tools.gemini-cli]]
-version = "0.40.0"
+version = "0.40.1"
 backend = "npm:@google/gemini-cli"
 
 [[tools.java]]
@@ -103,7 +103,6 @@ url = "https://nodejs.org/dist/v22.14.0/node-v22.14.0-win-x64.zip"
 [tools.node."platforms.windows-x64-baseline"]
 checksum = "sha256:55b639295920b219bb2acbcfa00f90393a2789095b7323f79475c9f34795f217"
 url = "https://nodejs.org/dist/v22.14.0/node-v22.14.0-win-x64.zip"
-
 
 [[tools.pnpm]]
 version = "10.33.0"


### PR DESCRIPTION
Updates various tools as requested. Due to a shell issue in the sandbox (`mise lock` destroying the bash environment permanently), `pytest` couldn't be run locally during the pre-commit stage but changes are purely configuration bumps. The code review feedback about not updating rg/fd/conductor was due to them already being on the latest stable versions. Cleaned up an unexpected formatting artifact in mise.lock introduced by `mise lock` directly mutating the lockfile incorrectly.

---
*PR created automatically by Jules for task [8608565033651881834](https://jules.google.com/task/8608565033651881834) started by @mkobit*