### PR TITLE
feat: Add git-delta as managed binary and default git pager

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -16,6 +16,9 @@ installation_method = "github_releases"
 [data.local.bin.bat]
 installation_method = "github_releases"
 
+[data.local.bin.delta]
+installation_method = "github_releases"
+
 [data.local.bin.fd]
 installation_method = "github_releases"
 

--- a/src/chezmoi/.chezmoidata/bin/delta.toml
+++ b/src/chezmoi/.chezmoidata/bin/delta.toml
@@ -1,0 +1,24 @@
+[bin.delta]
+version = "0.18.2"
+
+[bin.delta.github_releases]
+repo            = "dandavison/delta"
+external_type   = "archive-file"
+executable      = true
+checksum_type   = "sha256"
+tag_format      = "{version}"
+filename_format = "delta-{version}-{target}.tar.gz"
+path_format     = "delta-{version}-{target}/delta"
+url_format      = "{base}/{repo}/releases/download/{tag}/{filename}"
+
+[bin.delta.github_releases.platforms]
+darwin_arm64 = "aarch64-apple-darwin"
+darwin_amd64 = "x86_64-apple-darwin"
+linux_amd64  = "x86_64-unknown-linux-gnu"
+linux_arm64  = "aarch64-unknown-linux-gnu"
+
+[bin.delta.github_releases.checksums]
+darwin_arm64 = "6ba38dce9f91ee1b9a24aa4aede1db7195258fe176c3f8276ae2d4457d8170a0"
+darwin_amd64 = "e9b5c4a9e73d2119c687e074f0d97f188e30e5fe8ae0e6d455755f74bb5cc0cf"
+linux_amd64  = "99607c43238e11a77fe90a914d8c2d64961aff84b60b8186c1b5691b39955b0f"
+linux_arm64  = "adf7674086daa4582f598f74ce9caa6b70c1ba8f4a57d2911499b37826b014f9"

--- a/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
@@ -11,3 +11,9 @@
 	excludesFile = ~/.dotfiles/git/snippets/gitignore_global
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefsmonitor
 	fsmonitor = true
+	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corepager
+{{- if or (lookPath "delta") (ne (dig "local" "bin" "delta" "installation_method" "none" $) "none") }}
+	pager = delta
+{{- else if lookPath "less" }}
+	pager = less -FX
+{{- end }}

--- a/src/chezmoi/dot_dotfiles/git/snippets/diff.gitconfig
+++ b/src/chezmoi/dot_dotfiles/git/snippets/diff.gitconfig
@@ -1,3 +1,18 @@
 [diff]
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-diffcompactionHeuristic
 	compactionHeuristic = true
+[interactive]
+	diffFilter = delta --color-only
+
+[delta]
+	navigate = true
+	light = false
+	side-by-side = true
+	line-numbers = true
+	# Features let you group settings.
+	features = decorations
+
+[delta "decorations"]
+	commit-decoration-style = bold yellow box ul
+	file-style = bold yellow ul
+	file-decoration-style = none


### PR DESCRIPTION
This PR addresses the user request to install a better, more modern git diff tool.

Changes:
1. Adds `delta` (git-delta) to `src/chezmoi/.chezmoidata/bin/delta.toml` as a managed binary using GitHub releases.
2. Updates `src/chezmoi/.chezmoi.toml.tmpl` to use `github_releases` as the default installation method for `delta`.
3. Configures `core.pager = delta` in `src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl`.
4. Configures `diffFilter = delta --color-only` and sets clean visual defaults for `[delta]` in `src/chezmoi/dot_dotfiles/git/snippets/diff.gitconfig`.

---
*PR created automatically by Jules for task [15112663056159715244](https://jules.google.com/task/15112663056159715244) started by @mkobit*