### PR TITLE
Remove conductor from Gemini tools

### DIFF
--- a/src/chezmoi/.chezmoidata/gemini.toml
+++ b/src/chezmoi/.chezmoidata/gemini.toml
@@ -34,10 +34,6 @@ sandbox_allowed_paths = ["~/"]
 
 [gemini.extensions]
 
-  [gemini.extensions.conductor]
-  url = "https://github.com/gemini-cli-extensions/conductor"
-  ref = "conductor-v0.4.1"
-  installation_method = "gemini-cli"
 
 [gemini.context]
 include_directories = ["~/.config/gh"]

--- a/src/chezmoi/dot_config/mise/tasks/executable_install-gemini-extensions.tmpl
+++ b/src/chezmoi/dot_config/mise/tasks/executable_install-gemini-extensions.tmpl
@@ -19,6 +19,7 @@ fi
 
 echo "Installing Gemini CLI extensions..."
 
+{{- if hasKey .gemini "extensions" }}
 {{- range $name, $ext := .gemini.extensions }}
 {{-   if eq $ext.installation_method "gemini-cli" }}
 echo "Uninstalling {{ $name }} (to ensure clean update)..."
@@ -28,6 +29,8 @@ echo "Installing {{ $name }} from {{ $ext.url }} ({{ $ext.ref }})..."
 # We pipe 'yes' to handle any manual consent prompts during non-interactive sessions
 yes | "${RUN_CMD[@]}" extensions install "{{ $ext.url }}" --ref "{{ $ext.ref }}" --consent || true
 {{-   end }}
+{{- end }}
+
 {{- end }}
 
 echo "Gemini extensions installation complete."


### PR DESCRIPTION
This commit removes the conductor extension from the Gemini configuration as requested.
- Removes `[gemini.extensions.conductor]` section from `src/chezmoi/.chezmoidata/gemini.toml`.
- Adds `hasKey` safeguard to the template in `src/chezmoi/dot_config/mise/tasks/executable_install-gemini-extensions.tmpl` to prevent rendering errors when no extensions exist.

---
*PR created automatically by Jules for task [9584690005634654711](https://jules.google.com/task/9584690005634654711) started by @mkobit*