### PR TITLE
feat(starship): add extensibility hook for overlay-injected custom se…

### DIFF
--- a/src/chezmoi/dot_config/starship.toml.tmpl
+++ b/src/chezmoi/dot_config/starship.toml.tmpl
@@ -38,3 +38,8 @@ ignore_branches = {{ dig "starship" "ignore_branches" list . | toToml }}
 
 [python]
 disabled = {{ not (dig "starship" "modules" "python" "enabled" true .) }}
+{{- range $name, $cfg := dig "starship" "custom_segments" dict . }}
+
+[custom.{{ $name }}]
+{{ $cfg | toToml -}}
+{{- end }}


### PR DESCRIPTION
…gments

Add a range loop over `starship.custom_segments` data at the end of starship.toml.tmpl, rendering each entry via toToml. When no data is provided the output is unchanged; overlays inject segments by setting `[data.starship.custom_segments.*]` in their .chezmoi.toml.tmpl.


Committed-By-Agent: claude