### PR TITLE
chore(ai): prune orphaned unmanaged agents from April experiments

### DIFF
--- a/src/chezmoi/.chezmoiremove
+++ b/src/chezmoi/.chezmoiremove
@@ -42,6 +42,19 @@ install-asdf.sh
 .cursor/skills/typescript-expert
 .cursor/skills/write-agent-context
 
+# Orphaned unmanaged agents from April 2026 experiments: agency-agents
+# engineering category (dumped flat and as a directory) and manual extractions
+# of installed official plugins. Agents will be onboarded curated + pinned via
+# the catalog later; drop/adjust these entries when that phase deploys to
+# .claude/agents so they don't fight the externals.
+.claude/agents/engineering
+.claude/agents/engineering-*.md
+.claude/agents/agent-sdk-dev
+.claude/agents/compound-review-agents
+.claude/agents/feature-dev
+.claude/agents/plugin-dev
+.claude/agents/pr-review-toolkit
+
 # Remove Oh-My-Zsh installation and custom configuration files when it is disabled
 {{ if ne .zsh.prompt "oh-my-zsh" }}
 .dotfiles/external/oh-my-zsh


### PR DESCRIPTION
## Summary
- Add static `.chezmoiremove` entries for orphaned unmanaged files in `~/.claude/agents/`: the agency-agents engineering category (dumped both flat and as a directory in April) and manual extractions of installed official plugins (agent-sdk-dev, compound-review-agents, feature-dev, plugin-dev, pr-review-toolkit)
- Overlay machines prune the same leftovers on next apply, matching the rulesync-era cursor cleanup precedent
- Entries are commented to be dropped/adjusted when the curated agents catalog phase deploys to `.claude/agents`

## Test plan
- [x] `chezmoi apply --force` — `~/.claude/agents/` emptied locally, nothing managed was touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)