### PR TITLE
fix(claude_statusline): prevent column clipping by moving long thread titles to top row

### DIFF
--- a/src/python/claude_statusline/claude_statusline/render.py
+++ b/src/python/claude_statusline/claude_statusline/render.py
@@ -1,14 +1,14 @@
 import shutil
 from collections.abc import Iterable
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
 from claude_statusline.layout import SegmentGenerationResult
 from claude_statusline.payload import StatusLineStdIn
-from claude_statusline.segments.constants import get_icon
+from claude_statusline.segments.constants import CYAN, RESET, get_icon
 from claude_statusline.segments.git import GitInfo
 
 
@@ -36,7 +36,7 @@ def render_lines(
     # TUI Mode layout engine uses a 5-column grid by default.
     table = Table(show_header=False, show_edge=False, box=None, padding=(0, 1), expand=True)
     table.add_column("col0", justify="left", no_wrap=True)
-    table.add_column("col1", justify="left", ratio=1, no_wrap=True)
+    table.add_column("col1", justify="left", ratio=1, overflow="ellipsis", no_wrap=True)
     table.add_column("col2", justify="right", no_wrap=True)
     table.add_column("col3", justify="right", no_wrap=True)
     table.add_column("col4", justify="right", no_wrap=True)
@@ -66,8 +66,17 @@ def render_lines(
         table.add_row(*col_texts)
 
     console = Console(width=safe_width, force_terminal=True, color_system="truecolor", highlight=False)
+
+    # Put session name at the top stretch row if available
+    if payload.session_name:
+        session_text = Text.from_ansi(f"{CYAN}#{payload.session_name}{RESET}", no_wrap=True)
+        session_text.overflow = "ellipsis"
+        renderable = Group(session_text, table)
+    else:
+        renderable = table
+
     with console.capture() as capture:
-        console.print(Panel(table, border_style="dim", expand=True))
+        console.print(Panel(renderable, border_style="dim", expand=True))
 
     captured_lines = capture.get().splitlines()
 

--- a/src/python/claude_statusline/claude_statusline/segments/claude.py
+++ b/src/python/claude_statusline/claude_statusline/segments/claude.py
@@ -8,7 +8,6 @@ from claude_statusline.segments.constants import (
     BOLD,
     BRIGHT_GREEN,
     BRIGHT_RED,
-    CYAN,
     DIM,
     GREEN,
     MAGENTA,
@@ -112,30 +111,7 @@ def format_model_info(payload: StatusLineStdIn) -> list[SegmentGenerationResult]
 
 
 def format_session_info(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
-    parts = [
-        f"{CYAN}#{payload.session_name}{RESET}" if payload.session_name else None,
-    ]
-
-    if payload.cost.total_duration_ms:
-        elapsed_seconds = payload.cost.total_duration_ms // 1000
-        hours, remainder = divmod(elapsed_seconds, 3600)
-        minutes, seconds = divmod(remainder, 60)
-
-        timer = f"{hours:02d}:{minutes:02d}:{seconds:02d}" if hours > 0 else f"{minutes:02d}:{seconds:02d}"
-
-        parts.append(f"{YELLOW}{get_icon('timer')} {timer}{RESET}")
-
     results = []
-    if payload.session_name:
-        results.append(
-            SegmentGenerationResult(
-                line=0,
-                index=0,
-                column=1,
-                generator="internal.claude",
-                segment=Segment(text=f"{CYAN}#{payload.session_name}{RESET}"),
-            )
-        )
 
     if payload.cost.total_duration_ms:
         elapsed_seconds = payload.cost.total_duration_ms // 1000

--- a/src/python/claude_statusline/tests/test_segments_claude.py
+++ b/src/python/claude_statusline/tests/test_segments_claude.py
@@ -137,12 +137,6 @@ class TestFormatModelInfo(unittest.TestCase):
 
 
 class TestFormatSessionInfo(unittest.TestCase):
-    def test_session_name_shown(self) -> None:
-        payload = StatusLineStdIn(session_name="my-session")
-        res = format_session_info(payload)
-        assert res is not None
-        self.assertIn("my-session", " ".join([r.segment.text for r in res]))
-
     def test_session_id_hash_not_shown(self) -> None:
         payload = StatusLineStdIn(session_id="abc123def456")
         res = format_session_info(payload)


### PR DESCRIPTION
- Extract the `session_name` generation logic from `format_session_info`
- Render `session_name` as a separate `Text` component above the table using `rich.console.Group` within `render_lines`
- Apply `overflow="ellipsis"` and `no_wrap=True` to the new title text component
- Ensure the main grid `col1` has `overflow="ellipsis"` to squish appropriately when other columns demand space

---
*PR created automatically by Jules for task [7995824209111274052](https://jules.google.com/task/7995824209111274052) started by @mkobit*