### PR TITLE
fix(env): pass repository source dir to chezmoi apply in setup script

### DIFF
--- a/.jules/env_setup.sh
+++ b/.jules/env_setup.sh
@@ -43,7 +43,7 @@ else
 fi
 
 echo "Applying chezmoi..."
-chezmoi apply -v
+chezmoi apply --source="$(pwd)" -v
 
 # Step 2: Install python dependencies
 echo "Installing python dependencies..."


### PR DESCRIPTION
The `.jules/env_setup.sh` environment setup script was failing to apply `chezmoi` configuration because it defaulted to checking `~/.local/share/chezmoi` for the configuration source, which does not exist in the isolated runner environment.

This change appends `--source="$(pwd)"` to the `chezmoi apply -v` command, explicitly pointing it to the current checked-out dotfiles repository directory. This ensures the environment correctly deploys the config and resolves the "no such file or directory" error when attempting to run `.jules/env_setup.sh`.

---
*PR created automatically by Jules for task [376583217117892630](https://jules.google.com/task/376583217117892630) started by @mkobit*