### PR TITLE
fix(mise): use -C /tmp for global tool install to avoid project lockfile

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
@@ -22,19 +22,19 @@ log_info "Trusting global mise config: {{ .chezmoi.destDir }}/.config/mise/confi
 "$MISE" trust "{{ .chezmoi.destDir }}/.config/mise/config.toml"
 log_success "Global mise config trusted: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 
-log_info "Installing global mise tools..."
-if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C /tmp; then
-    log_success "Global mise tools installed."
+log_info "Installing global mise tools in {{ .chezmoi.destDir }}..."
+if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C "{{ .chezmoi.destDir }}"; then
+    log_success "Global mise tools installed in {{ .chezmoi.destDir }}."
 else
-    log_error "Failed to install global mise tools."
+    log_error "Failed to install global mise tools in {{ .chezmoi.destDir }}."
     exit 1
 fi
 
-log_info "Pruning unused global mise tools..."
-if "$MISE" prune -y -C /tmp; then
-    log_success "Global mise tools pruned."
+log_info "Pruning unused global mise tools in {{ .chezmoi.destDir }}..."
+if "$MISE" prune -y -C "{{ .chezmoi.destDir }}"; then
+    log_success "Global mise tools pruned in {{ .chezmoi.destDir }}."
 else
-    log_warn "Failed to prune global mise tools."
+    log_warn "Failed to prune global mise tools in {{ .chezmoi.destDir }}."
 fi
 
 log_info "Reshimming global mise tools..."

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
@@ -23,7 +23,7 @@ log_info "Trusting global mise config: {{ .chezmoi.destDir }}/.config/mise/confi
 log_success "Global mise config trusted: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 
 log_info "Installing global mise tools..."
-if MISE_INSTALL_BEFORE=0d "$MISE" install -C /tmp; then
+if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C /tmp; then
     log_success "Global mise tools installed."
 else
     log_error "Failed to install global mise tools."

--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl
@@ -22,20 +22,19 @@ log_info "Trusting global mise config: {{ .chezmoi.destDir }}/.config/mise/confi
 "$MISE" trust "{{ .chezmoi.destDir }}/.config/mise/config.toml"
 log_success "Global mise config trusted: {{ .chezmoi.destDir }}/.config/mise/config.toml"
 
-log_info "Installing global mise tools in {{ .chezmoi.destDir }}..."
-if MISE_INSTALL_BEFORE=0d MISE_LOCKED=0 "$MISE" install -C "{{ .chezmoi.destDir }}"; then
-    log_success "Global mise tools installed in {{ .chezmoi.destDir }}."
+log_info "Installing global mise tools..."
+if MISE_INSTALL_BEFORE=0d "$MISE" install -C /tmp; then
+    log_success "Global mise tools installed."
 else
-    log_error "Failed to install global mise tools in {{ .chezmoi.destDir }}."
+    log_error "Failed to install global mise tools."
     exit 1
 fi
 
-log_info "Pruning unused global mise tools in {{ .chezmoi.destDir }}..."
-if "$MISE" prune -y -C "{{ .chezmoi.destDir }}"; then
-    log_success "Global mise tools pruned in {{ .chezmoi.destDir }}."
+log_info "Pruning unused global mise tools..."
+if "$MISE" prune -y -C /tmp; then
+    log_success "Global mise tools pruned."
 else
-    log_warn "Failed to prune global mise tools in {{ .chezmoi.destDir }}."
-    # We don't exit 1 here, as prune failure shouldn't fail the whole install process
+    log_warn "Failed to prune global mise tools."
 fi
 
 log_info "Reshimming global mise tools..."


### PR DESCRIPTION
## Summary

- When `mise install` runs from the chezmoi destDir, it picks up the repo-level `mise.toml` which has `locked = true` and only `uv` — causing global tools like `python` to be skipped or fail
- Running with `-C /tmp` avoids the project-level config entirely

## Test plan

- [ ] Apply chezmoi on a fresh machine and verify global mise tools (python, etc.) install correctly
- [ ] Verify `mise prune` still works after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)