### PR TITLE
fix: fix gemini installation version in mise

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -62,5 +62,5 @@ package_manager = "bun"
   installation_method = "mise"
 
   [mise.global_tools.gemini-cli]
-  version             = "0.40.1"
+  version             = "0.42.0"
   installation_method = "mise"

--- a/src/chezmoi/dot_config/mise/mise.lock
+++ b/src/chezmoi/dot_config/mise/mise.lock
@@ -49,7 +49,7 @@ checksum = "sha256:c68c7903c1190101590cc1b2129835f47211b3b37ae87759f2b97d6534aa3
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-windows-x64-baseline.zip"
 
 [[tools.gemini-cli]]
-version = "0.40.1"
+version = "0.42.0"
 backend = "npm:@google/gemini-cli"
 
 [[tools.java]]


### PR DESCRIPTION
Updates the gemini-cli version in chezmoi to the latest available version (0.42.0) to resolve an issue where an old, non-existent version (0.37.1) was failing to install, causing CI failures.

---
*PR created automatically by Jules for task [13388663149287504180](https://jules.google.com/task/13388663149287504180) started by @mkobit*