### PR TITLE
feat: Add alias completions for git, eza, and chezmoi

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/chezmoi.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/chezmoi.sh
@@ -1,3 +1,9 @@
 {{ completion .shell }}
 
 alias cz='chezmoi'
+
+{{- if eq $.shell "zsh" }}
+compdef cz=chezmoi
+{{- else if eq $.shell "bash" }}
+complete -F _chezmoi -o bashdefault -o default cz
+{{- end }}

--- a/src/chezmoi/.chezmoitemplates/shell/eza.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/eza.sh
@@ -18,5 +18,21 @@ if command -v eza >/dev/null 2>&1; then
     alias l='eza --long --all'
     alias tree='eza --tree'
     alias lt='eza --tree'
+
+    {{- if eq $.shell "zsh" }}
+    compdef ls=eza
+    compdef ll=eza
+    compdef la=eza
+    compdef l=eza
+    compdef tree=eza
+    compdef lt=eza
+    {{- else if eq $.shell "bash" }}
+    complete -F _eza -o bashdefault -o default ls
+    complete -F _eza -o bashdefault -o default ll
+    complete -F _eza -o bashdefault -o default la
+    complete -F _eza -o bashdefault -o default l
+    complete -F _eza -o bashdefault -o default tree
+    complete -F _eza -o bashdefault -o default lt
+    {{- end }}
 fi
 {{- end }}

--- a/src/chezmoi/.chezmoitemplates/shell/git_alias.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/git_alias.sh
@@ -1,6 +1,12 @@
 # Git alias
 alias g='git'
 
+{{- if eq $.shell "zsh" }}
+compdef g=git
+{{- else if eq $.shell "bash" }}
+complete -F _git -o bashdefault -o default g
+{{- end }}
+
 # Prevent prompt tools (Starship, claude-statusline, etc.) from acquiring the
 # advisory index.lock during read-only operations like `git status`.
 # Safe with fsmonitor active — change tracking is handled by the daemon,


### PR DESCRIPTION
This PR adds native shell completion mappings for common shell aliases, allowing autocompletion of arguments for `git` (as `g`), `eza` (as `ls`, `ll`, etc.), and `chezmoi` (as `cz`) in both `zsh` and `bash`.

Changes:
* `src/chezmoi/.chezmoitemplates/shell/git_alias.sh`: Added `compdef g=git` for zsh and `complete -F _git ... g` for bash.
* `src/chezmoi/.chezmoitemplates/shell/eza.sh`: Added completion wrappers mapping `ls`, `ll`, `la`, `l`, `tree`, and `lt` to their underlying `eza` completions in both shells.
* `src/chezmoi/.chezmoitemplates/shell/chezmoi.sh`: Added `compdef cz=chezmoi` for zsh and `complete -F _chezmoi ... cz` for bash.

---
*PR created automatically by Jules for task [9632362179113694701](https://jules.google.com/task/9632362179113694701) started by @mkobit*