### PR TITLE
feat(claude-statusline): implement grid layout engine

### DIFF
--- a/src/python/claude_statusline/claude_statusline/layout.py
+++ b/src/python/claude_statusline/claude_statusline/layout.py
@@ -10,5 +10,6 @@ class SegmentGenerationResult(BaseModel):
     segment: Segment
     line: int = 0
     index: int = 0
+    column: int | None = None
     generator: str = "internal"
     cache_duration: TimeDelta | None = None

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -19,6 +19,7 @@ from claude_statusline.render import render_lines
 from claude_statusline.segments.claude import (
     format_context_usage,
     format_cost,
+    format_lines_impact,
     format_model_info,
     format_session_info,
 )
@@ -194,15 +195,17 @@ def main(  # noqa: C901
     asyncio.run(fetch_all())
 
     try:
-        internal_results = [
+        internal_results_nested = [
             format_model_info(payload),
             format_session_info(payload),
             format_directory(cwd),
             format_obsidian_vault(cwd),
             format_context_usage(payload.context_window),
             format_cost(payload),
+            format_lines_impact(payload),
         ]
-        all_segments.extend([r for r in internal_results if r])
+        for result_list in internal_results_nested:
+            all_segments.extend(result_list)
     except Exception as e:
         all_segments.extend(handle_error(e, "internal.claude_or_workspace"))
 

--- a/src/python/claude_statusline/claude_statusline/main.py
+++ b/src/python/claude_statusline/claude_statusline/main.py
@@ -135,10 +135,11 @@ def main(  # noqa: C901
         return []
 
     async def fetch_all() -> None:  # noqa: C901
+        nonlocal all_segments
         git_key = f"internal.git:{cwd.resolve()}"
         cached_git = await cache.get(git_key)
         if cached_git is not None:
-            all_segments.extend(cached_git)
+            all_segments = all_segments + cached_git
         else:
 
             async def wrap_git():
@@ -154,7 +155,7 @@ def main(  # noqa: C901
             cmd_key = f"external:{cmd}"
             cached_cmd = await cache.get(cmd_key)
             if cached_cmd is not None:
-                all_segments.extend(cached_cmd)
+                all_segments = all_segments + cached_cmd
             else:
 
                 async def wrap_cmd(c=cmd, ck=cmd_key):
@@ -171,9 +172,9 @@ def main(  # noqa: C901
         cache_updates = []
         for _, key, res in results:
             if isinstance(res, Exception):
-                all_segments.extend(handle_error(res, key))
+                all_segments = all_segments + handle_error(res, key)
             else:
-                all_segments.extend(res)
+                all_segments = all_segments + res
                 if res:
                     try:
                         if any(hasattr(r, "cache_duration") and r.cache_duration for r in res):
@@ -205,9 +206,9 @@ def main(  # noqa: C901
             format_lines_impact(payload),
         ]
         for result_list in internal_results_nested:
-            all_segments.extend(result_list)
+            all_segments = all_segments + result_list
     except Exception as e:
-        all_segments.extend(handle_error(e, "internal.claude_or_workspace"))
+        all_segments = all_segments + handle_error(e, "internal.claude_or_workspace")
 
     lines = render_lines(payload, None, all_segments)
 

--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -32,23 +32,38 @@ def render_lines(
     # Find unique rows (lines)
     all_lines = sorted({seg.line for seg in segments_list})
 
+    # Reference: https://github.com/Owloops/claude-powerline
+    # TUI Mode layout engine uses a 5-column grid by default.
     table = Table(show_header=False, show_edge=False, box=None, padding=(0, 1), expand=True)
-    table.add_column("left", justify="left", ratio=1, no_wrap=True)
-    table.add_column("right", justify="right", no_wrap=True)
+    table.add_column("col0", justify="left", no_wrap=True)
+    table.add_column("col1", justify="left", ratio=1, no_wrap=True)
+    table.add_column("col2", justify="right", no_wrap=True)
+    table.add_column("col3", justify="right", no_wrap=True)
+    table.add_column("col4", justify="right", no_wrap=True)
 
     for line in all_lines:
         line_segs = [s for s in segments_list if s.line == line]
 
-        # Split into left (index < 10) and right (index >= 10)
-        left_segs = [s for s in line_segs if s.index < 10]
-        right_segs = [s for s in line_segs if s.index >= 10]
+        # Group segments by column
+        col_segs: dict[int, list[SegmentGenerationResult]] = {i: [] for i in range(5)}
 
-        left_text = sep.join(s.segment.text for s in sorted(left_segs, key=lambda x: x.index))
-        right_text = sep.join(s.segment.text for s in sorted(right_segs, key=lambda x: x.index))
+        for s in line_segs:
+            if s.column is not None:
+                col = max(0, min(4, s.column))
+                col_segs[col].append(s)
+            # Fallback mapping based on index
+            elif s.index < 10:
+                col_segs[0].append(s)
+            else:
+                col_segs[4].append(s)
 
-        table.add_row(
-            Text.from_ansi(left_text) if left_text else Text(""), Text.from_ansi(right_text) if right_text else Text("")
-        )
+        col_texts = []
+        for i in range(5):
+            segs = sorted(col_segs[i], key=lambda x: x.index)
+            text = sep.join(s.segment.text for s in segs)
+            col_texts.append(Text.from_ansi(text) if text else Text(""))
+
+        table.add_row(*col_texts)
 
     console = Console(width=safe_width, force_terminal=True, color_system="truecolor", highlight=False)
     with console.capture() as capture:

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -33,7 +33,7 @@ def format_tokens(tokens: int, max_tokens: int = 0) -> str:
     return f"{val:>{width}}"
 
 
-def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | None:
+def format_context_usage(cw: ContextWindowInfo) -> list[SegmentGenerationResult]:
     """Formats context usage as a battery icon with remaining % and token counts."""
     used_pct = cw.used_percentage or 0.0
     remaining_pct = 100.0 - used_pct
@@ -63,32 +63,55 @@ def format_context_usage(cw: ContextWindowInfo) -> SegmentGenerationResult | Non
     )
 
     dot = get_icon("dot")
-    parts = [pct_str, f"{DIM}{dot}{RESET} {token_str}" if token_str else None]
 
-    return SegmentGenerationResult(
-        line=2,
-        index=0,
-        generator="internal.claude",
-        segment=Segment(text=" ".join(filter(None, parts))),
-    )
+    results = []
+    if pct_str:
+        results.append(
+            SegmentGenerationResult(
+                line=2, index=0, column=0, generator="internal.claude", segment=Segment(text=pct_str)
+            )
+        )
+    if token_str:
+        results.append(
+            SegmentGenerationResult(
+                line=2,
+                index=10,
+                column=1,
+                generator="internal.claude",
+                segment=Segment(text=f"{DIM}{dot}{RESET} {token_str}"),
+            )
+        )
+    return results
 
 
-def format_model_info(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
+def format_model_info(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
     style = payload.output_style
-    parts = [
-        f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}",
-        f"{MAGENTA}@{payload.agent.name}{RESET}" if payload.agent.name else None,
-        f"{DIM}[{style.name}]{RESET}" if style and style.name else None,
-    ]
-    return SegmentGenerationResult(
-        line=0,
-        index=0,
-        generator="internal.claude",
-        segment=Segment(text=" ".join(filter(None, parts))),
+    results = []
+    model_str = f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}"
+    results.append(
+        SegmentGenerationResult(line=0, index=0, column=0, generator="internal.claude", segment=Segment(text=model_str))
     )
 
+    agent_style_parts = []
+    if payload.agent.name:
+        agent_style_parts.append(f"{MAGENTA}@{payload.agent.name}{RESET}")
+    if style and style.name:
+        agent_style_parts.append(f"{DIM}[{style.name}]{RESET}")
 
-def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
+    if agent_style_parts:
+        results.append(
+            SegmentGenerationResult(
+                line=0,
+                index=10,
+                column=1,
+                generator="internal.claude",
+                segment=Segment(text=" ".join(agent_style_parts)),
+            )
+        )
+    return results
+
+
+def format_session_info(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
     parts = [
         f"{CYAN}#{payload.session_name}{RESET}" if payload.session_name else None,
     ]
@@ -102,43 +125,68 @@ def format_session_info(payload: StatusLineStdIn) -> SegmentGenerationResult | N
 
         parts.append(f"{YELLOW}{get_icon('timer')} {timer}{RESET}")
 
-    filtered = [p for p in parts if p]
-    if not filtered:
-        return None
-    return SegmentGenerationResult(
-        line=0,
-        index=10,
-        generator="internal.claude",
-        segment=Segment(text=" ".join(filtered)),
-    )
+    results = []
+    if payload.session_name:
+        results.append(
+            SegmentGenerationResult(
+                line=0,
+                index=0,
+                column=1,
+                generator="internal.claude",
+                segment=Segment(text=f"{CYAN}#{payload.session_name}{RESET}"),
+            )
+        )
+
+    if payload.cost.total_duration_ms:
+        elapsed_seconds = payload.cost.total_duration_ms // 1000
+        hours, remainder = divmod(elapsed_seconds, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        timer = f"{hours:02d}:{minutes:02d}:{seconds:02d}" if hours > 0 else f"{minutes:02d}:{seconds:02d}"
+        results.append(
+            SegmentGenerationResult(
+                line=0,
+                index=10,
+                column=4,
+                generator="internal.claude",
+                segment=Segment(text=f"{YELLOW}{get_icon('timer')} {timer}{RESET}"),
+            )
+        )
+
+    return results
 
 
-def format_cost(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
+def format_cost(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
     if not payload.cost.total_cost_usd:
-        return None
-    return SegmentGenerationResult(
-        line=2,
-        index=20,
-        generator="internal.claude",
-        segment=Segment(text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"),
-    )
+        return []
+    return [
+        SegmentGenerationResult(
+            line=2,
+            index=20,
+            column=4,
+            generator="internal.claude",
+            segment=Segment(text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"),
+        )
+    ]
 
 
-def format_lines_impact(payload: StatusLineStdIn) -> SegmentGenerationResult | None:
+def format_lines_impact(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
     added = payload.cost.total_lines_added or 0
     removed = payload.cost.total_lines_removed or 0
 
     if added == 0 and removed == 0:
-        return None
+        return []
 
     parts = [
         f"{BRIGHT_GREEN}+{added}{RESET}" if added > 0 else None,
         f"{BRIGHT_RED}-{removed}{RESET}" if removed > 0 else None,
     ]
 
-    return SegmentGenerationResult(
-        line=1,
-        index=30,
-        generator="internal.claude",
-        segment=Segment(text=" ".join(filter(None, parts))),
-    )
+    return [
+        SegmentGenerationResult(
+            line=1,
+            index=30,
+            column=4,
+            generator="internal.claude",
+            segment=Segment(text=" ".join(filter(None, parts))),
+        )
+    ]

--- a/src/python/claude_statusline/claude_statusline/segments/git.py
+++ b/src/python/claude_statusline/claude_statusline/segments/git.py
@@ -168,21 +168,32 @@ async def generate_git_segment(cwd: Path, is_worktree: bool) -> Sequence[Segment
         stash_count=stash_count,
     )
 
-    result = format_git_full(info)
-    if result:
-        return [result]
-    return []
+    return format_git_full(info)
 
 
-def format_git_full(info: GitInfo | None) -> SegmentGenerationResult | None:
+def format_git_full(info: GitInfo | None) -> list[SegmentGenerationResult]:
     if not info:
-        return None
+        return []
 
     branch_icon = get_icon("worktree") if info.is_worktree else get_icon("branch")
     branch_url = _build_branch_url(info.remote, info.branch) if info.remote else None
     branch_display = f"\033]8;;{branch_url}\033\\{info.branch}\033]8;;\033\\" if branch_url else info.branch
-    parts = [f"{MAGENTA}{branch_icon} {branch_display}{RESET}"]
 
+    results = []
+
+    # Col 0: Branch
+    results.append(
+        SegmentGenerationResult(
+            line=1,
+            index=0,
+            column=0,
+            segment=Segment(text=f"{MAGENTA}{branch_icon} {branch_display}{RESET}"),
+            generator="internal.git",
+            cache_duration=TimeDelta(seconds=5),
+        )
+    )
+
+    # Col 1: Status
     status_parts = [
         f"{RED}{get_icon('dirty')}{RESET}" if info.dirty else None,
         f"{YELLOW}{get_icon('staged')}{RESET}" if info.staged else None,
@@ -192,14 +203,40 @@ def format_git_full(info: GitInfo | None) -> SegmentGenerationResult | None:
     if not filled:
         filled = [f"{GREEN}{get_icon('clean')}{RESET}"]
 
-    parts.append(f"[{''.join(filled)}]")
+    results.append(
+        SegmentGenerationResult(
+            line=1,
+            index=10,
+            column=1,
+            segment=Segment(text=f"[{''.join(filled)}]"),
+            generator="internal.git",
+            cache_duration=TimeDelta(seconds=5),
+        )
+    )
 
+    # Col 2: Ahead / Behind
+    ahead_behind_parts = []
     if info.ahead > 0:
-        parts.append(f"{GREEN}↑{info.ahead}{RESET}")
+        ahead_behind_parts.append(f"{GREEN}↑{info.ahead}{RESET}")
     if info.behind > 0:
-        parts.append(f"{RED}↓{info.behind}{RESET}")
+        ahead_behind_parts.append(f"{RED}↓{info.behind}{RESET}")
+
+    if ahead_behind_parts:
+        results.append(
+            SegmentGenerationResult(
+                line=1,
+                index=20,
+                column=2,
+                segment=Segment(text=" ".join(ahead_behind_parts)),
+                generator="internal.git",
+                cache_duration=TimeDelta(seconds=5),
+            )
+        )
+
+    # Col 3: Stash / Remote
+    stash_remote_parts = []
     if info.stash_count > 0:
-        parts.append(f"{YELLOW}{get_icon('stash')}{info.stash_count}{RESET}")
+        stash_remote_parts.append(f"{YELLOW}{get_icon('stash')}{info.stash_count}{RESET}")
 
     if info.remote:
         platform_icon = (
@@ -209,12 +246,18 @@ def format_git_full(info: GitInfo | None) -> SegmentGenerationResult | None:
             if "gitlab.com" in info.remote
             else get_icon("remote")
         )
-        parts.append(f"[ \033]8;;{info.remote}\033\\{platform_icon}\033]8;;\033\\ ]")
+        stash_remote_parts.append(f"[ \033]8;;{info.remote}\033\\{platform_icon}\033]8;;\033\\ ]")
 
-    return SegmentGenerationResult(
-        line=1,
-        index=0,
-        segment=Segment(text=" ".join(parts)),
-        generator="internal.git",
-        cache_duration=TimeDelta(seconds=5),
-    )
+    if stash_remote_parts:
+        results.append(
+            SegmentGenerationResult(
+                line=1,
+                index=30,
+                column=3,
+                segment=Segment(text=" ".join(stash_remote_parts)),
+                generator="internal.git",
+                cache_duration=TimeDelta(seconds=5),
+            )
+        )
+
+    return results

--- a/src/python/claude_statusline/claude_statusline/segments/workspace.py
+++ b/src/python/claude_statusline/claude_statusline/segments/workspace.py
@@ -21,27 +21,33 @@ def shorten_path(path: Path) -> str:
         return str(path)
 
 
-def format_directory(cwd: Path) -> SegmentGenerationResult | None:
+def format_directory(cwd: Path) -> list[SegmentGenerationResult]:
     display_path = shorten_path(cwd)
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
-    return SegmentGenerationResult(
-        line=0,
-        index=5,
-        generator="internal.workspace",
-        segment=Segment(text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"),
-    )
+    return [
+        SegmentGenerationResult(
+            line=0,
+            index=5,
+            column=4,
+            generator="internal.workspace",
+            segment=Segment(text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"),
+        )
+    ]
 
 
-def format_obsidian_vault(cwd: Path) -> SegmentGenerationResult | None:
+def format_obsidian_vault(cwd: Path) -> list[SegmentGenerationResult]:
     current = cwd
     while current != current.parent:
         if (current / ".obsidian").is_dir():
             vault_name = current.name
-            return SegmentGenerationResult(
-                line=0,
-                index=40,
-                generator="internal.workspace",
-                segment=Segment(text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}"),
-            )
+            return [
+                SegmentGenerationResult(
+                    line=0,
+                    index=40,
+                    column=2,
+                    generator="internal.workspace",
+                    segment=Segment(text=f"{BLUE}{get_icon('obsidian')} {vault_name}{RESET}"),
+                )
+            ]
         current = current.parent
-    return None
+    return []

--- a/src/python/claude_statusline/tests/test_segments_claude.py
+++ b/src/python/claude_statusline/tests/test_segments_claude.py
@@ -68,12 +68,12 @@ class TestFormatContextUsage(unittest.TestCase):
             with self.subTest(used_pct=used_pct):
                 res = format_context_usage(ContextWindowInfo(used_percentage=used_pct))
                 assert res is not None
-                self.assertIn(expected_color, res.segment.text)
+                self.assertIn(expected_color, " ".join([r.segment.text for r in res]))
 
     def test_battery_icon_present(self) -> None:
         res = format_context_usage(ContextWindowInfo(used_percentage=22.0))
         assert res is not None
-        self.assertIn("78%", res.segment.text)
+        self.assertIn("78%", " ".join([r.segment.text for r in res]))
 
     def test_token_counts_shown_when_window_known(self) -> None:
         cw = ContextWindowInfo(
@@ -84,23 +84,23 @@ class TestFormatContextUsage(unittest.TestCase):
         )
         res = format_context_usage(cw)
         assert res is not None
-        self.assertIn("50k", res.segment.text)
-        self.assertIn("200k", res.segment.text)
+        self.assertIn("50k", " ".join([r.segment.text for r in res]))
+        self.assertIn("200k", " ".join([r.segment.text for r in res]))
 
     def test_no_token_counts_without_window_size(self) -> None:
         res = format_context_usage(ContextWindowInfo(used_percentage=50.0))
         assert res is not None
-        self.assertNotIn("/", res.segment.text)
+        self.assertNotIn("/", " ".join([r.segment.text for r in res]))
 
     def test_zero_usage_defaults_to_bright_green(self) -> None:
         res = format_context_usage(ContextWindowInfo(used_percentage=None))
         assert res is not None
-        self.assertIn(BRIGHT_GREEN, res.segment.text)
+        self.assertIn(BRIGHT_GREEN, " ".join([r.segment.text for r in res]))
 
     def test_placed_on_line_2(self) -> None:
         res = format_context_usage(ContextWindowInfo(used_percentage=50.0))
         assert res is not None
-        self.assertEqual(res.line, 2)
+        self.assertEqual(res[0].line if res else None, 2)
 
 
 class TestFormatModelInfo(unittest.TestCase):
@@ -108,7 +108,7 @@ class TestFormatModelInfo(unittest.TestCase):
         payload = StatusLineStdIn(model=ModelInfo(display_name="Sonnet 4.6"))
         res = format_model_info(payload)
         assert res is not None
-        self.assertIn("Sonnet 4.6", res.segment.text)
+        self.assertIn("Sonnet 4.6", " ".join([r.segment.text for r in res]))
 
     def test_output_style_present(self) -> None:
         payload = StatusLineStdIn(
@@ -117,14 +117,14 @@ class TestFormatModelInfo(unittest.TestCase):
         )
         res = format_model_info(payload)
         assert res is not None
-        self.assertIn("[concise]", res.segment.text)
+        self.assertIn("[concise]", " ".join([r.segment.text for r in res]))
 
     def test_no_output_style_when_absent(self) -> None:
         payload = StatusLineStdIn(model=ModelInfo(display_name="X"))
         res = format_model_info(payload)
         assert res is not None
-        self.assertNotIn("concise", res.segment.text)
-        self.assertNotIn("default", res.segment.text)
+        self.assertNotIn("concise", " ".join([r.segment.text for r in res]))
+        self.assertNotIn("default", " ".join([r.segment.text for r in res]))
 
     def test_agent_name_present(self) -> None:
         payload = StatusLineStdIn(
@@ -133,7 +133,7 @@ class TestFormatModelInfo(unittest.TestCase):
         )
         res = format_model_info(payload)
         assert res is not None
-        self.assertIn("my-agent", res.segment.text)
+        self.assertIn("my-agent", " ".join([r.segment.text for r in res]))
 
 
 class TestFormatSessionInfo(unittest.TestCase):
@@ -141,22 +141,22 @@ class TestFormatSessionInfo(unittest.TestCase):
         payload = StatusLineStdIn(session_name="my-session")
         res = format_session_info(payload)
         assert res is not None
-        self.assertIn("my-session", res.segment.text)
+        self.assertIn("my-session", " ".join([r.segment.text for r in res]))
 
     def test_session_id_hash_not_shown(self) -> None:
         payload = StatusLineStdIn(session_id="abc123def456")
         res = format_session_info(payload)
-        self.assertIsNone(res)
+        self.assertEqual(res, [])
 
     def test_timer_formatted(self) -> None:
         payload = StatusLineStdIn(cost=CostInfo(total_duration_ms=3_661_000))
         res = format_session_info(payload)
         assert res is not None
-        self.assertIn("01:01:01", res.segment.text)
+        self.assertIn("01:01:01", " ".join([r.segment.text for r in res]))
 
     def test_returns_none_with_no_data(self) -> None:
         res = format_session_info(StatusLineStdIn())
-        self.assertIsNone(res)
+        self.assertEqual(res, [])
 
 
 class TestFormatCost(unittest.TestCase):
@@ -164,18 +164,18 @@ class TestFormatCost(unittest.TestCase):
         payload = StatusLineStdIn(cost=CostInfo(total_cost_usd=1.23))
         res = format_cost(payload)
         assert res is not None
-        self.assertIn("1.23", res.segment.text)
+        self.assertIn("1.23", " ".join([r.segment.text for r in res]))
 
     def test_returns_none_when_zero(self) -> None:
         payload = StatusLineStdIn(cost=CostInfo(total_cost_usd=0.0))
         res = format_cost(payload)
-        self.assertIsNone(res)
+        self.assertEqual(res, [])
 
     def test_placed_on_line_2(self) -> None:
         payload = StatusLineStdIn(cost=CostInfo(total_cost_usd=0.5))
         res = format_cost(payload)
         assert res is not None
-        self.assertEqual(res.line, 2)
+        self.assertEqual(res[0].line if res else None, 2)
 
 
 if __name__ == "__main__":

--- a/src/python/claude_statusline/tests/test_segments_git.py
+++ b/src/python/claude_statusline/tests/test_segments_git.py
@@ -34,56 +34,56 @@ class TestFormatGitFull(unittest.TestCase):
     def test_branch_name_shown(self) -> None:
         res = format_git_full(_git_info())
         assert res is not None
-        self.assertIn("main", res.segment.text)
+        self.assertIn("main", " ".join([r.segment.text for r in res]))
 
     def test_clean_icon_in_brackets(self) -> None:
         res = format_git_full(_git_info())
         assert res is not None
-        self.assertIn(get_icon("clean"), res.segment.text)
-        self.assertIn("[", res.segment.text)
-        self.assertIn("]", res.segment.text)
+        self.assertIn(get_icon("clean"), " ".join([r.segment.text for r in res]))
+        self.assertIn("[", " ".join([r.segment.text for r in res]))
+        self.assertIn("]", " ".join([r.segment.text for r in res]))
 
     def test_dirty_icon_in_brackets(self) -> None:
         res = format_git_full(_git_info(dirty=True))
         assert res is not None
-        self.assertIn(RED, res.segment.text)
-        self.assertIn(get_icon("dirty"), res.segment.text)
-        self.assertIn("[", res.segment.text)
+        self.assertIn(RED, " ".join([r.segment.text for r in res]))
+        self.assertIn(get_icon("dirty"), " ".join([r.segment.text for r in res]))
+        self.assertIn("[", " ".join([r.segment.text for r in res]))
 
     def test_staged_icon_in_brackets(self) -> None:
         res = format_git_full(_git_info(staged=True))
         assert res is not None
-        self.assertIn(YELLOW, res.segment.text)
-        self.assertIn(get_icon("staged"), res.segment.text)
+        self.assertIn(YELLOW, " ".join([r.segment.text for r in res]))
+        self.assertIn(get_icon("staged"), " ".join([r.segment.text for r in res]))
 
     def test_untracked_icon_in_brackets(self) -> None:
         res = format_git_full(_git_info(untracked=True))
         assert res is not None
-        self.assertIn(CYAN, res.segment.text)
-        self.assertIn(get_icon("untracked"), res.segment.text)
+        self.assertIn(CYAN, " ".join([r.segment.text for r in res]))
+        self.assertIn(get_icon("untracked"), " ".join([r.segment.text for r in res]))
 
     def test_ahead_behind_shown(self) -> None:
         res = format_git_full(_git_info(ahead=3, behind=1))
         assert res is not None
-        self.assertIn("↑3", res.segment.text)
-        self.assertIn("↓1", res.segment.text)
+        self.assertIn("↑3", " ".join([r.segment.text for r in res]))
+        self.assertIn("↓1", " ".join([r.segment.text for r in res]))
 
     def test_stash_shown(self) -> None:
         res = format_git_full(_git_info(stash_count=2))
         assert res is not None
-        self.assertIn("2", res.segment.text)
-        self.assertIn(get_icon("stash"), res.segment.text)
+        self.assertIn("2", " ".join([r.segment.text for r in res]))
+        self.assertIn(get_icon("stash"), " ".join([r.segment.text for r in res]))
 
     def test_stash_hidden_when_zero(self) -> None:
         res = format_git_full(_git_info(stash_count=0))
         assert res is not None
-        self.assertNotIn(get_icon("stash"), res.segment.text)
+        self.assertNotIn(get_icon("stash"), " ".join([r.segment.text for r in res]))
 
     def test_remote_link_points_to_branch(self) -> None:
         res = format_git_full(_git_info(branch="feat/my-feature"))
         assert res is not None
         expected = "https://github.com/example/repo/tree/feat/my-feature"
-        self.assertIn(expected, res.segment.text)
+        self.assertIn(expected, " ".join([r.segment.text for r in res]))
 
     def test_gitlab_remote_link_uses_dash_tree(self) -> None:
         res = format_git_full(
@@ -93,26 +93,26 @@ class TestFormatGitFull(unittest.TestCase):
             )
         )
         assert res is not None
-        self.assertIn("https://gitlab.com/org/project/-/tree/main", res.segment.text)
+        self.assertIn("https://gitlab.com/org/project/-/tree/main", " ".join([r.segment.text for r in res]))
 
     def test_no_remote_no_link(self) -> None:
         res = format_git_full(_git_info(remote=None))
         assert res is not None
-        self.assertNotIn(get_icon("remote"), res.segment.text)
+        self.assertNotIn(get_icon("remote"), " ".join([r.segment.text for r in res]))
 
     def test_worktree_uses_worktree_icon(self) -> None:
         res = format_git_full(_git_info(is_worktree=True))
         assert res is not None
-        self.assertIn(get_icon("worktree"), res.segment.text)
-        self.assertNotIn(get_icon("branch"), res.segment.text)
+        self.assertIn(get_icon("worktree"), " ".join([r.segment.text for r in res]))
+        self.assertNotIn(get_icon("branch"), " ".join([r.segment.text for r in res]))
 
     def test_placed_on_line_1(self) -> None:
         res = format_git_full(_git_info())
         assert res is not None
-        self.assertEqual(res.line, 1)
+        self.assertEqual(res[0].line if res else None, 1)
 
     def test_returns_none_for_none_input(self) -> None:
-        self.assertIsNone(format_git_full(None))
+        self.assertEqual(format_git_full(None), [])
 
 
 class TestGenerateGitSegment(unittest.TestCase):
@@ -148,7 +148,7 @@ class TestGenerateGitSegment(unittest.TestCase):
             results = asyncio.run(generate_git_segment(Path("/tmp/repo"), False))
 
         self.assertGreater(len(results), 0)
-        text = results[0].segment.text
+        text = " ".join(r.segment.text for r in results)
         self.assertIn("feature-branch", text)
         self.assertIn("https://github.com/user/repo", text)
         self.assertIn(GREEN, text)


### PR DESCRIPTION
- Updates `render_lines` in `render.py` to use a 5-column `rich.Table` (col0-col4), aligning with the TUI mode layout from `claude-powerline`.
- Adds `column` field to `SegmentGenerationResult` to map segments directly into the grid structure.
- Refactors formatting functions across `claude.py`, `workspace.py`, and `git.py` to return lists of segments, correctly distributing UI elements across the new columns.
- Adjusts test suite assertions to handle list returns correctly.

---
*PR created automatically by Jules for task [18027638328672686968](https://jules.google.com/task/18027638328672686968) started by @mkobit*