### PR TITLE
fix: cast chezmoi path vars to string before passing to joinPath

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_07_trust-install-repo-mise-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_07_trust-install-repo-mise-tools.sh.tmpl
@@ -1,4 +1,4 @@
-{{- $misePath := joinPath .chezmoi.workingTree "mise.toml" -}}
+{{- $misePath := joinPath (.chezmoi.workingTree | toString) "mise.toml" -}}
 {{- if and (ne (dig "local" "bin" "mise" "installation_method" "none" $) "none") (stat $misePath) -}}
 #!/usr/bin/env bash
 # mise version: {{ .bin.mise.version }}

--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
@@ -1,7 +1,7 @@
 {{- $root := dig "local_bin_tools_root" .chezmoi.workingTree . -}}
 #!/usr/bin/env bash
 # hashes:{{ range $name, $tool := .local_bin_tools }}{{ if index $tool "source_dir" }}
-# {{ $name }}: {{ include (joinPath $root (index $tool "source_dir") "pyproject.toml") | sha256sum }}{{ end }}{{ end }}
+# {{ $name }}: {{ include (joinPath ($root | toString) (index $tool "source_dir") "pyproject.toml") | sha256sum }}{{ end }}{{ end }}
 set -euo pipefail
 
 MISE="{{ .chezmoi.destDir }}/.local/bin/mise"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
@@ -1,6 +1,6 @@
 {{- $root := dig "local_bin_tools_root" .chezmoi.workingTree . -}}
 #!/usr/bin/env bash
-# hashes:{{ range $name, $tool := .local_bin_tools }}{{ if index $tool "source_dir" }}
+# hashes:{{ range $name, $tool := (default dict (get . "local_bin_tools")) }}{{ if index $tool "source_dir" }}
 # {{ $name }}: {{ include (joinPath ($root | toString) (index $tool "source_dir") "pyproject.toml") | sha256sum }}{{ end }}{{ end }}
 set -euo pipefail
 
@@ -14,7 +14,7 @@ fi
 
 "$MISE" trust "{{ $root }}/mise.toml"
 
-{{ range $name, $tool := .local_bin_tools -}}
+{{ range $name, $tool := (default dict (get . "local_bin_tools")) -}}
 {{- if eq $tool.installation_method "dotfiles.uv" }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
   "$MISE" exec --cd "{{ $root }}" -- uv tool install --force --editable "{{ $root }}/{{ $tool.source_dir }}"

--- a/src/chezmoi/dot_config/zellij/layouts/mkobit-workspace.kdl.tmpl
+++ b/src/chezmoi/dot_config/zellij/layouts/mkobit-workspace.kdl.tmpl
@@ -1,4 +1,4 @@
-{{- $workspaceDir := joinPath .chezmoi.destDir "workspace/mkobit" -}}
+{{- $workspaceDir := joinPath (.chezmoi.destDir | toString) "workspace/mkobit" -}}
 {{- if stat $workspaceDir -}}
 layout {
     default_tab_template {

--- a/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
+++ b/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
@@ -1,4 +1,4 @@
-{{- $items := index .ai_plugins "items" -}}
+{{- $items := index (default dict (get . "ai_plugins")) "items" -}}
 {{- if $items -}}
 #!/usr/bin/env bash
 {{/*
@@ -38,7 +38,7 @@ fi
 
 # --- 2. Desired set (rendered from registry at chezmoi apply time) ---
 DESIRED=$(cat <<'DESIRED_PLUGINS'
-{{ range (index .ai_plugins "items") -}}
+{{ range (index (default dict (get . "ai_plugins")) "items") -}}
 {{ if eq .tool "claude" -}}
 {{ .name }}
 {{ end -}}

--- a/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
+++ b/src/chezmoi/dot_local/share/ai/.chezmoiscripts/run_once_sync-personal-plugins.sh.tmpl
@@ -9,7 +9,7 @@
     - Uninstalls plugins installed from @personal-plugins but removed from registry
   Never touches plugins from other marketplaces (e.g. @stripe-internal-marketplace).
 */ -}}
-# registry hash: {{ include (joinPath .chezmoi.sourceDir "dot_local/share/ai/.chezmoidata/plugins.toml") | sha256sum }}
+# registry hash: {{ include (joinPath (.chezmoi.sourceDir | toString) "dot_local/share/ai/.chezmoidata/plugins.toml") | sha256sum }}
 
 set -euo pipefail
 


### PR DESCRIPTION
To prevent type mismatch errors, variables like `.chezmoi.destDir`, `.chezmoi.sourceDir`, and `.chezmoi.workingTree` must be cast to string before being used with functions like `joinPath`, because they evaluate as `chezmoi.AbsPath` objects instead of strings.

---
*PR created automatically by Jules for task [1067357410776252895](https://jules.google.com/task/1067357410776252895) started by @mkobit*