### PR TITLE
feat: add btop external using static release binaries

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/btop.toml
+++ b/src/chezmoi/.chezmoidata/bin/btop.toml
@@ -7,7 +7,7 @@ executable          = true
 checksum_type       = "sha256"
 tag_format          = "v{version}"
 filename_format     = "btop-{target}.tar.gz"
-path_format         = "btop/bin/btop"
+path_format         = "./btop/bin/btop"
 url_format          = "{base}/{repo}/releases/download/{tag}/{filename}"
 
 [btop.platforms]

--- a/src/chezmoi/.chezmoidata/bin/btop.toml
+++ b/src/chezmoi/.chezmoidata/bin/btop.toml
@@ -1,0 +1,19 @@
+[btop]
+version             = "1.4.7"
+installation_method = "chezmoi_external"
+repo                = "aristocratos/btop"
+external_type       = "archive-file"
+executable          = true
+checksum_type       = "sha256"
+tag_format          = "v{version}"
+filename_format     = "btop-{target}.tar.gz"
+path_format         = "btop/bin/btop"
+url_format          = "{base}/{repo}/releases/download/{tag}/{filename}"
+
+[btop.platforms]
+linux_amd64  = "x86_64-unknown-linux-musl"
+linux_arm64  = "aarch64-unknown-linux-musl"
+
+[btop.checksums]
+linux_amd64  = "5099054dd6a101bd12eb6ff3702a9a6a3f57aaa27923a0da478ae5b517faf335"
+linux_arm64  = "6270de0ef4c84cf0eea61cb148b3ad9ae91a11e9c3309867ffc6b3751024c252"

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/btop.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/btop.toml.tmpl
@@ -1,0 +1,5 @@
+{{- with .btop -}}
+{{- if eq .installation_method "chezmoi_external" -}}
+{{- template "external/release" (dict "key" "btop" "data" . "root" $) -}}
+{{- end -}}
+{{- end -}}

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -6,6 +6,8 @@ import pytest
 @pytest.mark.parametrize("binary", ["fzf", "rg", "eza", "bat", "zoxide", "btop"])
 def test_cli_tool_available(host, binary, shell_cmd):
     """Verify each CLI binary is on PATH in bash and zsh."""
+    if binary == "btop" and host.system_info.type == "darwin":
+        pytest.skip("btop is not managed via chezmoi on macOS (no static binary available from upstream)")
     result = host.run(f"{shell_cmd} 'command -v {binary}'")
     assert result.rc == 0, f"'{binary}' not found via {shell_cmd!r}.\nstderr: {result.stderr}"
 

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.integration
 @pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
-@pytest.mark.parametrize("binary", ["fzf", "rg", "eza", "bat", "zoxide"])
+@pytest.mark.parametrize("binary", ["fzf", "rg", "eza", "bat", "zoxide", "btop"])
 def test_cli_tool_available(host, binary, shell_cmd):
     """Verify each CLI binary is on PATH in bash and zsh."""
     result = host.run(f"{shell_cmd} 'command -v {binary}'")


### PR DESCRIPTION
This PR adds `btop` as a managed external dependency.

- Configured `src/chezmoi/.chezmoidata/bin/btop.toml` using static binaries (version 1.4.7) from aristocratic/btop for Linux (`linux_amd64` and `linux_arm64`).
- Used the correct `.tar.gz` archive types and retrieved the sha256 checksums from the latest releases.
- Configured the template injection loop in `src/chezmoi/dot_local/bin/.chezmoiexternals/btop.toml.tmpl` to route through the `external/release` function block.

---
*PR created automatically by Jules for task [13937503091623203748](https://jules.google.com/task/13937503091623203748) started by @mkobit*