### PR TITLE
feat(jules): stable env_setup.sh with full apply and stdout guard

### DIFF
--- a/.jules/env_setup.sh
+++ b/.jules/env_setup.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Jules environment setup.
-# Full chezmoi apply minus removes. remove_ entries are excluded permanently
-# as a defensive policy — removes may delete paths Jules depends on.
 set -euo pipefail
 
 echo "Setting up dotfiles environment..."
@@ -34,16 +31,12 @@ GOMAXPROCS=1 chezmoi apply \
 
 export PATH="$HOME/.local/bin:${PATH}"
 
-# Detect bash -l stdout pollution before Jules' env-save hook runs.
-# The hook executes `bash -l -c 'env'` and parses stdout as KEY=VALUE pairs.
-# Any non-KEY=VALUE output (warnings, banners, missing-tool messages) corrupts
-# the parse silently, breaking all subsequent Jules tasks with no clear error.
+# Exit 1 if bash -l emits stdout — Jules' env-save hook parses it as KEY=VALUE.
 bash_l_stdout=$(bash -l -c 'true' 2>/dev/null)
 if [[ -n "$bash_l_stdout" ]]; then
     echo "ERROR: bash -l produced stdout — Jules env-save hook will fail." >&2
     echo "~/.bash_profile or a file it sources is printing to stdout in a non-interactive login shell." >&2
     echo "Fix: gate the output behind [[ \$- == *i* ]] or redirect to stderr." >&2
-    echo "Stdout was:" >&2
     printf '%s\n' "$bash_l_stdout" >&2
     exit 1
 fi

--- a/.jules/env_setup.sh
+++ b/.jules/env_setup.sh
@@ -1,31 +1,22 @@
 #!/usr/bin/env bash
-# Jules environment setup for dotfiles repository
-# Docs: https://jules.google/docs/environment/
-
+# Jules environment setup.
+# Full chezmoi apply minus removes. remove_ entries are excluded permanently
+# as a defensive policy — removes may delete paths Jules depends on.
 set -euo pipefail
 
 echo "Setting up dotfiles environment..."
-
-# Diagnostic Info
-echo "--- Diagnostic Information ---"
 echo "User: $(whoami)"
-GIT_COMMIT_HASH=$(git rev-parse HEAD)
-GIT_COMMIT_DATE=$(git log -1 --format=%cI)
-export GIT_COMMIT_HASH
-export GIT_COMMIT_DATE
-echo "Git commit hash: ${GIT_COMMIT_HASH}"
-echo "Git commit date: ${GIT_COMMIT_DATE}"
-echo "------------------------------"
+export GIT_COMMIT_HASH=$(git rev-parse HEAD)
+echo "Commit: ${GIT_COMMIT_HASH}"
 
+export DEBIAN_FRONTEND=noninteractive
 
-# Step 1: Install chezmoi matching CI version, then apply it.
-# This writes the global mise config (dot_config/mise/) to $HOME, which is required
-# before global tools can be installed with the correct lockfile.
 CHEZMOI_CI_VERSION=$(grep 'CHEZMOI_VERSION:' .github/workflows/ci.yml | awk '{print $2}' | tr -d '"' | tr -d "'")
 
 install_chezmoi() {
-    echo "Installing chezmoi ${CHEZMOI_CI_VERSION}..."
-    /usr/bin/env bash -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin -t "${CHEZMOI_CI_VERSION}"
+    { set +x; } 2>/dev/null
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin" -t "${CHEZMOI_CI_VERSION}"
+    { set -x; } 2>/dev/null
     export PATH="$HOME/.local/bin:$PATH"
 }
 
@@ -33,22 +24,30 @@ if ! command -v chezmoi &>/dev/null; then
     install_chezmoi
 else
     current_version=$(chezmoi --version | awk '{print $3}' | tr -d ',')
-    if [ "${current_version}" != "${CHEZMOI_CI_VERSION}" ]; then
-        echo "Updating chezmoi from ${current_version} to ${CHEZMOI_CI_VERSION}..."
-        install_chezmoi
-    else
-        echo "chezmoi ${CHEZMOI_CI_VERSION} is already installed."
-    fi
+    [ "${current_version}" != "${CHEZMOI_CI_VERSION}" ] && install_chezmoi || echo "chezmoi ${CHEZMOI_CI_VERSION} ok"
 fi
 
-echo "Applying chezmoi..."
-chezmoi apply --source="$(pwd)"
+CHEZMOI_SOURCE="$(pwd)"
+GOMAXPROCS=1 chezmoi apply \
+    --source="${CHEZMOI_SOURCE}" --destination="${HOME}" --no-tty \
+    --exclude=remove
 
-# Step 2: Install python dependencies
-echo "Installing python dependencies..."
-export PATH="$HOME/.local/bin:$PATH"
-eval "$(mise activate bash --shims)"
-eval "$(mise activate bash)"
-uv sync --all-packages --frozen
+export PATH="$HOME/.local/bin:${PATH}"
 
+# Detect bash -l stdout pollution before Jules' env-save hook runs.
+# The hook executes `bash -l -c 'env'` and parses stdout as KEY=VALUE pairs.
+# Any non-KEY=VALUE output (warnings, banners, missing-tool messages) corrupts
+# the parse silently, breaking all subsequent Jules tasks with no clear error.
+bash_l_stdout=$(bash -l -c 'true' 2>/dev/null)
+if [[ -n "$bash_l_stdout" ]]; then
+    echo "ERROR: bash -l produced stdout — Jules env-save hook will fail." >&2
+    echo "~/.bash_profile or a file it sources is printing to stdout in a non-interactive login shell." >&2
+    echo "Fix: gate the output behind [[ \$- == *i* ]] or redirect to stderr." >&2
+    echo "Stdout was:" >&2
+    printf '%s\n' "$bash_l_stdout" >&2
+    exit 1
+fi
+echo "bash -l stdout: clean"
+
+git config --global commit.gpgsign false
 echo "Environment ready"


### PR DESCRIPTION
## Summary

- Full `chezmoi apply --exclude=remove` — all files, externals, modify scripts, and run_ scripts
- Exits 1 with a clear error if `bash -l` produces any stdout after apply, so Jules gets an actionable message instead of a silent post-save failure

## Context

Result of the bisect in #582–#588: A, B, and C (full apply) all pass after fixing stdout pollution in shell templates. This is the stable final form.