### PR TITLE
fix(git): use chezmoi.destDir for global gitignore location

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl
@@ -8,7 +8,7 @@
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf
 	autocrlf = input
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreexcludesFile
-	excludesFile = ~/.dotfiles/git/snippets/gitignore_global
+	excludesFile = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/gitignore_global
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corefsmonitor
 	fsmonitor = true
 	# Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corepager


### PR DESCRIPTION
Replaces the standard `~` path with `{{ .chezmoi.destDir }}` in `src/chezmoi/dot_dotfiles/git/snippets/core.gitconfig.tmpl` to dynamically inject the absolute path for the global gitignore file using chezmoi's deployment target directory rather than a potentially incorrect user home directory.

---
*PR created automatically by Jules for task [4333253977347638340](https://jules.google.com/task/4333253977347638340) started by @mkobit*