### PR TITLE
fix(claude_statusline): pin terminal width in CLI tests

### DIFF
--- a/src/python/claude_statusline/tests/test_main.py
+++ b/src/python/claude_statusline/tests/test_main.py
@@ -13,6 +13,13 @@ from claude_statusline.main import cli, run_external_generator
 from claude_statusline.segments.workspace import shorten_path
 
 
+@pytest.fixture(autouse=True)
+def wide_terminal(monkeypatch):
+    # Rendering truncates to the terminal width (render.py reads COLUMNS via
+    # shutil.get_terminal_size), so narrow terminals cut off asserted text.
+    monkeypatch.setenv("COLUMNS", "200")
+
+
 class TestMainSmoke(unittest.TestCase):
     """Smoke tests verifying the CLI entry point runs end-to-end."""
 


### PR DESCRIPTION
## Summary
- Add an autouse fixture setting `COLUMNS=200` in `test_main.py`: the rich panel renderer truncates to the terminal width (`shutil.get_terminal_size` honors `COLUMNS`), so text-presence assertions flaked on narrow local terminals while passing in CI

## Test plan
- [x] `COLUMNS=60 uv run pytest src/python/claude_statusline` — 59 passed (failed before the fix)
- [x] `COLUMNS=78 uv run pytest src/python/claude_statusline` — 59 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)