### PR TITLE
chore(git): ignore .antigravity/ and .antigravitycli/ globally

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -7,3 +7,5 @@
 /bazel-*
 .scratch/
 mise.local.toml
+.antigravity/
+.antigravitycli/


### PR DESCRIPTION
This PR updates .gitignore_global to ignore the .antigravity/ and .antigravitycli/ directories.