### PR TITLE
fix: Update Windows Terminal shift+enter binding to send standard carriage return

### DIFF
--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -72,7 +72,7 @@ if (!\$actionExists) {
     \$newAction = [PSCustomObject]@{
         command = [PSCustomObject]@{
             action = 'sendInput'
-            input = '\u001b[13;2u'
+            input = '\u001b\r'
         }
         id = \$targetActionId
         keys = 'shift+enter'


### PR DESCRIPTION
Updates the `run_onchange_after_windows_terminal_settings.sh.tmpl` script to bind `shift+enter` to `\u001b\r` (Escape + CR) instead of `\u001b[13;2u` (Kitty Keyboard Protocol). Claude Code and Antigravity currently do not recognize the Kitty sequence and print literal characters, whereas sending a standard carriage return achieves the expected newline behavior without artifacting.

---
*PR created automatically by Jules for task [1654335450929020337](https://jules.google.com/task/1654335450929020337) started by @mkobit*