### PR TITLE
fix(zellij): emit aliases for any installation method except none

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/zellij.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/zellij.sh
@@ -1,5 +1,4 @@
-{{- $zellij := index . "zellij" | default (dict) -}}
-{{- if eq (dig "installation_method" "" $zellij) "chezmoi_external" }}
+{{- if ne (dig "local" "bin" "zellij" "installation_method" "none" $) "none" }}
 # Zellij aliases and fzf completion
 alias zj="zellij"
 alias zja="zellij attach"


### PR DESCRIPTION
Condition was `eq installation_method "chezmoi_external"`, which silently skipped aliases when method is `github_releases`. Align with the eza/mise pattern: `ne ... "none"`.


Committed-By-Agent: claude