### PR TITLE
chore: add log_level = warn to global mise config

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -28,6 +28,7 @@ cache_prune_age = "60 days"
 disable_hints   = ["self_update"]
 http_retries    = 5
 install_before  = "7d"
+log_level     = "warn"
 [mise.settings.npm]
 package_manager = "bun"
 


### PR DESCRIPTION
Set log_level to "warn" in global mise config to reduce noise.

---
*PR created automatically by Jules for task [1850769264703185122](https://jules.google.com/task/1850769264703185122) started by @mkobit*