### PR TITLE
Migrate from click and pyright to typer and ty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,6 @@ updates:
       patterns:
       - pydantic
       - pydantic-*
-      - typer
     whenever:
       patterns:
       - whenever

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -10,7 +10,7 @@
      name = "my-tool"
      version = "0.0.0"
      requires-python = ">=3.14"
-     dependencies = ["click>=8"]
+     dependencies = ["typer>=0.15.1"]
 
      [project.scripts]
      my-tool = "my_tool.main:cli"

--- a/src/python/claude_statusline/pyproject.toml
+++ b/src/python/claude_statusline/pyproject.toml
@@ -20,7 +20,6 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "pyright>=1.1.408",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-asyncio>=1.3.0",

--- a/src/python/transcribe/pyproject.toml
+++ b/src/python/transcribe/pyproject.toml
@@ -3,10 +3,10 @@ name = "transcribe"
 version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
-    "click>=8",
     "faster-whisper>=1",
     "jinja2>=3",
     "tqdm>=4",
+    "typer>=0.24.2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-05-02T19:30:03.966733735Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "claude-statusline",
@@ -169,7 +173,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -185,7 +188,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.7" },
@@ -633,15 +635,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -826,19 +819,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.409"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -1054,18 +1034,18 @@ name = "transcribe"
 version = "0.0.0"
 source = { editable = "src/python/transcribe" }
 dependencies = [
-    { name = "click" },
     { name = "faster-whisper" },
     { name = "jinja2" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.3.3" },
     { name = "faster-whisper", specifier = ">=1" },
     { name = "jinja2", specifier = ">=3" },
     { name = "tqdm", specifier = ">=4" },
+    { name = "typer", specifier = ">=0.24.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrated the `transcribe` app from `click` to `typer`.
Removed `pyright` in favor of `ty`.
Adjusted `dependabot` configuration for uv packages based on the request.
Updated documentation to prefer `typer`.

---
*PR created automatically by Jules for task [2662618487490473112](https://jules.google.com/task/2662618487490473112) started by @mkobit*