### PR TITLE
fix(local-bin): guard source_dir and package_name access for none-met…

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_after_onchange_08_install-local-bin-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_after_onchange_08_install-local-bin-tools.sh.tmpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# hashes:{{ range $name, $tool := .local_bin_tools }}
-# {{ $name }}: {{ include (joinPath $.chezmoi.workingTree $tool.source_dir "pyproject.toml") | sha256sum }}{{ end }}
+# hashes:{{ range $name, $tool := .local_bin_tools }}{{ if index $tool "source_dir" }}
+# {{ $name }}: {{ include (joinPath $.chezmoi.workingTree (index $tool "source_dir") "pyproject.toml") | sha256sum }}{{ end }}{{ end }}
 set -euo pipefail
 
 MISE="{{ .chezmoi.destDir }}/.local/bin/mise"
@@ -15,8 +15,8 @@ fi
 {{- if eq $tool.installation_method "dotfiles.uv" }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
   "$MISE" exec --cd "{{ $.chezmoi.workingTree }}" -- uv tool install --force --editable "{{ $.chezmoi.workingTree }}/{{ $tool.source_dir }}"
-{{- else }}
+{{- else if ne $tool.installation_method "none" }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
-  "$MISE" exec --cd "{{ $.chezmoi.workingTree }}" -- uv tool uninstall {{ $tool.package_name }} 2>/dev/null || true
+  "$MISE" exec --cd "{{ $.chezmoi.workingTree }}" -- uv tool uninstall {{ index $tool "package_name" }} 2>/dev/null || true
 {{- end }}
 {{ end -}}


### PR DESCRIPTION
…hod tools

Tools with installation_method="none" may lack source_dir/package_name keys, causing missingkey=error template failures. Use index for safe key access and skip the uninstall branch entirely for none-method tools.


Committed-By-Agent: claude