### PR TITLE
feat(ai): deploy agents to opencode via agent-opencode transform

### DIFF
--- a/src/ai/AGENTS.md
+++ b/src/ai/AGENTS.md
@@ -3,6 +3,6 @@
 Skills deploy as static files via chezmoi externals — never the Claude plugin marketplace or `claude plugin` CLI.
 The catalog is `src/chezmoi/.chezmoidata/ai/skills.toml`: upstream sources pin a commit `ref` + archive `sha256`; skill entries are `"present"` (all tools), `"absent"`, or a single tool name like `"claude"` (never delete a key — set it `"absent"` so `.chezmoiremove.tmpl` prunes the installed copy).
 Authored skills live in `src/ai/skills/<name>/` and deploy as copies, never symlinks.
-Upstream agents use the same model via `.chezmoidata/ai/agents.toml`: Claude Code gets the raw format under `~/.claude/agents/<source>/`, while antigravity and cursor receive each agent rewritten as a skill by the `skill_filter` `agent-skill` transform; onboarding any upstream skill or agent requires a content review at the pinned ref.
+Upstream agents use the same model via `.chezmoidata/ai/agents.toml`: Claude Code gets the raw format under `~/.claude/agents/<source>/`, antigravity and cursor receive each agent rewritten as a skill by the `skill_filter` `agent-skill` transform, and opencode gets agents rewritten by `agent-opencode` under `~/.config/opencode/agents/<source>/`; onboarding any upstream skill or agent requires a content review at the pinned ref.
 `src/python/skill_filter` must stay stdlib-only — it runs via system python3 at apply time, before uv/mise exist.
 Guide: `README.md` in this directory.

--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -43,8 +43,8 @@ Each tool receives agents in its native shape:
 
 - **Claude Code** gets the raw upstream format: one exact archive external per source placing selected agent `.md` files flat under `~/.claude/agents/<source>/` (discovery is recursive, and the agent's identity is its frontmatter `name:`), so deselected agents prune automatically.
 - **Antigravity and cursor** consume agents as skills: each agent is rewritten to `SKILL.md` form by the `skill_filter` `agent-skill` transform (skill name = the agent file's basename, `description` carried over verbatim, body unchanged) and placed as `<skills dir>/<basename>/SKILL.md`. Deselected copies are pruned by the same `.chezmoiremove.tmpl` files that prune skills.
+- **opencode** gets one exact external per source under `~/.config/opencode/agents/<source>/`, with each agent rewritten by the `agent-opencode` transform: an explicit `name:` (overriding opencode's path-derived agent name) plus `mode: subagent`. Deselected agents prune automatically.
 
-opencode is a planned target — it needs its own transform (`mode: subagent` frontmatter).
 Onboarding an agent requires a prompt-injection review of its full content at the pinned ref.
 
 ## Authored skills

--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -7,16 +7,18 @@
 # consume agents as skills: each agent is rewritten to SKILL.md form by the
 # skill_filter agent-skill transform (skill name = file basename, description
 # carried over, body unchanged) and placed in the tool's skills directory.
-# opencode is a planned target (needs its own transform).
+# opencode gets agents rewritten by the agent-opencode transform (explicit
+# name + mode: subagent) flat under ~/.config/opencode/agents/<source>/.
 #
 # Each [.agents] entry maps an in-archive path (under agents_root, default "")
 # without the .md suffix to a state, mirroring the skills vocabulary:
 # "present" (all tools), "absent", or a single tool name ("claude",
-# "antigravity", "cursor"). The Claude external is exact, so deselected agents
-# prune automatically there; antigravity/cursor copies are pruned by the
-# dot_gemini/ and dot_cursor/ .chezmoiremove.tmpl files — keep keys when
-# deselecting. Emptying a source entirely orphans its
-# ~/.claude/agents/<source>/ directory — prune manually.
+# "antigravity", "cursor", "opencode"). The Claude and opencode externals are
+# exact, so deselected agents prune automatically there; antigravity/cursor
+# copies are pruned by the dot_gemini/ and dot_cursor/ .chezmoiremove.tmpl
+# files — keep keys when deselecting. Emptying a source entirely orphans its
+# ~/.claude/agents/<source>/ and ~/.config/opencode/agents/<source>/
+# directories — prune manually.
 #
 # Onboarding requires a prompt-injection review of each agent at the pinned
 # ref (see memory: supply-chain scrutiny). Pin via:

--- a/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-agents.toml.tmpl
@@ -12,6 +12,11 @@
     SKILL.md form by the agent-skill transform (name from the file basename,
     description carried over, body unchanged). Deselected agents are pruned by
     the dot_gemini/ and dot_cursor/ .chezmoiremove.tmpl files.
+  - opencode gets one exact external per source under
+    .config/opencode/agents/<source>/ (discovery is recursive), with each file
+    rewritten by the agent-opencode transform (explicit name overrides
+    opencode's path-derived agent name; mode: subagent). Pruning is automatic
+    because the external is exact.
 
   Agent states mirror the skills vocabulary: "present" (all tools), "absent",
   or a single tool name. Archive hosts are shared with the skills catalog
@@ -22,7 +27,7 @@
 {{- $hosts := .ai.skills.hosts -}}
 {{- $script := joinPath .chezmoi.workingTree "src/python/skill_filter/skill_filter/main.py" -}}
 {{- $skillTools := dict "antigravity" ".gemini/antigravity-cli/skills" "cursor" ".cursor/skills" -}}
-{{- $validStates := list "present" "absent" "claude" "antigravity" "cursor" -}}
+{{- $validStates := list "present" "absent" "claude" "antigravity" "cursor" "opencode" -}}
 {{- $config := dict -}}
 {{- range $sourceName, $source := $cfg.external -}}
 {{-   $states := dig "agents" (dict) $source -}}
@@ -41,6 +46,7 @@
 {{-     end -}}
 {{-     $root := dig "agents_root" "" $source -}}
 {{-     $claudeSelects := list -}}
+{{-     $opencodeSelects := list -}}
 {{-     range $agentPath, $state := $states -}}
 {{-       if not (has $state $validStates) -}}
 {{-         fail (printf "ai.agents.external.%s.agents.%s: state must be one of %v, got %q" $sourceName $agentPath $validStates $state) -}}
@@ -48,6 +54,9 @@
 {{-       $path := ternary (printf "%s/%s.md" $root $agentPath) (printf "%s.md" $agentPath) (ne $root "") -}}
 {{-       if or (eq $state "present") (eq $state "claude") -}}
 {{-         $claudeSelects = concat $claudeSelects (list "--select" $path) -}}
+{{-       end -}}
+{{-       if or (eq $state "present") (eq $state "opencode") -}}
+{{-         $opencodeSelects = concat $opencodeSelects (list "--select" $path) -}}
 {{-       end -}}
 {{-       range $tool, $skillsDir := $skillTools -}}
 {{-         if or (eq $state "present") (eq $state $tool) -}}
@@ -81,6 +90,19 @@
                   "args" (concat (list $script) $claudeSelects))
 -}}
 {{-       $_ := set $config (printf ".claude/agents/%s" $sourceName) $entry -}}
+{{-     end -}}
+{{-     if $opencodeSelects -}}
+{{-       $entry := dict
+                "type" "archive"
+                "url" $url
+                "checksum" (dict "sha256" $source.sha256)
+                "exact" true
+                "format" "tar"
+                "filter" (dict
+                  "command" "python3"
+                  "args" (concat (list $script) $opencodeSelects (list "--transform" "agent-opencode")))
+-}}
+{{-       $_ := set $config (printf ".config/opencode/agents/%s" $sourceName) $entry -}}
 {{-     end -}}
 {{-   end -}}
 {{- end -}}

--- a/src/python/skill_filter/skill_filter/main.py
+++ b/src/python/skill_filter/skill_filter/main.py
@@ -21,10 +21,12 @@ hardlink members are skipped with a warning. Members with absolute paths or
 ``..`` components abort the run, since pinned-checksum archives should never
 contain them.
 
-``--transform`` applies a content rewrite to every selected file:
-``agent-skill`` converts a Claude Code agent ``.md`` into SKILL.md form
-(``name`` derived from the source file basename, ``description`` carried over
-verbatim, body unchanged) for tools that consume agents as skills.
+``--transform`` applies a content rewrite to every selected file. All
+transforms derive ``name`` from the source file basename, carry the
+``description`` frontmatter line over verbatim, and leave the body unchanged:
+``agent-skill`` converts a Claude Code agent ``.md`` into SKILL.md form for
+tools that consume agents as skills; ``agent-opencode`` emits opencode agent
+frontmatter (adds ``mode: subagent``).
 """
 
 import argparse
@@ -71,7 +73,13 @@ def _normalize_relative(path: str, what: str) -> str:
 Transform = Callable[[str, bytes], bytes]
 
 
-def _transform_agent_skill(src: str, content: bytes) -> bytes:
+class _AgentParts(NamedTuple):
+    name: str
+    description: str
+    body: tuple[str, ...]
+
+
+def _parse_agent(src: str, content: bytes) -> _AgentParts:
     lines = content.decode("utf-8").split("\n")
     if not lines or lines[0] != "---":
         raise FilterError(f"agent file {src!r} has no frontmatter")
@@ -82,11 +90,27 @@ def _transform_agent_skill(src: str, content: bytes) -> bytes:
     if description is None:
         raise FilterError(f"agent file {src!r} frontmatter has no description")
     name = posixpath.basename(src).removesuffix(".md")
-    header = ("---", f"name: {name}", description, "---")
-    return "\n".join((*header, *lines[closing + 1 :])).encode("utf-8")
+    return _AgentParts(name=name, description=description, body=tuple(lines[closing + 1 :]))
 
 
-TRANSFORMS: dict[str, Transform] = {"agent-skill": _transform_agent_skill}
+def _transform_agent_skill(src: str, content: bytes) -> bytes:
+    parts = _parse_agent(src, content)
+    header = ("---", f"name: {parts.name}", parts.description, "---")
+    return "\n".join((*header, *parts.body)).encode("utf-8")
+
+
+def _transform_agent_opencode(src: str, content: bytes) -> bytes:
+    # An explicit name overrides opencode's path-derived agent name, which
+    # would otherwise contain the source subdirectory (e.g. "src/agent-name").
+    parts = _parse_agent(src, content)
+    header = ("---", f"name: {parts.name}", parts.description, "mode: subagent", "---")
+    return "\n".join((*header, *parts.body)).encode("utf-8")
+
+
+TRANSFORMS: dict[str, Transform] = {
+    "agent-skill": _transform_agent_skill,
+    "agent-opencode": _transform_agent_opencode,
+}
 
 
 def _stripped_name(name: str, strip_components: int) -> str | None:

--- a/src/python/skill_filter/tests/test_main.py
+++ b/src/python/skill_filter/tests/test_main.py
@@ -201,6 +201,20 @@ must survive unchanged.
 """
 
 
+AGENT_AS_OPENCODE_MD = b"""---
+name: engineering-sre
+description: Expert site reliability engineer specializing in SLOs and error budgets.
+mode: subagent
+---
+
+# Mission
+
+A body line that is exactly
+---
+must survive unchanged.
+"""
+
+
 class TestAgentSkillTransform:
     def test_rewrites_frontmatter_and_preserves_body(self):
         source = make_archive({"engineering/engineering-sre.md": AGENT_MD})
@@ -212,6 +226,17 @@ class TestAgentSkillTransform:
             )
         )
         assert result == {"SKILL.md": AGENT_AS_SKILL_MD}
+
+    def test_opencode_transform_adds_subagent_mode(self):
+        source = make_archive({"engineering/engineering-sre.md": AGENT_MD})
+        result = read_archive(
+            run_filter(
+                source,
+                [parse_selection("engineering/engineering-sre.md")],
+                transform_name="agent-opencode",
+            )
+        )
+        assert result == {"engineering-sre.md": AGENT_AS_OPENCODE_MD}
 
     def test_missing_frontmatter_raises(self):
         source = make_archive({"engineering/agent.md": b"# Just a heading\n"})

--- a/tests/integration/test_ai_skills.py
+++ b/tests/integration/test_ai_skills.py
@@ -31,10 +31,18 @@ def test_tool_skill_dir_deployed_and_valid(chezmoi_dest, relative_dir):
     assert_entries_are_valid_skills(skills_dir)
 
 
+# Tool agent directories actively deployed to by .chezmoiexternals/ai-agents.toml.tmpl.
+ACTIVE_AGENT_DIRS = [
+    pytest.param(Path(".claude/agents"), id="claude"),
+    pytest.param(Path(".config/opencode/agents"), id="opencode"),
+]
+
+
 @pytest.mark.integration
-def test_claude_agents_dir_deployed_and_valid(chezmoi_dest):
+@pytest.mark.parametrize("relative_dir", ACTIVE_AGENT_DIRS)
+def test_agents_dir_deployed_and_valid(chezmoi_dest, relative_dir):
     """Verify each deployed agent source directory contains only non-empty .md agent files."""
-    agents_dir = chezmoi_dest / ".claude/agents"
+    agents_dir = chezmoi_dest / relative_dir
     assert agents_dir.is_dir(), f"{agents_dir} does not exist after chezmoi apply"
     source_dirs = [entry for entry in sorted(agents_dir.iterdir()) if entry.name != ".DS_Store"]
     assert source_dirs, f"{agents_dir} contains no agent sources"


### PR DESCRIPTION
## Summary
- Adds opencode as a fourth agent deployment target: one exact archive external per source under `~/.config/opencode/agents/<source>/`, pruning deselected agents automatically.
- New `agent-opencode` transform in `skill_filter`: emits explicit `name:` (overriding opencode's path-derived agent name, which would otherwise include the source subdirectory) plus `mode: subagent`, with the description line carried over verbatim and body unchanged. Shares `_parse_agent` with the existing `agent-skill` transform.
- State vocabulary gains `"opencode"`; `"present"` now reaches all four tools. Docs (`src/ai/README.md`, `src/ai/AGENTS.md`, catalog header) updated.
- Integration test generalized to parametrize over Claude and opencode agent dirs.

## Test plan
- [x] `uv run pytest src/python/skill_filter tests/integration/test_ai_skills.py` — 36 passed
- [x] `uv run ruff check`, `ruff format --check`, `ty check` — clean
- [x] `chezmoi apply --force ~/.config/opencode` — 15 agents deployed; verified `engineering-sre.md` frontmatter: `name: engineering-sre`, verbatim description, `mode: subagent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)