### PR TITLE
fix(shell): guard bind and stty for non-terminal contexts

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/keybindings.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/keybindings.sh
@@ -21,8 +21,10 @@ zle -N zle-line-init      _zle_vi_mode_cursor
 {{- if eq .shell "bash" }}
 # Enable vi mode in bash
 set -o vi
-# Bash cursor shape in vi mode
-bind 'set show-mode-in-prompt on'
-bind 'set vi-ins-mode-string \1\e[6 q\2'
-bind 'set vi-cmd-mode-string \1\e[2 q\2'
+# Bash cursor shape in vi mode — only when readline is active (interactive terminal)
+if [[ $- == *i* ]]; then
+    bind 'set show-mode-in-prompt on'
+    bind 'set vi-ins-mode-string \1\e[6 q\2'
+    bind 'set vi-cmd-mode-string \1\e[2 q\2'
+fi
 {{- end }}

--- a/src/chezmoi/.chezmoitemplates/shell/performance.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/performance.sh
@@ -149,7 +149,7 @@ setopt HIST_SAVE_NO_DUPS
 {{- if eq .shell "zsh" }}
 unsetopt FLOW_CONTROL
 {{- end }}
-stty -ixon
+[[ -t 0 ]] && stty -ixon
 
 # Speed up job control for tmux environments
 {{- if eq .shell "zsh" }}


### PR DESCRIPTION
## Summary

- `stty -ixon` in `performance.sh` fails with `Inappropriate ioctl for device` when stdin is not a terminal (Jules post-script hooks, CI test runners, piped scripts)
- `bind` calls in `keybindings.sh` produce `line editing not enabled` warnings in the same contexts

Both are interactive-only features that should only activate when a real terminal is present.

## Changes

- `performance.sh`: `stty -ixon` → `[[ -t 0 ]] && stty -ixon`
- `keybindings.sh`: bash `bind` calls wrapped in `if [[ $- == *i* ]]`

## Test plan

- [ ] CI integration tests pass (bash login shell test was already catching the stty error)
- [ ] Manually verify vi-mode cursor shapes still work in interactive bash and zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)