### PR TITLE
feat(ai): onboard 8 engineering/testing agents from agency-agents

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -23,6 +23,12 @@ ref = "a077c9ac0be381ec15e7dcbb690f641d6091a5db" # 2026-06-07
 sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
 
 [ai.agents.external.agency-agents.agents]
+"engineering/engineering-backend-architect" = "present"
+"engineering/engineering-codebase-onboarding-engineer" = "present"
+"engineering/engineering-database-optimizer" = "present"
+"engineering/engineering-prompt-engineer" = "present"
+"engineering/engineering-software-architect" = "present"
+"engineering/engineering-sre" = "present"
 "product/product-feedback-synthesizer" = "present"
 "product/product-manager" = "present"
 "product/product-sprint-prioritizer" = "present"
@@ -33,3 +39,7 @@ sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
 # Rejected 2026-06-12: prompt embeds the author's own project layout (runs
 # ./qa-playwright-capture.sh, writes ai/memory-bank/ paths); adapt or replace.
 "project-management/project-manager-senior" = "absent"
+# Audit caveat 2026-06-12: no malicious content, but the prompt eagerly directs
+# running real load/stress/penetration tests — only point it at safe targets.
+"testing/testing-api-tester" = "present"
+"testing/testing-performance-benchmarker" = "present"


### PR DESCRIPTION
## Summary
- Adds the user-approved engineering/testing set to the agents catalog: backend-architect, software-architect, sre, database-optimizer, codebase-onboarding-engineer, prompt-engineer, api-tester, performance-benchmarker.
- Security audit at pinned ref `a077c9ac` (background agent review + local raw-byte verification): no injection patterns, zero-width/bidi characters, HTML comments, or remote-fetch instructions in any of the 8 files.
- api-tester onboarded with an inline caveat: its prompt eagerly directs real load/stress/penetration testing, and agency-agents frontmatter has no `tools` key (inherits all tools) — only point it at safe targets.

## Test plan
- [x] `chezmoi apply --force ~/.claude/agents` deploys all 15 agents to `~/.claude/agents/agency-agents/`
- [x] Deployed files byte-identical to independently fetched copies at the pinned ref
- [x] `uv run pytest src/python tests/integration` — 250 passed (4 known pre-existing test_local_bin_tools venv-shadowing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)