### PR TITLE
feat(ai): add cursor as a skill deployment target

### DIFF
--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -1,6 +1,6 @@
 # AI skill deployment
 
-Skills are deployed as static files into each tool's discovery directory (`~/.claude/skills/`, `~/.gemini/antigravity-cli/skills/`).
+Skills are deployed as static files into each tool's discovery directory (`~/.claude/skills/`, `~/.gemini/antigravity-cli/skills/`, `~/.cursor/skills/`).
 There is no marketplace, plugin CLI, or symlinking — chezmoi owns the full lifecycle.
 
 Two kinds of skills share one catalog: `src/chezmoi/.chezmoidata/ai/skills.toml`.
@@ -31,9 +31,9 @@ To compute the pin for a new ref:
 curl -sL https://codeload.github.com/<owner>/<repo>/tar.gz/<commit-sha> | sha256sum
 ```
 
-A skill state is `"present"` (deploy to every tool), `"absent"`, or a single tool name (`"claude"`, `"antigravity"`) to deploy only to that tool.
+A skill state is `"present"` (deploy to every tool), `"absent"`, or a single tool name (`"claude"`, `"antigravity"`, `"cursor"`) to deploy only to that tool.
 To remove a skill, set it to `"absent"` — never delete the key, which would orphan the installed copy.
-The `.chezmoiremove.tmpl` files in `dot_claude/` and `dot_gemini/` prune any skill that does not target their tool on apply.
+The `.chezmoiremove.tmpl` files in `dot_claude/`, `dot_gemini/`, and `dot_cursor/` prune any skill that does not target their tool on apply.
 
 ## Upstream agents (Claude Code only)
 
@@ -68,6 +68,6 @@ Overlay-only sources go in an overlay `.chezmoidata` file under distinct `[ai.sk
 
 ```sh
 chezmoi diff
-chezmoi apply ~/.claude/skills ~/.gemini/antigravity-cli/skills
+chezmoi apply ~/.claude/skills ~/.gemini/antigravity-cli/skills ~/.cursor/skills
 uv run pytest src/python/skill_filter
 ```

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -3,7 +3,7 @@
 # Skills are deployed as static files by chezmoi externals (see .chezmoiexternals/ai-skills.toml.tmpl).
 # Each upstream is pinned to an exact commit and archive checksum.
 # The archive is piped through src/python/skill_filter at apply time to extract one skill per external.
-# Skills marked "absent" are pruned via dot_claude/.chezmoiremove.tmpl and dot_gemini/.chezmoiremove.tmpl;
+# Skills marked "absent" are pruned via the .chezmoiremove.tmpl files in dot_claude/, dot_gemini/, and dot_cursor/;
 # keep the key when deselecting a skill — deleting it outright orphans any installed copy.
 #
 # Every present skill installs to every tool's skill directory; the target
@@ -34,7 +34,7 @@ write-agent-context = "present"
 # url (full archive URL for one-off published artifacts, bypasses host construction).
 # Each [.skills] entry maps an upstream skill directory name to a state:
 #   "present" (all tools), "absent" (pruned everywhere), or a single tool name
-#   ("claude", "antigravity") to deploy only to that tool.
+#   ("claude", "antigravity", "cursor") to deploy only to that tool.
 [ai.skills.external.superpowers]
 repo = "obra/superpowers"
 ref = "6fd4507659784c351abbd2bc264c7162cfd386dc" # 2026-05-29

--- a/src/chezmoi/.chezmoiexternals/ai-authored-skills.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-authored-skills.toml.tmpl
@@ -8,9 +8,9 @@
   "absent" are pruned by the .chezmoiremove templates; a file deleted from a
   present skill leaves an orphan in the target until removed manually (file
   externals are not exact). A skill state may also name a single tool
-  ("claude", "antigravity") to deploy only there.
+  ("claude", "antigravity", "cursor") to deploy only there.
 */ -}}
-{{- $tools := dict "claude" ".claude/skills" "antigravity" ".gemini/antigravity-cli/skills" -}}
+{{- $tools := dict "claude" ".claude/skills" "antigravity" ".gemini/antigravity-cli/skills" "cursor" ".cursor/skills" -}}
 {{- $root := joinPath .chezmoi.workingTree "src/ai/skills" -}}
 {{- $config := dict -}}
 {{- range $skillName, $state := dig "authored" (dict) .ai.skills -}}

--- a/src/chezmoi/.chezmoiexternals/ai-skills.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-skills.toml.tmpl
@@ -7,10 +7,10 @@
   mise are not installed until after apply. Target directories are fixed by
   each tool's skill discovery and are hardcoded here; overlays deselect skills
   via "absent" states rather than disabling a target. A skill state may also
-  name a single tool ("claude", "antigravity") to deploy only there.
+  name a single tool ("claude", "antigravity", "cursor") to deploy only there.
 */ -}}
 {{- $cfg := .ai.skills -}}
-{{- $tools := dict "claude" ".claude/skills" "antigravity" ".gemini/antigravity-cli/skills" -}}
+{{- $tools := dict "claude" ".claude/skills" "antigravity" ".gemini/antigravity-cli/skills" "cursor" ".cursor/skills" -}}
 {{- $script := joinPath .chezmoi.workingTree "src/python/skill_filter/skill_filter/main.py" -}}
 {{- $config := dict -}}
 {{- range $sourceName, $source := $cfg.external -}}

--- a/src/chezmoi/.chezmoiremove
+++ b/src/chezmoi/.chezmoiremove
@@ -30,17 +30,14 @@ install-asdf.sh
 .claude/skills/claude-extension-builder
 .claude/commands/claude/new/skill.md
 
-# Rulesync-era cursor rules and skill copies (dot_cursor/ was deleted from
-# source without pruning; cursor is not a skill deployment target)
+# Rulesync-era cursor rules (dot_cursor/ was deleted from source without
+# pruning). Skill copies are pruned by dot_cursor/.chezmoiremove.tmpl now
+# that cursor is a skill deployment target.
 .cursor/rules/00-preferences.mdc
 .cursor/rules/01-agents-md.mdc
 .cursor/rules/02-no-auto-commit.mdc
 .cursor/rules/10-technical-writing.mdc
 .cursor/rules/11-write-agent-context.mdc
-.cursor/skills/pr-reviewer
-.cursor/skills/technical-writing
-.cursor/skills/typescript-expert
-.cursor/skills/write-agent-context
 
 # Orphaned unmanaged agents from April 2026 experiments: agency-agents
 # engineering category (dumped flat and as a directory) and manual extractions

--- a/src/chezmoi/dot_cursor/.chezmoiremove.tmpl
+++ b/src/chezmoi/dot_cursor/.chezmoiremove.tmpl
@@ -1,0 +1,18 @@
+{{- /*
+  Prunes catalog skills (.chezmoidata/ai/skills.toml) that do not target
+  ~/.cursor/skills: state "absent", or a tool-name state for another tool.
+  Only known catalog keys are removed; deleting a catalog key outright
+  orphans any installed copy.
+*/ -}}
+{{- range $sourceName, $source := .ai.skills.external -}}
+{{-   range $skillName, $state := dig "skills" (dict) $source -}}
+{{-     if not (or (eq $state "present") (eq $state "cursor")) }}
+skills/{{ $skillName }}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
+{{- range $skillName, $state := dig "authored" (dict) .ai.skills -}}
+{{-   if not (or (eq $state "present") (eq $state "cursor")) }}
+skills/{{ $skillName }}
+{{-   end -}}
+{{- end -}}

--- a/tests/integration/test_ai_skills.py
+++ b/tests/integration/test_ai_skills.py
@@ -6,10 +6,6 @@ import pytest
 ACTIVE_SKILL_DIRS = [
     pytest.param(Path(".claude/skills"), id="claude"),
     pytest.param(Path(".gemini/antigravity-cli/skills"), id="antigravity"),
-]
-
-# Directories of tools that are not deployment targets yet but may hold skills.
-OPTIONAL_SKILL_DIRS = [
     pytest.param(Path(".cursor/skills"), id="cursor"),
 ]
 
@@ -32,16 +28,6 @@ def test_tool_skill_dir_deployed_and_valid(chezmoi_dest, relative_dir):
     skills_dir = chezmoi_dest / relative_dir
     assert skills_dir.is_dir(), f"{skills_dir} does not exist after chezmoi apply"
     assert any(skills_dir.iterdir()), f"{skills_dir} contains no skills"
-    assert_entries_are_valid_skills(skills_dir)
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("relative_dir", OPTIONAL_SKILL_DIRS)
-def test_optional_tool_skill_dir_valid_when_present(chezmoi_dest, relative_dir):
-    """Verify skill directories of non-target tools contain only valid skills if they exist."""
-    skills_dir = chezmoi_dest / relative_dir
-    if not skills_dir.is_dir():
-        pytest.skip(f"{relative_dir} is not deployed on this machine")
     assert_entries_are_valid_skills(skills_dir)
 
 


### PR DESCRIPTION
## Summary
- Add `"cursor" ".cursor/skills"` to the `$tools` map in both skill dispatch templates; skill states now accept `"cursor"` as a tool-name state
- New `dot_cursor/.chezmoiremove.tmpl` prunes skills that do not target cursor; static rulesync-era `.cursor/skills/*` removal entries retired (the template and exact externals own them now)
- Integration test moves cursor from optional to active skill dirs

## Test plan
- [x] `chezmoi apply --force` — 16 skills deployed to `~/.cursor/skills` (matches antigravity; claude-only skill-creator correctly excluded)
- [x] `uv run pytest src/python tests/integration` — 250 passed, only known PATH artifacts fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)