### PR TITLE
fix(windows-terminal): Fix backslash escaping for shift-enter JSON payload

### DIFF
--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -90,7 +90,7 @@ if (\$modified) {
     \$json = \$settings | ConvertTo-Json -Depth 20
     # ConvertTo-Json will escape our backslash, creating '\\u001b' in the file.
     # We replace it back to a single backslash so WT parses it as an escape character.
-    \$json = \$json -replace '\\\\u001b', '\u001b'
+    \$json = \$json.Replace('\\u001b', '\u001b')
     [System.IO.File]::WriteAllText(\$settingsPath, \$json, [System.Text.UTF8Encoding]::new(\$false))
     Write-Host \"Successfully updated Windows Terminal settings at \$settingsPath\"
 } else {

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "claude-statusline",


### PR DESCRIPTION
This PR fixes an issue where the bash script to configure Windows Terminal was improperly escaping the `\u001b` string when transforming settings using Powershell's `ConvertTo-Json`. The regex `-replace` parameter would swallow backslashes, leading to literal `\u001b` written to the settings JSON instead of an actual escape sequence string. The fix replaces the regex operator with `.Replace()` from the .NET string class.

---
*PR created automatically by Jules for task [11777162103252042188](https://jules.google.com/task/11777162103252042188) started by @mkobit*