### PR TITLE
feat(agy): install Antigravity CLI via official installer script

### DIFF
--- a/src/chezmoi/.chezmoidata/agy.toml
+++ b/src/chezmoi/.chezmoidata/agy.toml
@@ -1,0 +1,4 @@
+[agy]
+installation_method = "dotfiles.script"
+# Update to trigger reinstall; installer always fetches latest from the manifest service
+version             = "1.0.2"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
@@ -1,0 +1,16 @@
+{{- if eq .agy.installation_method "dotfiles.script" -}}
+#!/bin/bash
+# agy {{ .agy.version }}
+set -euo pipefail
+
+if command -v agy &>/dev/null; then
+    current=$(agy --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
+    if [[ "$current" == "{{ .agy.version }}" ]]; then
+        echo "agy {{ .agy.version }} already installed"
+        exit 0
+    fi
+fi
+
+echo "Installing Antigravity CLI {{ .agy.version }}..."
+curl -fsSL https://antigravity.google/cli/install.sh | bash -s -- --dir "{{ .chezmoi.destDir }}/.local/bin"
+{{- end }}

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -29,3 +29,18 @@ def test_opencode_help(host):
         pytest.skip("opencode is currently disabled on macOS")
     result = host.run("opencode --help")
     assert result.rc == 0, f"'opencode --help' failed.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
+def test_agy_available(host, shell_cmd):
+    """Verify agy is on PATH in bash and zsh."""
+    result = host.run(f"{shell_cmd} 'command -v agy'")
+    assert result.rc == 0, f"'agy' not found via {shell_cmd!r}.\nstderr: {result.stderr}"
+
+
+@pytest.mark.integration
+def test_agy_version(host):
+    """Verify agy --version exits successfully."""
+    result = host.run("agy --version")
+    assert result.rc == 0, f"'agy --version' failed.\nstderr: {result.stderr}\nstdout: {result.stdout}"


### PR DESCRIPTION
## Summary

- Adds `.chezmoidata/agy.toml` to track version and installation method for the Antigravity CLI (`agy`)
- Adds `run_onchange_install-agy.sh.tmpl` to install via the official `install.sh` with `--dir` targeting `{{ .chezmoi.destDir }}/.local/bin`
- Overlays can disable installation by setting `installation_method` to any value other than `"dotfiles.script"`
- Bumping `version` in `agy.toml` acts as the upgrade trigger (installer always fetches latest from the manifest service)
- Adds integration tests for PATH availability and `agy --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)