### PR TITLE
fix(jules-cli): make starting_branch optional

### DIFF
--- a/src/python/jules_cli/jules_cli/models.py
+++ b/src/python/jules_cli/jules_cli/models.py
@@ -40,7 +40,7 @@ class Source(BaseModel):
 class GitHubRepoContext(BaseModel):
     """Context for a GitHub repository source."""
 
-    starting_branch: str
+    starting_branch: str | None = None
     model_config = frozen_config
 
 


### PR DESCRIPTION
Made `starting_branch` optional in the `GitHubRepoContext` model. This fixes a `ValidationError` when running `jules session list`, which occurs because the `starting_branch` field might be omitted by the API backend.

---
*PR created automatically by Jules for task [10321429067022683882](https://jules.google.com/task/10321429067022683882) started by @mkobit*