### PR TITLE
feat(ai): deploy agents to antigravity and cursor as transformed skills

### DIFF
--- a/src/ai/AGENTS.md
+++ b/src/ai/AGENTS.md
@@ -3,6 +3,6 @@
 Skills deploy as static files via chezmoi externals — never the Claude plugin marketplace or `claude plugin` CLI.
 The catalog is `src/chezmoi/.chezmoidata/ai/skills.toml`: upstream sources pin a commit `ref` + archive `sha256`; skill entries are `"present"` (all tools), `"absent"`, or a single tool name like `"claude"` (never delete a key — set it `"absent"` so `.chezmoiremove.tmpl` prunes the installed copy).
 Authored skills live in `src/ai/skills/<name>/` and deploy as copies, never symlinks.
-Upstream Claude Code subagents use the same model via `.chezmoidata/ai/agents.toml` (Claude-only — agent frontmatter is tool-proprietary); onboarding any upstream skill or agent requires a content review at the pinned ref.
+Upstream agents use the same model via `.chezmoidata/ai/agents.toml`: Claude Code gets the raw format under `~/.claude/agents/<source>/`, while antigravity and cursor receive each agent rewritten as a skill by the `skill_filter` `agent-skill` transform; onboarding any upstream skill or agent requires a content review at the pinned ref.
 `src/python/skill_filter` must stay stdlib-only — it runs via system python3 at apply time, before uv/mise exist.
 Guide: `README.md` in this directory.

--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -35,11 +35,16 @@ A skill state is `"present"` (deploy to every tool), `"absent"`, or a single too
 To remove a skill, set it to `"absent"` — never delete the key, which would orphan the installed copy.
 The `.chezmoiremove.tmpl` files in `dot_claude/`, `dot_gemini/`, and `dot_cursor/` prune any skill that does not target their tool on apply.
 
-## Upstream agents (Claude Code only)
+## Upstream agents
 
-Claude Code subagents follow the same pin-and-select model via `src/chezmoi/.chezmoidata/ai/agents.toml` and `src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl`.
-Each source gets one exact archive external placing selected agent `.md` files flat under `~/.claude/agents/<source>/`, so flipping an agent to `"absent"` prunes it on the next apply without a removal template.
-Agents deploy only to Claude Code: agent frontmatter is tool-proprietary (other tools need format conversion), unlike the quasi-standard SKILL.md.
+Agents follow the same pin-and-select model via `src/chezmoi/.chezmoidata/ai/agents.toml` and `src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl`.
+Agent states use the same vocabulary as skills: `"present"` (all tools), `"absent"`, or a single tool name.
+Each tool receives agents in its native shape:
+
+- **Claude Code** gets the raw upstream format: one exact archive external per source placing selected agent `.md` files flat under `~/.claude/agents/<source>/` (discovery is recursive, and the agent's identity is its frontmatter `name:`), so deselected agents prune automatically.
+- **Antigravity and cursor** consume agents as skills: each agent is rewritten to `SKILL.md` form by the `skill_filter` `agent-skill` transform (skill name = the agent file's basename, `description` carried over verbatim, body unchanged) and placed as `<skills dir>/<basename>/SKILL.md`. Deselected copies are pruned by the same `.chezmoiremove.tmpl` files that prune skills.
+
+opencode is a planned target — it needs its own transform (`mode: subagent` frontmatter).
 Onboarding an agent requires a prompt-injection review of its full content at the pinned ref.
 
 ## Authored skills

--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -1,17 +1,22 @@
-# AI agent deployment catalog (Claude Code subagents only).
+# AI agent deployment catalog.
 #
-# Agents are single .md files selected from pinned upstream archives and placed
-# under ~/.claude/skills sibling dir ~/.claude/agents/<source>/ by
-# .chezmoiexternals/ai-agents.toml.tmpl. Claude Code is the only target: agent
-# frontmatter is tool-proprietary (antigravity converts agents into skills,
-# cursor into .mdc rules, etc.), so cross-tool deployment needs the deferred
-# transformation layer. The upstream agency-agents format (name, description,
-# color, emoji, vibe) is native Claude Code subagent format.
+# Agents are single .md files selected from pinned upstream archives by
+# .chezmoiexternals/ai-agents.toml.tmpl. Claude Code receives the native
+# format flat under ~/.claude/agents/<source>/ (the upstream agency-agents
+# frontmatter is native Claude Code subagent format). Antigravity and cursor
+# consume agents as skills: each agent is rewritten to SKILL.md form by the
+# skill_filter agent-skill transform (skill name = file basename, description
+# carried over, body unchanged) and placed in the tool's skills directory.
+# opencode is a planned target (needs its own transform).
 #
 # Each [.agents] entry maps an in-archive path (under agents_root, default "")
-# without the .md suffix to "present" or "absent". The external is exact, so
-# agents flipped to "absent" are pruned on the next apply; emptying a source
-# entirely orphans its ~/.claude/agents/<source>/ directory — prune manually.
+# without the .md suffix to a state, mirroring the skills vocabulary:
+# "present" (all tools), "absent", or a single tool name ("claude",
+# "antigravity", "cursor"). The Claude external is exact, so deselected agents
+# prune automatically there; antigravity/cursor copies are pruned by the
+# dot_gemini/ and dot_cursor/ .chezmoiremove.tmpl files — keep keys when
+# deselecting. Emptying a source entirely orphans its
+# ~/.claude/agents/<source>/ directory — prune manually.
 #
 # Onboarding requires a prompt-injection review of each agent at the pinned
 # ref (see memory: supply-chain scrutiny). Pin via:

--- a/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
@@ -1,33 +1,35 @@
 {{- /*
-  Generates one archive external per source with present agents from the
-  catalog in .chezmoidata/ai/agents.toml. Each external downloads the pinned
-  upstream archive (verified against sha256, cached once per URL) and pipes it
-  through skill_filter with one --select per present agent file, placing them
-  flat under .claude/agents/<source>/ (Claude Code discovers agents in
-  subdirectories). The external is exact, so absent agents are pruned without
-  a removal template. Archive hosts are shared with the skills catalog
+  Generates externals for the agents catalog in .chezmoidata/ai/agents.toml.
+  Each source's pinned upstream archive (verified against sha256, cached once
+  per URL) is piped through skill_filter per target tool:
+
+  - Claude Code gets the native format: one exact external per source with one
+    --select per agent, placed flat under .claude/agents/<source>/ (Claude
+    Code discovers agents in subdirectories). Absent or other-tool agents are
+    pruned automatically because the external is exact.
+  - Antigravity and cursor consume agents as skills: one exact external per
+    (agent, tool) keyed <skills dir>/<basename>, with the file rewritten to
+    SKILL.md form by the agent-skill transform (name from the file basename,
+    description carried over, body unchanged). Deselected agents are pruned by
+    the dot_gemini/ and dot_cursor/ .chezmoiremove.tmpl files.
+
+  Agent states mirror the skills vocabulary: "present" (all tools), "absent",
+  or a single tool name. Archive hosts are shared with the skills catalog
   ([ai.skills.hosts]). The filter runs via system python3 and must stay
   stdlib-only because uv and mise are not installed until after apply.
 */ -}}
 {{- $cfg := .ai.agents -}}
 {{- $hosts := .ai.skills.hosts -}}
 {{- $script := joinPath .chezmoi.workingTree "src/python/skill_filter/skill_filter/main.py" -}}
+{{- $skillTools := dict "antigravity" ".gemini/antigravity-cli/skills" "cursor" ".cursor/skills" -}}
+{{- $validStates := list "present" "absent" "claude" "antigravity" "cursor" -}}
 {{- $config := dict -}}
 {{- range $sourceName, $source := $cfg.external -}}
-{{-   $selects := list -}}
-{{-   range $agentPath, $state := dig "agents" (dict) $source -}}
-{{-     if eq $state "present" -}}
-{{-       if or (not (dig "ref" "" $source)) (not (dig "sha256" "" $source)) -}}
-{{-         fail (printf "ai.agents.external.%s: ref and sha256 are required (versions are always pinned)" $sourceName) -}}
-{{-       end -}}
-{{-       $root := dig "agents_root" "" $source -}}
-{{-       $path := ternary (printf "%s/%s.md" $root $agentPath) (printf "%s.md" $agentPath) (ne $root "") -}}
-{{-       $selects = concat $selects (list "--select" $path) -}}
-{{-     else if ne $state "absent" -}}
-{{-       fail (printf "ai.agents.external.%s.agents.%s: state must be \"present\" or \"absent\", got %q" $sourceName $agentPath $state) -}}
+{{-   $states := dig "agents" (dict) $source -}}
+{{-   if $states -}}
+{{-     if or (not (dig "ref" "" $source)) (not (dig "sha256" "" $source)) -}}
+{{-       fail (printf "ai.agents.external.%s: ref and sha256 are required (versions are always pinned)" $sourceName) -}}
 {{-     end -}}
-{{-   end -}}
-{{-   if $selects -}}
 {{-     $url := dig "url" "" $source -}}
 {{-     if not $url -}}
 {{-       $hostName := dig "host" "github" $source -}}
@@ -37,17 +39,49 @@
 {{-       end -}}
 {{-       $url = $host.url_format | replace "{repo}" $source.repo | replace "{ref}" $source.ref -}}
 {{-     end -}}
-{{-     $entry := dict
-            "type" "archive"
-            "url" $url
-            "checksum" (dict "sha256" $source.sha256)
-            "exact" true
-            "format" "tar"
-            "filter" (dict
-              "command" "python3"
-              "args" (concat (list $script) $selects))
+{{-     $root := dig "agents_root" "" $source -}}
+{{-     $claudeSelects := list -}}
+{{-     range $agentPath, $state := $states -}}
+{{-       if not (has $state $validStates) -}}
+{{-         fail (printf "ai.agents.external.%s.agents.%s: state must be one of %v, got %q" $sourceName $agentPath $validStates $state) -}}
+{{-       end -}}
+{{-       $path := ternary (printf "%s/%s.md" $root $agentPath) (printf "%s.md" $agentPath) (ne $root "") -}}
+{{-       if or (eq $state "present") (eq $state "claude") -}}
+{{-         $claudeSelects = concat $claudeSelects (list "--select" $path) -}}
+{{-       end -}}
+{{-       range $tool, $skillsDir := $skillTools -}}
+{{-         if or (eq $state "present") (eq $state $tool) -}}
+{{-           $key := printf "%s/%s" $skillsDir (base $agentPath) -}}
+{{-           if hasKey $config $key -}}
+{{-             fail (printf "ai.agents: duplicate external target %q (agent basenames must be unique across sources)" $key) -}}
+{{-           end -}}
+{{-           $entry := dict
+                  "type" "archive"
+                  "url" $url
+                  "checksum" (dict "sha256" $source.sha256)
+                  "exact" true
+                  "format" "tar"
+                  "filter" (dict
+                    "command" "python3"
+                    "args" (list $script "--select" (printf "%s:SKILL.md" $path) "--transform" "agent-skill"))
 -}}
-{{-     $_ := set $config (printf ".claude/agents/%s" $sourceName) $entry -}}
+{{-           $_ := set $config $key $entry -}}
+{{-         end -}}
+{{-       end -}}
+{{-     end -}}
+{{-     if $claudeSelects -}}
+{{-       $entry := dict
+                "type" "archive"
+                "url" $url
+                "checksum" (dict "sha256" $source.sha256)
+                "exact" true
+                "format" "tar"
+                "filter" (dict
+                  "command" "python3"
+                  "args" (concat (list $script) $claudeSelects))
+-}}
+{{-       $_ := set $config (printf ".claude/agents/%s" $sourceName) $entry -}}
+{{-     end -}}
 {{-   end -}}
 {{- end -}}
 {{- if $config -}}{{- toToml $config -}}{{- end -}}

--- a/src/chezmoi/dot_cursor/.chezmoiremove.tmpl
+++ b/src/chezmoi/dot_cursor/.chezmoiremove.tmpl
@@ -1,8 +1,8 @@
 {{- /*
-  Prunes catalog skills (.chezmoidata/ai/skills.toml) that do not target
-  ~/.cursor/skills: state "absent", or a tool-name state for another tool.
-  Only known catalog keys are removed; deleting a catalog key outright
-  orphans any installed copy.
+  Prunes catalog skills (.chezmoidata/ai/skills.toml) and agents-as-skills
+  (.chezmoidata/ai/agents.toml) that do not target ~/.cursor/skills: state
+  "absent", or a tool-name state for another tool. Only known catalog keys
+  are removed; deleting a catalog key outright orphans any installed copy.
 */ -}}
 {{- range $sourceName, $source := .ai.skills.external -}}
 {{-   range $skillName, $state := dig "skills" (dict) $source -}}
@@ -14,5 +14,12 @@ skills/{{ $skillName }}
 {{- range $skillName, $state := dig "authored" (dict) .ai.skills -}}
 {{-   if not (or (eq $state "present") (eq $state "cursor")) }}
 skills/{{ $skillName }}
+{{-   end -}}
+{{- end -}}
+{{- range $sourceName, $source := .ai.agents.external -}}
+{{-   range $agentPath, $state := dig "agents" (dict) $source -}}
+{{-     if not (or (eq $state "present") (eq $state "cursor")) }}
+skills/{{ base $agentPath }}
+{{-     end -}}
 {{-   end -}}
 {{- end -}}

--- a/src/chezmoi/dot_gemini/.chezmoiremove.tmpl
+++ b/src/chezmoi/dot_gemini/.chezmoiremove.tmpl
@@ -1,5 +1,6 @@
 {{- /*
-  Prunes catalog skills (.chezmoidata/ai/skills.toml) that do not target
+  Prunes catalog skills (.chezmoidata/ai/skills.toml) and agents-as-skills
+  (.chezmoidata/ai/agents.toml) that do not target
   ~/.gemini/antigravity-cli/skills (antigravity CLI global skills): state
   "absent", or a tool-name state for another tool. Only known catalog keys
   are removed; deleting a catalog key outright orphans any installed copy.
@@ -14,5 +15,12 @@ antigravity-cli/skills/{{ $skillName }}
 {{- range $skillName, $state := dig "authored" (dict) .ai.skills -}}
 {{-   if not (or (eq $state "present") (eq $state "antigravity")) }}
 antigravity-cli/skills/{{ $skillName }}
+{{-   end -}}
+{{- end -}}
+{{- range $sourceName, $source := .ai.agents.external -}}
+{{-   range $agentPath, $state := dig "agents" (dict) $source -}}
+{{-     if not (or (eq $state "present") (eq $state "antigravity")) }}
+antigravity-cli/skills/{{ base $agentPath }}
+{{-     end -}}
 {{-   end -}}
 {{- end -}}

--- a/src/python/skill_filter/skill_filter/main.py
+++ b/src/python/skill_filter/skill_filter/main.py
@@ -20,6 +20,11 @@ are placed in the output. ``dest`` defaults to the basename of ``src``; a
 hardlink members are skipped with a warning. Members with absolute paths or
 ``..`` components abort the run, since pinned-checksum archives should never
 contain them.
+
+``--transform`` applies a content rewrite to every selected file:
+``agent-skill`` converts a Claude Code agent ``.md`` into SKILL.md form
+(``name`` derived from the source file basename, ``description`` carried over
+verbatim, body unchanged) for tools that consume agents as skills.
 """
 
 import argparse
@@ -29,7 +34,7 @@ import io
 import posixpath
 import sys
 import tarfile
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import BinaryIO, NamedTuple
 
 
@@ -63,6 +68,27 @@ def _normalize_relative(path: str, what: str) -> str:
     return normalized
 
 
+Transform = Callable[[str, bytes], bytes]
+
+
+def _transform_agent_skill(src: str, content: bytes) -> bytes:
+    lines = content.decode("utf-8").split("\n")
+    if not lines or lines[0] != "---":
+        raise FilterError(f"agent file {src!r} has no frontmatter")
+    closing = next((index for index, line in enumerate(lines[1:], start=1) if line == "---"), None)
+    if closing is None:
+        raise FilterError(f"agent file {src!r} has unterminated frontmatter")
+    description = next((line for line in lines[1:closing] if line.startswith("description:")), None)
+    if description is None:
+        raise FilterError(f"agent file {src!r} frontmatter has no description")
+    name = posixpath.basename(src).removesuffix(".md")
+    header = ("---", f"name: {name}", description, "---")
+    return "\n".join((*header, *lines[closing + 1 :])).encode("utf-8")
+
+
+TRANSFORMS: dict[str, Transform] = {"agent-skill": _transform_agent_skill}
+
+
 def _stripped_name(name: str, strip_components: int) -> str | None:
     normalized = posixpath.normpath(name)
     if normalized.startswith(("/", "..")):
@@ -81,7 +107,7 @@ def _output_name(name: str, selection: Selection) -> str | None:
     return f"{selection.dest}/{remainder}" if remainder else selection.dest
 
 
-def _renamed_member(member: tarfile.TarInfo, name: str) -> tarfile.TarInfo:
+def _renamed_member(member: tarfile.TarInfo, name: str, size: int | None = None) -> tarfile.TarInfo:
     # TarInfo.replace() requires python 3.12; copy manually to support older system pythons.
     renamed = copy.copy(member)
     renamed.name = name
@@ -89,6 +115,8 @@ def _renamed_member(member: tarfile.TarInfo, name: str) -> tarfile.TarInfo:
     renamed.gid = 0
     renamed.uname = ""
     renamed.gname = ""
+    if size is not None:
+        renamed.size = size
     return renamed
 
 
@@ -97,6 +125,7 @@ def filter_archive(
     dst: BinaryIO,
     selections: Sequence[Selection],
     strip_components: int = 1,
+    transform: Transform | None = None,
 ) -> None:
     """Copy selected, re-rooted subtrees from a tar.gz stream to a tar stream."""
     # stdin is not seekable, so buffer the archive to allow random access reads.
@@ -104,7 +133,7 @@ def filter_archive(
     with tarfile.open(fileobj=buffered, mode="r:") as archive:
         triples = sorted(
             (
-                (output_name, member, selection.src)
+                (output_name, member, selection)
                 for member in archive.getmembers()
                 if (name := _stripped_name(member.name, strip_components)) is not None
                 for selection in selections
@@ -112,19 +141,23 @@ def filter_archive(
             ),
             key=lambda triple: triple[0],
         )
-        matched_sources = {src_path for _, _, src_path in triples}
+        matched_sources = {selection.src for _, _, selection in triples}
         unmatched = [selection.src for selection in selections if selection.src not in matched_sources]
         if unmatched:
             raise FilterError(f"selections matched nothing in the archive: {', '.join(unmatched)}")
         # Stream mode: stdout is a pipe when invoked by chezmoi, and plain "w" mode seeks.
         with tarfile.open(fileobj=dst, mode="w|") as output:
-            for output_name, member, _ in triples:
+            for output_name, member, selection in triples:
                 if member.issym() or member.islnk():
                     print(f"skill-filter: skipping link member {member.name!r}", file=sys.stderr)
                 elif member.isfile():
-                    content = archive.extractfile(member)
-                    assert content is not None
-                    output.addfile(_renamed_member(member, output_name), content)
+                    extracted = archive.extractfile(member)
+                    assert extracted is not None
+                    if transform is None:
+                        output.addfile(_renamed_member(member, output_name), extracted)
+                    else:
+                        content = transform(selection.src, extracted.read())
+                        output.addfile(_renamed_member(member, output_name, size=len(content)), io.BytesIO(content))
                 elif member.isdir():
                     output.addfile(_renamed_member(member, output_name))
                 else:
@@ -146,6 +179,11 @@ def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
         default=1,
         help="leading path components to strip before matching (default 1, the GitHub archive top directory)",
     )
+    parser.add_argument(
+        "--transform",
+        choices=sorted(TRANSFORMS),
+        help="content rewrite applied to every selected file",
+    )
     return parser.parse_args(list(argv))
 
 
@@ -155,7 +193,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         selections = [parse_selection(raw) for raw in args.select]
         if len(selections) > 1 and any(selection.dest == "." for selection in selections):
             raise FilterError("a '.' destination is only allowed with a single --select")
-        filter_archive(sys.stdin.buffer, sys.stdout.buffer, selections, args.strip_components)
+        transform = TRANSFORMS[args.transform] if args.transform else None
+        filter_archive(sys.stdin.buffer, sys.stdout.buffer, selections, args.strip_components, transform)
     except (FilterError, tarfile.TarError, gzip.BadGzipFile, EOFError) as error:
         print(f"skill-filter: {error}", file=sys.stderr)
         return 1

--- a/src/python/skill_filter/tests/test_main.py
+++ b/src/python/skill_filter/tests/test_main.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from skill_filter.main import FilterError, Selection, filter_archive, main, parse_selection
+from skill_filter.main import (
+    TRANSFORMS,
+    FilterError,
+    Selection,
+    filter_archive,
+    main,
+    parse_selection,
+)
 
 SCRIPT = Path(__file__).parent.parent / "skill_filter" / "main.py"
 
@@ -36,9 +43,15 @@ def read_archive(buffer: io.BytesIO) -> dict[str, bytes | None]:
         }
 
 
-def run_filter(source: io.BytesIO, selections: list[Selection], strip_components: int = 1) -> io.BytesIO:
+def run_filter(
+    source: io.BytesIO,
+    selections: list[Selection],
+    strip_components: int = 1,
+    transform_name: str | None = None,
+) -> io.BytesIO:
     output = io.BytesIO()
-    filter_archive(source, output, selections, strip_components)
+    transform = TRANSFORMS[transform_name] if transform_name else None
+    filter_archive(source, output, selections, strip_components, transform)
     return output
 
 
@@ -160,6 +173,62 @@ class TestDeterminism:
         assert names == sorted(names)
 
 
+AGENT_MD = b"""---
+name: SRE (Site Reliability Engineer)
+description: Expert site reliability engineer specializing in SLOs and error budgets.
+color: "#e63946"
+emoji: \xf0\x9f\x9b\xa1\xef\xb8\x8f
+vibe: Reliability is a feature.
+---
+
+# Mission
+
+A body line that is exactly
+---
+must survive unchanged.
+"""
+
+AGENT_AS_SKILL_MD = b"""---
+name: engineering-sre
+description: Expert site reliability engineer specializing in SLOs and error budgets.
+---
+
+# Mission
+
+A body line that is exactly
+---
+must survive unchanged.
+"""
+
+
+class TestAgentSkillTransform:
+    def test_rewrites_frontmatter_and_preserves_body(self):
+        source = make_archive({"engineering/engineering-sre.md": AGENT_MD})
+        result = read_archive(
+            run_filter(
+                source,
+                [parse_selection("engineering/engineering-sre.md:SKILL.md")],
+                transform_name="agent-skill",
+            )
+        )
+        assert result == {"SKILL.md": AGENT_AS_SKILL_MD}
+
+    def test_missing_frontmatter_raises(self):
+        source = make_archive({"engineering/agent.md": b"# Just a heading\n"})
+        with pytest.raises(FilterError, match="no frontmatter"):
+            run_filter(source, [parse_selection("engineering/agent.md:SKILL.md")], transform_name="agent-skill")
+
+    def test_unterminated_frontmatter_raises(self):
+        source = make_archive({"engineering/agent.md": b"---\nname: x\n"})
+        with pytest.raises(FilterError, match="unterminated"):
+            run_filter(source, [parse_selection("engineering/agent.md:SKILL.md")], transform_name="agent-skill")
+
+    def test_missing_description_raises(self):
+        source = make_archive({"engineering/agent.md": b"---\nname: x\n---\nbody\n"})
+        with pytest.raises(FilterError, match="no description"):
+            run_filter(source, [parse_selection("engineering/agent.md:SKILL.md")], transform_name="agent-skill")
+
+
 class TestSelectionParsing:
     @pytest.mark.parametrize("raw", ["", "/abs", "../up", "a/../..", "a:..", "a:/abs", "."])
     def test_invalid_selection_raises(self, raw):
@@ -225,3 +294,20 @@ class TestSubprocess:
         result = self.run_script("--select", "skills/a:.", stdin=b"not a tarball")
         assert result.returncode == 1
         assert result.stdout == b""
+
+    def test_agent_skill_transform_through_pipes(self):
+        source = make_archive({"engineering/engineering-sre.md": AGENT_MD})
+        result = self.run_script(
+            "--select",
+            "engineering/engineering-sre.md:SKILL.md",
+            "--transform",
+            "agent-skill",
+            stdin=source.getvalue(),
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        assert read_archive(io.BytesIO(result.stdout)) == {"SKILL.md": AGENT_AS_SKILL_MD}
+
+    def test_unknown_transform_rejected(self):
+        result = self.run_script("--select", "a:.", "--transform", "nonsense", stdin=b"")
+        assert result.returncode == 2
+        assert b"invalid choice" in result.stderr


### PR DESCRIPTION
## Summary
- Adds a `--transform agent-skill` stage to `skill_filter`: rewrites a Claude Code agent `.md` into SKILL.md form (skill name = file basename, `description:` line carried over verbatim, body byte-identical) inside the existing tar-in/tar-out filter contract. Stdlib-only, deterministic output.
- Agent catalog states now mirror the skills vocabulary: `"present"` (all tools), `"absent"`, or a single tool name (`"claude"`, `"antigravity"`, `"cursor"`). Claude keeps the raw native format flat under `~/.claude/agents/<source>/`; antigravity and cursor get one exact per-agent external placing `<skills dir>/<basename>/SKILL.md`.
- `dot_gemini/` and `dot_cursor/` removal templates prune agents-as-skills that don't target their tool, same as catalog skills.
- opencode is the next planned target (needs its own transform); docs updated accordingly.

## Test plan
- [x] 5 new skill_filter unit tests (transform happy path incl. body-`---` survival, missing/unterminated frontmatter, missing description, unknown transform rejected, full pipe contract via subprocess) — 30 passing
- [x] `chezmoi apply` deploys all 15 agents as skills to both `~/.cursor/skills` and `~/.gemini/antigravity-cli/skills`; SKILL.md body verified identical to the Claude copy; cursor and antigravity copies byte-identical
- [x] Flipped an agent to `"claude"`: skill copies pruned from both tools, Claude copy retained; revert restores them
- [x] `uv run pytest src/python tests/integration` — 255 passed (4 known pre-existing test_local_bin_tools venv-shadowing failures); ruff + ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)