### PR TITLE
fix(zsh): guard eza compdef calls to prevent startup errors

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/eza.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/eza.sh
@@ -12,12 +12,14 @@ if command -v eza >/dev/null 2>&1; then
     alias lt='eza --tree'
 
     {{- if eq $.shell "zsh" }}
-    compdef ls=eza
-    compdef ll=eza
-    compdef la=eza
-    compdef l=eza
-    compdef tree=eza
-    compdef lt=eza
+    if (( ${+_comps[eza]} )); then
+        compdef ls=eza
+        compdef ll=eza
+        compdef la=eza
+        compdef l=eza
+        compdef tree=eza
+        compdef lt=eza
+    fi
     {{- else if eq $.shell "bash" }}
     complete -F _eza -o bashdefault -o default ls
     complete -F _eza -o bashdefault -o default ll


### PR DESCRIPTION
Fixes zsh interactive shell errors during startup when `eza` is installed as a binary without a corresponding `_eza` completion file in `fpath`. By guarding the `compdef` alias bindings in `src/chezmoi/.chezmoitemplates/shell/eza.sh` with a check against the `_comps` array (`if (( ${+_comps[eza]} )); then`), `compdef` is only run if the base completion actually exists. Tests remain unchanged.

---
*PR created automatically by Jules for task [4427887051208483176](https://jules.google.com/task/4427887051208483176) started by @mkobit*