### PR TITLE
feat: Add WSL clipboard integration for Vim and Neovim

### DIFF
--- a/src/chezmoi/.chezmoitemplates/nvim/base.lua
+++ b/src/chezmoi/.chezmoitemplates/nvim/base.lua
@@ -21,6 +21,22 @@ opt.autoread = true
 -- Use the system clipboard
 opt.clipboard = 'unnamedplus'
 
+-- WSL clipboard integration
+if vim.fn.has('wsl') == 1 then
+  vim.g.clipboard = {
+    name = 'WslClipboard',
+    copy = {
+      ['+'] = 'clip.exe',
+      ['*'] = 'clip.exe',
+    },
+    paste = {
+      ['+'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ['*'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+    },
+    cache_enabled = 0,
+  }
+end
+
 -- Set default encoding to UTF-8
 opt.encoding = 'utf-8'
 

--- a/src/chezmoi/.chezmoitemplates/nvim/editing.lua
+++ b/src/chezmoi/.chezmoitemplates/nvim/editing.lua
@@ -15,6 +15,22 @@ opt.swapfile = false
 -- Use system clipboard for all operations
 opt.clipboard = 'unnamedplus'
 
+-- WSL clipboard integration
+if vim.fn.has('wsl') == 1 then
+  vim.g.clipboard = {
+    name = 'WslClipboard',
+    copy = {
+      ['+'] = 'clip.exe',
+      ['*'] = 'clip.exe',
+    },
+    paste = {
+      ['+'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+      ['*'] = 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))',
+    },
+    cache_enabled = 0,
+  }
+end
+
 -- Set a reasonable update time (affects plugins like gitgutter)
 opt.updatetime = 300
 

--- a/src/chezmoi/dot_dotfiles/vim/snippets/base.vim
+++ b/src/chezmoi/dot_dotfiles/vim/snippets/base.vim
@@ -34,9 +34,18 @@ set hidden
 """ Updates the buffer when a file is changed externally
 set autoread
 
-""" Use the system clipboard
-""" Seamlessly copy/paste between Vim and other applications
+" Use the system clipboard
+"" Seamlessly copy/paste between Vim and other applications
 set clipboard=unnamed
+
+" WSL clipboard integration
+if has('wsl')
+  let g:clipboard = {}
+  let g:clipboard.name = 'WslClipboard'
+  let g:clipboard.copy = { '+': 'clip.exe', '*': 'clip.exe' }
+  let g:clipboard.paste = { '+': 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))', '*': 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))' }
+  let g:clipboard.cache_enabled = 0
+endif
 
 """ Set default encoding to UTF-8
 """ Ensures proper handling of international characters

--- a/src/chezmoi/dot_dotfiles/vim/snippets/editing.vim
+++ b/src/chezmoi/dot_dotfiles/vim/snippets/editing.vim
@@ -21,6 +21,15 @@ set autoread
 " Use system clipboard for all operations
 set clipboard=unnamed,unnamedplus
 
+" WSL clipboard integration
+if has('wsl')
+  let g:clipboard = {}
+  let g:clipboard.name = 'WslClipboard'
+  let g:clipboard.copy = { '+': 'clip.exe', '*': 'clip.exe' }
+  let g:clipboard.paste = { '+': 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))', '*': 'powershell.exe -c [Console]::Out.Write($(Get-Clipboard -Raw).tostring().replace("`r", ""))' }
+  let g:clipboard.cache_enabled = 0
+endif
+
 " Set a reasonable update time (affects plugins like gitgutter)
 set updatetime=300
 


### PR DESCRIPTION
Adds support for copying and pasting to/from the Windows clipboard
when running Vim or Neovim inside WSL, using clip.exe and powershell.exe. This modifies Neovim settings in `.chezmoitemplates/nvim/editing.lua` and `.chezmoitemplates/nvim/base.lua`, and Vim settings in `dot_dotfiles/vim/snippets/editing.vim` and `dot_dotfiles/vim/snippets/base.vim`.

---
*PR created automatically by Jules for task [6118967272629456290](https://jules.google.com/task/6118967272629456290) started by @mkobit*