### PR TITLE
fix(scripts): add early-exit guards to run_once macOS configuration s…

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_configure-iterm2-bell.sh.tmpl
@@ -2,6 +2,11 @@
 
 source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 
+if [[ "$(defaults read com.googlecode.iterm2 SilenceBell 2>/dev/null)" == "1" ]]; then
+    log_info "iTerm2 bell already silenced — skipping"
+    exit 0
+fi
+
 log_info "Configuring iTerm2 to disable bell sounds..."
 
 # iTerm2 configuration is stored in com.googlecode.iterm2.plist

--- a/src/chezmoi/.chezmoiscripts/run_once_configure-macos-input.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_configure-macos-input.sh.tmpl
@@ -22,6 +22,11 @@ set -euo pipefail
 
 source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 
+if [[ "$(defaults read com.apple.speech.recognition.AppleSpeechRecognition.prefs DictationAccepted 2>/dev/null)" == "1" ]]; then
+    log_info "macOS input already configured — skipping"
+    exit 0
+fi
+
 SYMBOLIC_HOTKEYS_PLIST="{{ .chezmoi.destDir }}/Library/Preferences/com.apple.symbolichotkeys.plist"
 
 # Suppress dictation "Enable?" pop-ups


### PR DESCRIPTION
…cripts

Both scripts use `defaults write` which is idempotent, but they will re-run on first unified chezmoi apply because the new single boltdb has no record of them. Guards skip the work and log a message instead.


Committed-By-Agent: claude