### PR TITLE
chore(git): add mise.local.toml to global gitignore

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -6,3 +6,4 @@
 *~
 /bazel-*
 .scratch/
+mise.local.toml


### PR DESCRIPTION
Adds `mise.local.toml` to the global gitignore snippets file.