### PR TITLE
chore(claude): use json.dumps sort_keys natively for stable output

### DIFF
--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -11,6 +11,7 @@ except Exception:
 
 managed = json.loads("""{{ .claude_code.settings | toPrettyJson }}""")
 
+
 def deep_merge(d1, d2):
     for k, v in d2.items():
         if isinstance(v, dict) and k in d1 and isinstance(d1[k], dict):
@@ -19,13 +20,7 @@ def deep_merge(d1, d2):
             d1[k] = v
     return d1
 
+
 merged = deep_merge(existing.copy(), managed)
 
-def sort_keys(obj):
-    if isinstance(obj, dict):
-        return {k: sort_keys(v) for k, v in sorted(obj.items())}
-    elif isinstance(obj, list):
-        return [sort_keys(i) for i in obj]
-    return obj
-
-print(json.dumps(sort_keys(merged), indent=2))
+print(json.dumps(merged, indent=2, sort_keys=True))

--- a/src/chezmoi/dot_claude/modify_settings.json.tmpl
+++ b/src/chezmoi/dot_claude/modify_settings.json.tmpl
@@ -23,4 +23,4 @@ def deep_merge(d1, d2):
 
 merged = deep_merge(existing.copy(), managed)
 
-print(json.dumps(merged, indent=2, sort_keys=True))
+print(json.dumps(merged, indent=2, sort_keys=True), end="")

--- a/src/chezmoi/modify_dot_claude.json.tmpl
+++ b/src/chezmoi/modify_dot_claude.json.tmpl
@@ -15,6 +15,7 @@ except Exception:
 
 preferences = json.loads("""{{ .claude_code.preferences | toPrettyJson }}""")
 
+
 def deep_merge(d1, d2):
     for k, v in d2.items():
         if isinstance(v, dict) and k in d1 and isinstance(d1[k], dict):
@@ -23,6 +24,7 @@ def deep_merge(d1, d2):
             d1[k] = v
     return d1
 
+
 merged = deep_merge(existing.copy(), preferences)
 
-print(json.dumps(merged, indent=2), end='')
+print(json.dumps(merged, indent=2, sort_keys=True), end="")


### PR DESCRIPTION
This simplifies the sorting of Claude's settings JSON files by removing a custom sort_keys function and leveraging the built-in json.dumps parameter, which natively provides recursive key sorting.

---
*PR created automatically by Jules for task [8232535044917327240](https://jules.google.com/task/8232535044917327240) started by @mkobit*