### PR TITLE
feat(starship): add python module toggle with default enabled

### DIFF
--- a/src/chezmoi/dot_config/.chezmoidata/starship.toml
+++ b/src/chezmoi/dot_config/.chezmoidata/starship.toml
@@ -9,3 +9,6 @@ enabled = true
 
 [starship.modules.git_status]
 enabled = true
+
+[starship.modules.python]
+enabled = true

--- a/src/chezmoi/dot_config/starship.toml.tmpl
+++ b/src/chezmoi/dot_config/starship.toml.tmpl
@@ -35,3 +35,6 @@ disabled = {{ not (dig "starship" "modules" "git_status" "enabled" true .) }}
 
 [git_branch]
 ignore_branches = {{ dig "starship" "ignore_branches" list . | toToml }}
+
+[python]
+disabled = {{ not (dig "starship" "modules" "python" "enabled" true .) }}


### PR DESCRIPTION
Follows the existing module-disable pattern for nodejs/ruby/git_status. Work overlay can now inject [data.starship.modules.python] enabled = false to silence slow python version detection in large repos.


Committed-By-Agent: claude