### PR TITLE
chore(deps): group dependabot updates by domain and trust level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,10 @@ updates:
       patterns:
       - pydantic
       - pydantic-*
-    wheneer:
+      - typer
+    whenever:
       patterns:
-      - wheneer
+      - whenever
     python-dependencies:
       patterns:
       - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     default-days: 14
   open-pull-requests-limit: 10
   groups:
+    github:
+      patterns:
+      - actions/*
+      - github/*
+    jdx:
+      patterns:
+      - jdx/*
     github-actions:
       patterns:
       - '*'
@@ -18,8 +25,7 @@ updates:
   commit-message:
     prefix: chore(deps)
     include: scope
-
-- package-ecosystem: "uv"
+- package-ecosystem: uv
   directory: /
   schedule:
     interval: weekly
@@ -27,6 +33,19 @@ updates:
     default-days: 14
   open-pull-requests-limit: 10
   groups:
+    astral:
+      patterns:
+      - ruff
+      - uv
+      - ty
+    pytest:
+      patterns:
+      - pytest
+      - pytest-*
+    trusted-libs:
+      patterns:
+      - pydantic
+      - pydantic-*
     python-dependencies:
       patterns:
       - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     jdx:
       patterns:
       - jdx/*
-    github-actions:
+    other:
       patterns:
       - '*'
   reviewers:
@@ -46,6 +46,9 @@ updates:
       patterns:
       - pydantic
       - pydantic-*
+    wheneer:
+      patterns:
+      - wheneer
     python-dependencies:
       patterns:
       - '*'


### PR DESCRIPTION
Separates Dependabot dependency updates into specific groups based on category, domain, and trustworthiness to enable smoother automatic merging in the future.

Added Groups:
- `github-actions`: `github` (actions/*, github/*), `jdx` (jdx/*)
- `uv`: `astral` (ruff, uv, ty), `pytest` (pytest*), `trusted-libs` (pydantic*)

Maintained fallbacks for both package ecosystems for unhandled updates.

---
*PR created automatically by Jules for task [1010692211325733411](https://jules.google.com/task/1010692211325733411) started by @mkobit*