### PR TITLE
chore: downgrade rich minimum version to >=14

### DIFF
--- a/src/python/claude_statusline/pyproject.toml
+++ b/src/python/claude_statusline/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.12.5",
-    "rich>=15.0.0",
+    "rich>=14",
     "typer>=0.15.1",
     "whenever>=0.9.5",
 ]

--- a/src/python/termtext/pyproject.toml
+++ b/src/python/termtext/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Terminal text formatting library"
 requires-python = ">=3.14"
 dependencies = [
-    "rich>=14.0.0",
+    "rich>=14",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-04T14:39:21.824782748Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -181,7 +181,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "rich", specifier = ">=15.0.0" },
+    { name = "rich", specifier = ">=14" },
     { name = "typer", specifier = ">=0.15.1" },
     { name = "whenever", specifier = ">=0.9.5" },
 ]
@@ -989,7 +989,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "rich", specifier = ">=14.0.0" }]
+requires-dist = [{ name = "rich", specifier = ">=14" }]
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
Downgrade minimum required version of `rich` to `>=14` in `claude_statusline` and `termtext` and updated `uv.lock`.

---
*PR created automatically by Jules for task [12761804063160960167](https://jules.google.com/task/12761804063160960167) started by @mkobit*