### PR TITLE
feat(ai): deploy curated Claude Code subagents via pinned chezmoi externals

### DIFF
--- a/src/ai/AGENTS.md
+++ b/src/ai/AGENTS.md
@@ -3,5 +3,6 @@
 Skills deploy as static files via chezmoi externals — never the Claude plugin marketplace or `claude plugin` CLI.
 The catalog is `src/chezmoi/.chezmoidata/ai/skills.toml`: upstream sources pin a commit `ref` + archive `sha256`; skill entries are `"present"` (all tools), `"absent"`, or a single tool name like `"claude"` (never delete a key — set it `"absent"` so `.chezmoiremove.tmpl` prunes the installed copy).
 Authored skills live in `src/ai/skills/<name>/` and deploy as copies, never symlinks.
+Upstream Claude Code subagents use the same model via `.chezmoidata/ai/agents.toml` (Claude-only — agent frontmatter is tool-proprietary); onboarding any upstream skill or agent requires a content review at the pinned ref.
 `src/python/skill_filter` must stay stdlib-only — it runs via system python3 at apply time, before uv/mise exist.
 Guide: `README.md` in this directory.

--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -35,6 +35,13 @@ A skill state is `"present"` (deploy to every tool), `"absent"`, or a single too
 To remove a skill, set it to `"absent"` — never delete the key, which would orphan the installed copy.
 The `.chezmoiremove.tmpl` files in `dot_claude/` and `dot_gemini/` prune any skill that does not target their tool on apply.
 
+## Upstream agents (Claude Code only)
+
+Claude Code subagents follow the same pin-and-select model via `src/chezmoi/.chezmoidata/ai/agents.toml` and `src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl`.
+Each source gets one exact archive external placing selected agent `.md` files flat under `~/.claude/agents/<source>/`, so flipping an agent to `"absent"` prunes it on the next apply without a removal template.
+Agents deploy only to Claude Code: agent frontmatter is tool-proprietary (other tools need format conversion), unlike the quasi-standard SKILL.md.
+Onboarding an agent requires a prompt-injection review of its full content at the pinned ref.
+
 ## Authored skills
 
 Full directory trees under `src/ai/skills/<name>/`, listed in `[ai.skills.authored]`, deployed as copies by `src/chezmoi/.chezmoiexternals/ai-authored-skills.toml.tmpl`.

--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -1,0 +1,35 @@
+# AI agent deployment catalog (Claude Code subagents only).
+#
+# Agents are single .md files selected from pinned upstream archives and placed
+# under ~/.claude/skills sibling dir ~/.claude/agents/<source>/ by
+# .chezmoiexternals/ai-agents.toml.tmpl. Claude Code is the only target: agent
+# frontmatter is tool-proprietary (antigravity converts agents into skills,
+# cursor into .mdc rules, etc.), so cross-tool deployment needs the deferred
+# transformation layer. The upstream agency-agents format (name, description,
+# color, emoji, vibe) is native Claude Code subagent format.
+#
+# Each [.agents] entry maps an in-archive path (under agents_root, default "")
+# without the .md suffix to "present" or "absent". The external is exact, so
+# agents flipped to "absent" are pruned on the next apply; emptying a source
+# entirely orphans its ~/.claude/agents/<source>/ directory — prune manually.
+#
+# Onboarding requires a prompt-injection review of each agent at the pinned
+# ref (see memory: supply-chain scrutiny). Pin via:
+#   curl -sL https://codeload.github.com/<repo>/tar.gz/<ref> | sha256sum
+
+[ai.agents.external.agency-agents]
+repo = "msitarzewski/agency-agents"
+ref = "a077c9ac0be381ec15e7dcbb690f641d6091a5db" # 2026-06-07
+sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
+
+[ai.agents.external.agency-agents.agents]
+"product/product-feedback-synthesizer" = "present"
+"product/product-manager" = "present"
+"product/product-sprint-prioritizer" = "present"
+"product/product-trend-researcher" = "present"
+"project-management/project-management-experiment-tracker" = "present"
+"project-management/project-management-meeting-notes-specialist" = "present"
+"project-management/project-management-project-shepherd" = "present"
+# Rejected 2026-06-12: prompt embeds the author's own project layout (runs
+# ./qa-playwright-capture.sh, writes ai/memory-bank/ paths); adapt or replace.
+"project-management/project-manager-senior" = "absent"

--- a/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
@@ -1,0 +1,53 @@
+{{- /*
+  Generates one archive external per source with present agents from the
+  catalog in .chezmoidata/ai/agents.toml. Each external downloads the pinned
+  upstream archive (verified against sha256, cached once per URL) and pipes it
+  through skill_filter with one --select per present agent file, placing them
+  flat under .claude/agents/<source>/ (Claude Code discovers agents in
+  subdirectories). The external is exact, so absent agents are pruned without
+  a removal template. Archive hosts are shared with the skills catalog
+  ([ai.skills.hosts]). The filter runs via system python3 and must stay
+  stdlib-only because uv and mise are not installed until after apply.
+*/ -}}
+{{- $cfg := .ai.agents -}}
+{{- $hosts := .ai.skills.hosts -}}
+{{- $script := joinPath .chezmoi.workingTree "src/python/skill_filter/skill_filter/main.py" -}}
+{{- $config := dict -}}
+{{- range $sourceName, $source := $cfg.external -}}
+{{-   $selects := list -}}
+{{-   range $agentPath, $state := dig "agents" (dict) $source -}}
+{{-     if eq $state "present" -}}
+{{-       if or (not (dig "ref" "" $source)) (not (dig "sha256" "" $source)) -}}
+{{-         fail (printf "ai.agents.external.%s: ref and sha256 are required (versions are always pinned)" $sourceName) -}}
+{{-       end -}}
+{{-       $root := dig "agents_root" "" $source -}}
+{{-       $path := ternary (printf "%s/%s.md" $root $agentPath) (printf "%s.md" $agentPath) (ne $root "") -}}
+{{-       $selects = concat $selects (list "--select" $path) -}}
+{{-     else if ne $state "absent" -}}
+{{-       fail (printf "ai.agents.external.%s.agents.%s: state must be \"present\" or \"absent\", got %q" $sourceName $agentPath $state) -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if $selects -}}
+{{-     $url := dig "url" "" $source -}}
+{{-     if not $url -}}
+{{-       $hostName := dig "host" "github" $source -}}
+{{-       $host := dig $hostName (dict) $hosts -}}
+{{-       if not $host -}}
+{{-         fail (printf "ai.agents.external.%s: unknown host %q (no ai.skills.hosts.%s entry)" $sourceName $hostName $hostName) -}}
+{{-       end -}}
+{{-       $url = $host.url_format | replace "{repo}" $source.repo | replace "{ref}" $source.ref -}}
+{{-     end -}}
+{{-     $entry := dict
+            "type" "archive"
+            "url" $url
+            "checksum" (dict "sha256" $source.sha256)
+            "exact" true
+            "format" "tar"
+            "filter" (dict
+              "command" "python3"
+              "args" (concat (list $script) $selects))
+-}}
+{{-     $_ := set $config (printf ".claude/agents/%s" $sourceName) $entry -}}
+{{-   end -}}
+{{- end -}}
+{{- if $config -}}{{- toToml $config -}}{{- end -}}

--- a/tests/integration/test_ai_skills.py
+++ b/tests/integration/test_ai_skills.py
@@ -43,3 +43,19 @@ def test_optional_tool_skill_dir_valid_when_present(chezmoi_dest, relative_dir):
     if not skills_dir.is_dir():
         pytest.skip(f"{relative_dir} is not deployed on this machine")
     assert_entries_are_valid_skills(skills_dir)
+
+
+@pytest.mark.integration
+def test_claude_agents_dir_deployed_and_valid(chezmoi_dest):
+    """Verify each deployed agent source directory contains only non-empty .md agent files."""
+    agents_dir = chezmoi_dest / ".claude/agents"
+    assert agents_dir.is_dir(), f"{agents_dir} does not exist after chezmoi apply"
+    source_dirs = [entry for entry in sorted(agents_dir.iterdir()) if entry.name != ".DS_Store"]
+    assert source_dirs, f"{agents_dir} contains no agent sources"
+    for source_dir in source_dirs:
+        assert source_dir.is_dir(), f"{source_dir} is not a directory; agent sources must be directories"
+        agent_files = [entry for entry in sorted(source_dir.iterdir()) if entry.name != ".DS_Store"]
+        assert agent_files, f"{source_dir} contains no agents"
+        for agent_file in agent_files:
+            assert agent_file.suffix == ".md", f"{agent_file} is not an .md agent file"
+            assert agent_file.stat().st_size > 0, f"{agent_file} is empty"


### PR DESCRIPTION
## Summary
- New `[ai.agents.external.*]` catalog (`.chezmoidata/ai/agents.toml`) + dispatch template generating one exact archive external per source, reusing `skill_filter` with per-file `--select` flags into `~/.claude/agents/<source>/`
- Claude-only target: agent frontmatter is tool-proprietary (other tools require format conversion — deferred transformation layer)
- Onboards 7 agents from msitarzewski/agency-agents pinned at `a077c9a` after a per-agent prompt-injection audit; `project-manager-senior` rejected (embeds the author's own project scripts/paths) and documented as `"absent"`
- Integration test validating every deployed agent source dir contains only non-empty `.md` files

## Test plan
- [x] `chezmoi execute-template` renders the expected external with 8 selects (7 after rejection)
- [x] `chezmoi apply --force` — 7 agents deployed flat under `~/.claude/agents/agency-agents/`
- [x] `uv run pytest src/python tests/integration` — only known pre-existing failures (PATH artifacts, statusline width flake)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)