### PR TITLE
chore: add min_version to mise configs

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.5.6"
+
 [tools]
 uv = "0.11.3"
 

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -1,4 +1,5 @@
 [mise]
+min_version = "2026.5.6"
 version             = "v2026.5.6"
 installation_method = "chezmoi_external"
 repo                = "jdx/mise"

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,3 +1,5 @@
+min_version = "2026.5.6"
+
 {{- /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
 {{- $tools := dict -}}
 {{- range $tool, $config := .mise.global_tools -}}

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,6 +1,5 @@
 min_version = "2026.5.6"
 
-
 {{ /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
 {{- $tools := dict -}}
 {{- range $tool, $config := .mise.global_tools -}}
@@ -12,7 +11,6 @@ min_version = "2026.5.6"
     {{- end -}}
   {{- end -}}
 {{- end -}}
-
 {{- /* Build filtered settings map - omit sub-keys tied to disabled tools */ -}}
 {{- $settings := dict -}}
 {{- range $k, $v := .mise.settings -}}
@@ -27,6 +25,7 @@ min_version = "2026.5.6"
 {{- if $tools -}}
 {{ dict "tools" $tools | toToml }}
 {{- end -}}
+
 {{- if $settings -}}
 {{ dict "settings" $settings | toToml }}
 {{- end -}}

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,4 +1,4 @@
-min_version = "2026.5.6"
+min_version = {{ .mise.min_version | quote }}
 
 {{ /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
 {{- $tools := dict -}}

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -22,10 +22,10 @@ min_version = "2026.5.6"
   {{- end -}}
 {{- end -}}
 
-{{- if $tools -}}
+{{- if $tools }}
 {{ dict "tools" $tools | toToml }}
 {{- end -}}
 
-{{- if $settings -}}
+{{- if $settings }}
 {{ dict "settings" $settings | toToml }}
 {{- end -}}

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,6 +1,7 @@
 min_version = "2026.5.6"
 
-{{- /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
+
+{{ /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
 {{- $tools := dict -}}
 {{- range $tool, $config := .mise.global_tools -}}
   {{- if eq (dig "installation_method" "" $config) "mise" -}}

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-05-06T03:31:38.704493513Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "claude-statusline",

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-06T03:31:38.704493513Z"
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "claude-statusline",


### PR DESCRIPTION
- Adds `min_version = "2026.5.6"` to `mise.toml`
- Adds `min_version = "2026.5.6"` to `src/chezmoi/dot_config/mise/config.toml.tmpl`

---
*PR created automatically by Jules for task [16669426288149537526](https://jules.google.com/task/16669426288149537526) started by @mkobit*