### PR TITLE
fix(git): use nvim if BOM declares it, not just lookPath

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
@@ -1,6 +1,6 @@
 [core]
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeditor
-{{- if lookPath "nvim" }}
+{{- if or (lookPath "nvim") (ne (dig "local" "bin" "nvim" "installation_method" "none" $) "none") }}
 	editor = nvim
 {{- else if lookPath "vim" }}
 	editor = vim


### PR DESCRIPTION
lookPath fails on first apply because nvim hasn't been installed yet by chezmoi externals. Check the BOM declaration too so the editor is correct from the first apply.


Committed-By-Agent: claude