### PR TITLE
fix(bash): guard config.bash sourcing to interactive shells only

### DIFF
--- a/src/chezmoi/modify_dot_bash_profile.tmpl
+++ b/src/chezmoi/modify_dot_bash_profile.tmpl
@@ -20,8 +20,11 @@ if [[ -f "{{ .chezmoi.destDir }}/.bashrc" ]]; then
 elif [[ -f "{{ .chezmoi.destDir }}/.profile" ]]; then
   source "{{ .chezmoi.destDir }}/.profile"
 fi
-# Ensure our config is always loaded even if standard files are missing or overriden
-if ! type -t g &>/dev/null && [[ -f "{{ .chezmoi.destDir }}/.dotfiles/bash/config.bash" ]]; then
+# Only load our config in interactive shells. Non-interactive login shells (e.g.
+# env-save hooks that run `bash -l -c 'env'`) must not source config.bash because
+# it prints tool-not-found warnings to stdout, corrupting any env-capture that
+# reads the login shell's stdout as KEY=VALUE pairs.
+if [[ $- == *i* ]] && ! type -t g &>/dev/null && [[ -f "{{ .chezmoi.destDir }}/.dotfiles/bash/config.bash" ]]; then
   source "{{ .chezmoi.destDir }}/.dotfiles/bash/config.bash"
 fi
 # {{ .chezmoi.workingTree }}/{{ .chezmoi.sourceFile }}:END:chezmoi:bash:{{ include "modify_dot_bash_profile.tmpl" | sha256sum | substr 0 8 }}


### PR DESCRIPTION
## Root cause

Jules' env-save hook runs `bash -l -c 'env'` — a **non-interactive login shell** — to capture PATH and env vars by parsing stdout as `KEY=VALUE` pairs.

We create `~/.bash_profile` (Jules never had one before). This means `bash -l` now sources it on every invocation. The previous unconditional `config.bash` sourcing caused tool-not-found warnings (fzf, starship, zoxide) to print to **stdout**, corrupting the `KEY=VALUE` parse and silently failing Jules' env-save hook on every single task.

## Fix

Add `[[ $- == *i* ]]` guard so `config.bash` only loads in **interactive** shells. Non-interactive login shells (`bash -l -c 'env'`, CI, scripts) see clean stdout.

## Proof

Confirmed by running `bash -l -c 'true' 2>/dev/null` in Jules' VM — removing `~/.bash_profile` after apply produced empty stdout and the env-save hook succeeded. With `~/.bash_profile` present (unguarded), stdout contained the warning lines.

## Test plan

- [ ] CI passes
- [ ] Interactive bash login shell still loads config.bash (verify `mise`, `starship` etc. activate)
- [ ] `bash -l -c 'env'` produces clean KEY=VALUE output with no spurious lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)