### PR TITLE
fix(claude): always apply settings/preferences and fix external relea…

### DIFF
--- a/src/chezmoi/.chezmoitemplates/external/release
+++ b/src/chezmoi/.chezmoitemplates/external/release
@@ -70,7 +70,23 @@
       | replace "{os}"       $root.chezmoi.os
       | replace "{arch}"     $root.chezmoi.arch -}}
 
-{{- $entry := dict "type" $d.external_type "url" $url -}}
+{{- $entry := dict "type" $d.external_type -}}
+
+{{- /* Use urls=[primary, fallback] so chezmoi retries on failure; url= alone has no fallback. */ -}}
+{{- if dig "fallback_url_format" "" $d -}}
+  {{- $fallback := $d.fallback_url_format
+        | replace "{base}"     $base
+        | replace "{repo}"     $d.repo
+        | replace "{version}"  $version
+        | replace "{tag}"      $tag
+        | replace "{filename}" $filename
+        | replace "{target}"   $target
+        | replace "{os}"       $root.chezmoi.os
+        | replace "{arch}"     $root.chezmoi.arch -}}
+  {{- $_ := set $entry "urls" (list $url $fallback) -}}
+{{- else -}}
+  {{- $_ := set $entry "url" $url -}}
+{{- end -}}
 
 {{- if dig "executable"       false $d -}}{{- $_ := set $entry "executable"      true -}}{{- end -}}
 {{- if dig "readonly"         false $d -}}{{- $_ := set $entry "readonly"        true -}}{{- end -}}
@@ -86,19 +102,6 @@
         | replace "{os}"      $root.chezmoi.os
         | replace "{arch}"    $root.chezmoi.arch -}}
   {{- $_ := set $entry "path" $path -}}
-{{- end -}}
-
-{{- if dig "fallback_url_format" "" $d -}}
-  {{- $fallback := $d.fallback_url_format
-        | replace "{base}"     $base
-        | replace "{repo}"     $d.repo
-        | replace "{version}"  $version
-        | replace "{tag}"      $tag
-        | replace "{filename}" $filename
-        | replace "{target}"   $target
-        | replace "{os}"       $root.chezmoi.os
-        | replace "{arch}"     $root.chezmoi.arch -}}
-  {{- $_ := set $entry "urls" (list $fallback) -}}
 {{- end -}}
 
 {{- $ctype := $d.checksum_type -}}

--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -1,4 +1,3 @@
-{{- if eq .claude_code.installation_method "dotfiles.script" -}}
 #!/usr/bin/env python3
 # Manages ~/.claude/settings.json — deployment config only.
 # UI preferences (editorMode, etc.) live in ~/.claude.json; see modify_dot_claude.json.tmpl.
@@ -22,4 +21,3 @@ def sort_keys(obj):
     return obj
 
 print(json.dumps(sort_keys(merged), indent=2))
-{{- end }}

--- a/src/chezmoi/modify_dot_claude.json.tmpl
+++ b/src/chezmoi/modify_dot_claude.json.tmpl
@@ -1,4 +1,3 @@
-{{- if eq .claude_code.installation_method "dotfiles.script" -}}
 #!/usr/bin/env python3
 # Manages ~/.claude.json — UI preferences only.
 # Claude Code uses this file as both a preferences store AND mutable runtime state
@@ -19,4 +18,3 @@ preferences = json.loads("""{{ .claude_code.preferences | toPrettyJson }}""")
 merged = {**existing, **preferences}
 
 print(json.dumps(merged, indent=2))
-{{- end }}


### PR DESCRIPTION
…se url fallback

Remove installation_method guard from both modify scripts so vim mode and deployment config are injected regardless of how Claude Code was installed.

Fix external/release template to emit urls=[primary,fallback] instead of url=primary + ignored urls=[fallback], so chezmoi actually retries on 404.


Committed-By-Agent: claude