### PR TITLE
feat(ai): add agent-run outer sandbox for autonomous CLI runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "termtext",
     "termstatus",
     "skill-filter",
+    "agent-sandbox",
 ]
 
 [dependency-groups]
@@ -32,6 +33,7 @@ members = [
     "src/python/transcribe",
     "src/python/termtext",
     "src/python/skill_filter",
+    "src/python/agent_sandbox",
 ]
 
 [tool.uv.sources]
@@ -41,6 +43,7 @@ transcribe = { workspace = true }
 termtext = { workspace = true }
 termstatus = { workspace = true }
 skill-filter = { workspace = true }
+agent-sandbox = { workspace = true }
 
 [tool.ruff]
 line-length = 120
@@ -129,7 +132,7 @@ ban-relative-imports = "all"
 max-complexity = 15
 
 [tool.ruff.lint.isort]
-known-first-party = ["termbud", "jules_cli", "termstatus", "transcribe", "termtext", "skill_filter"]
+known-first-party = ["termbud", "jules_cli", "termstatus", "transcribe", "termtext", "skill_filter", "agent_sandbox"]
 
 [tool.ty.src]
 include = [

--- a/src/chezmoi/.chezmoidata/ai/sandbox.toml
+++ b/src/chezmoi/.chezmoidata/ai/sandbox.toml
@@ -1,0 +1,34 @@
+# Sandbox profiles consumed by `agent-run` (src/python/agent_sandbox).
+#
+# Overlay-extensible: override or add profiles via [data.ai.sandbox.*] in an
+# overlay chezmoi.toml.tmpl or .chezmoidata/ai/sandbox.toml.
+#
+# HITL = run agent CLIs directly (claude, agy, opencode). The tool's own
+# permission prompts are the UX. Nothing here applies.
+#
+# Autonomous = run via `agent-run -- TOOL ARGS`. The wrapper consults this
+# data to build the outer sandbox; the tool runs with its own
+# --dangerously-skip-permissions (or equivalent) inside it.
+
+[ai.sandbox]
+# Profile picked when `agent-run` is called without --profile and
+# $AGENT_RUN_PROFILE is unset.
+default_profile = "autonomous"
+
+[ai.sandbox.profiles.autonomous]
+enabled = true
+# "auto" = bwrap on linux, sandbox-exec on darwin. Future: explicit "bwrap"
+# or "seatbelt" overrides for testing.
+backend = "auto"
+# Project worktree mounted read-write.
+project_write = true
+# Network namespace shared with host so the agent can reach model APIs and
+# localhost:11434 (ollama). "none" reserved for future air-gapped runs.
+network = "shared"
+
+[ai.sandbox.profiles.readonly]
+enabled = true
+backend = "auto"
+# Project mounted read-only — for audit / read-only inspection runs.
+project_write = false
+network = "shared"

--- a/src/chezmoi/.chezmoidata/local_bin_tools.toml
+++ b/src/chezmoi/.chezmoidata/local_bin_tools.toml
@@ -27,3 +27,8 @@ package_name = "transcribe"
 installation_method = "dotfiles.uv"
 source_dir = "src/python/termbud"
 package_name = "termbud"
+
+[local_bin_tools.agent_run]
+installation_method = "dotfiles.uv"
+source_dir = "src/python/agent_sandbox"
+package_name = "agent-sandbox"

--- a/src/chezmoi/dot_config/ai-policy/claude/autonomous-settings.json.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/claude/autonomous-settings.json.tmpl
@@ -1,0 +1,10 @@
+{{- /* Claude Code settings fragment for agent-run autonomous sandbox sessions,
+passed via `claude --settings`. Prompts are bypassed because the bwrap sandbox
+plus credential absence is the boundary; nothing inside the sandbox is
+trusted, so per-tool deny lists are deliberately empty (they live in
+agent-writable files anyway). Claude's own native sandbox stays off because
+our outer bwrap is the enforcement layer. */ -}}
+{{- dict
+      "permissions" (dict "defaultMode" "bypassPermissions")
+      "sandbox" (dict "enabled" false)
+    | toPrettyJson "  " -}}

--- a/src/chezmoi/dot_config/ai-policy/git/sandbox.gitconfig.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/git/sandbox.gitconfig.tmpl
@@ -1,0 +1,10 @@
+# Global git config used inside agent-run sandboxes via GIT_CONFIG_GLOBAL.
+# Inherits the regular config, then forces signing off: ~/.gnupg is masked in
+# the sandbox, so signed commits would fail. Unsigned commits also mark
+# sandbox-made history for later human review.
+[include]
+	path = {{ .chezmoi.destDir }}/.dotfiles/git/config
+[commit]
+	gpgsign = false
+[tag]
+	gpgSign = false

--- a/src/chezmoi/dot_config/ai-policy/opencode/autonomous.json.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/opencode/autonomous.json.tmpl
@@ -1,0 +1,8 @@
+{{- /* OpenCode config for agent-run autonomous sandbox sessions, passed via
+OPENCODE_CONFIG. Permission system fully open — the boundary is the bwrap
+sandbox plus credential absence, not anything settable inside the agent's
+config. */ -}}
+{{- dict
+      "$schema" "https://opencode.ai/config.json"
+      "permission" (dict "edit" "allow" "webfetch" "allow" "bash" "allow")
+    | toPrettyJson "  " -}}

--- a/src/chezmoi/dot_config/ai-policy/sandbox.json.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/sandbox.json.tmpl
@@ -1,0 +1,1 @@
+{{- dig "ai" "sandbox" (dict) . | toPrettyJson -}}

--- a/src/python/agent_sandbox/agent_sandbox/backend.py
+++ b/src/python/agent_sandbox/agent_sandbox/backend.py
@@ -1,0 +1,69 @@
+"""Sandbox backend dispatch.
+
+A backend turns a SandboxSpec into an argv that runs the user's command in
+an isolated environment. The Linux/WSL implementation uses bwrap; the macOS
+path will use sandbox-exec + a Seatbelt profile (not implemented yet).
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+from agent_sandbox.bwrap import SandboxSpec
+from agent_sandbox.bwrap import build_args as _bwrap_build_args
+
+
+class SandboxBackend(Protocol):
+    name: str
+
+    def build_args(
+        self,
+        spec: SandboxSpec,
+        environ: Mapping[str, str],
+        mask_paths: Sequence[str] = (),
+    ) -> list[str]: ...
+
+
+class BwrapBackend:
+    name = "bwrap"
+
+    def build_args(
+        self,
+        spec: SandboxSpec,
+        environ: Mapping[str, str],
+        mask_paths: Sequence[str] = (),
+    ) -> list[str]:
+        return _bwrap_build_args(spec, environ, mask_paths)
+
+
+class SeatbeltBackend:
+    """Stub: macOS sandbox-exec backend, not implemented in this pass.
+
+    When implemented: render a .sb profile under
+    ~/.config/ai-policy/seatbelt/<profile>.sb from sandbox.toml, then emit
+    `sandbox-exec -p <profile-file> -- <command>`.
+    """
+
+    name = "seatbelt"
+
+    def build_args(
+        self,
+        spec: SandboxSpec,
+        environ: Mapping[str, str],
+        mask_paths: Sequence[str] = (),
+    ) -> list[str]:
+        raise NotImplementedError("macOS Seatbelt backend not yet implemented; track this when first Mac use is needed")
+
+
+def select_backend(backend_name: str, *, platform: str) -> SandboxBackend:
+    """Map a profile's backend field + the current platform to a concrete backend."""
+    if backend_name == "auto":
+        if platform.startswith("linux"):
+            return BwrapBackend()
+        if platform == "darwin":
+            return SeatbeltBackend()
+        raise ValueError(f"no auto backend for platform {platform!r}")
+    if backend_name == "bwrap":
+        return BwrapBackend()
+    if backend_name == "seatbelt":
+        return SeatbeltBackend()
+    raise ValueError(f"unknown backend {backend_name!r}")

--- a/src/python/agent_sandbox/agent_sandbox/bwrap.py
+++ b/src/python/agent_sandbox/agent_sandbox/bwrap.py
@@ -1,0 +1,108 @@
+"""bwrap invocation builder.
+
+Pure argument construction so the bind table is unit-testable. Strategy:
+read-only OS, tmpfs over the whole home (default-deny for credentials and
+personal state), then explicit re-binds for the toolchain and agent state.
+"""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ENV_PASSTHROUGH = ("TERM", "LANG", "LC_ALL", "COLORTERM", "OLLAMA_HOST")
+
+# Read-only toolchain and config mounts re-exposed under the tmpfs home.
+RO_HOME_PATHS = (
+    ".local/bin",
+    ".local/share/mise",
+    ".config/mise",
+    ".dotfiles",
+    ".config/ai-policy",
+    ".local/share/ai",
+)
+
+# Agent state and OAuth stores: the agents' own credentials are the one secret
+# class that must be present for the tools to run at all.
+# Exact agy state dir is uncertain (binary uses XDG_CONFIG_HOME); we bind both
+# common candidates so OAuth state survives across runs regardless of which
+# one ends up being canonical.
+RW_HOME_PATHS = (
+    ".claude",
+    ".claude.json",
+    ".gemini",
+    ".antigravity",
+    ".config/antigravity-cli",
+    ".config/opencode",
+    ".local/share/opencode",
+)
+
+# Dedicated cache mounted at ~/.cache. Never share the host cache: a poisoned
+# cache would cross the sandbox boundary when the human later builds on host.
+CACHE_REL = ".local/share/agent-sandbox/cache"
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    home: Path
+    project_root: Path
+    project_write: bool
+    profile_name: str
+    cwd: Path
+    git_common_dir: Path | None = None
+    extra_env: dict[str, str] = field(default_factory=dict)
+    keep_tty: bool = False
+
+
+def default_mask_paths(uid: int) -> tuple[str, ...]:
+    # /mnt masks Windows drives on WSL; /run/user/<uid> masks gpg/ssh agent sockets.
+    candidates = ("/mnt", f"/run/user/{uid}")
+    return tuple(path for path in candidates if Path(path).is_dir())
+
+
+def build_args(spec: SandboxSpec, environ: Mapping[str, str], mask_paths: Sequence[str] = ()) -> list[str]:
+    home = spec.home
+    args: list[str] = [
+        "bwrap",
+        "--die-with-parent",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
+        "--unshare-cgroup-try",
+    ]
+    if not spec.keep_tty:
+        # Prevents TIOCSTI input injection into the host terminal.
+        args.append("--new-session")
+    # /tmp here is the bwrap mount target for a fresh tmpfs, not insecure temp use.
+    args += ["--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--tmpfs", "/tmp"]  # noqa: S108
+    for path in mask_paths:
+        args += ["--tmpfs", path]
+    args += ["--tmpfs", str(home)]
+    for rel in RO_HOME_PATHS:
+        path = home / rel
+        if path.exists():
+            args += ["--ro-bind", str(path), str(path)]
+    for rel in RW_HOME_PATHS:
+        path = home / rel
+        if path.exists():
+            args += ["--bind", str(path), str(path)]
+    args += ["--bind", str(home / CACHE_REL), str(home / ".cache")]
+    project_bind = "--bind" if spec.project_write else "--ro-bind"
+    args += [project_bind, str(spec.project_root), str(spec.project_root)]
+    if spec.git_common_dir is not None:
+        # Linked worktrees write objects and refs into the main checkout's .git.
+        args += [project_bind, str(spec.git_common_dir), str(spec.git_common_dir)]
+    args += ["--clearenv", "--setenv", "HOME", str(home)]
+    args += ["--setenv", "PATH", environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")]
+    for key in ENV_PASSTHROUGH:
+        value = environ.get(key)
+        if value is not None:
+            args += ["--setenv", key, value]
+    env = {
+        "AGENT_RUN_PROFILE": spec.profile_name,
+        "GIT_CONFIG_GLOBAL": str(home / ".config/ai-policy/git/sandbox.gitconfig"),
+        **spec.extra_env,
+    }
+    for key in sorted(env):
+        args += ["--setenv", key, env[key]]
+    args += ["--chdir", str(spec.cwd)]
+    return args

--- a/src/python/agent_sandbox/agent_sandbox/config.py
+++ b/src/python/agent_sandbox/agent_sandbox/config.py
@@ -1,0 +1,75 @@
+"""Sandbox profile resolution for agent-run.
+
+The config is rendered by chezmoi from .chezmoidata/ai/sandbox.toml. Schema
+deliberately small: profiles are just bind-table decisions. No bash rules,
+no per-repo overrides — a malicious repo must not be able to upgrade its
+own capabilities, so profile resolution never reads from the project tree.
+"""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".config" / "ai-policy" / "sandbox.json"
+
+
+class ConfigError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    backend: str
+    project_write: bool
+    network: str
+
+
+@dataclass(frozen=True)
+class SandboxConfig:
+    default_profile: str
+    profiles: dict[str, Profile]
+
+
+def load_config(path: Path | None = None) -> SandboxConfig:
+    config_path = path if path is not None else CONFIG_PATH
+    try:
+        raw = json.loads(config_path.read_text())
+    except FileNotFoundError as exc:
+        raise ConfigError(f"sandbox config not found: {config_path} (run `chezmoi apply` to deploy it)") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"unreadable sandbox config {config_path}: {exc}") from exc
+    profiles = {
+        name: Profile(
+            name=name,
+            backend=data.get("backend", "auto"),
+            project_write=bool(data.get("project_write", False)),
+            network=data.get("network", "shared"),
+        )
+        for name, data in raw.get("profiles", {}).items()
+        if data.get("enabled") is not False
+    }
+    if not profiles:
+        raise ConfigError(f"no enabled profiles in {config_path}")
+    return SandboxConfig(
+        default_profile=raw.get("default_profile", "autonomous"),
+        profiles=profiles,
+    )
+
+
+def resolve_profile(
+    config: SandboxConfig,
+    cli_profile: str | None,
+    env_profile: str | None,
+) -> Profile:
+    """Resolve active profile: CLI flag > $AGENT_RUN_PROFILE > config default."""
+    for source, candidate in (("--profile", cli_profile), ("AGENT_RUN_PROFILE", env_profile)):
+        if candidate:
+            profile = config.profiles.get(candidate)
+            if profile is None:
+                raise ConfigError(f"unknown profile {candidate!r} from {source}; available: {sorted(config.profiles)}")
+            return profile
+    profile = config.profiles.get(config.default_profile)
+    if profile is None:
+        raise ConfigError(f"default_profile {config.default_profile!r} is not an enabled profile")
+    return profile

--- a/src/python/agent_sandbox/agent_sandbox/main.py
+++ b/src/python/agent_sandbox/agent_sandbox/main.py
@@ -1,0 +1,252 @@
+"""agent-run: launch AI agent CLIs inside an outer sandbox.
+
+The tool-native permission system is the UX boundary in HITL — run the CLI
+directly for that. This wrapper is for no-human-in-the-loop runs: outer
+bwrap (Linux/WSL) or sandbox-exec (macOS, future) + credential absence is
+the actual security boundary. Each adapter flips the tool's bypass flag
+because the outer sandbox enforces — nothing inside it is trusted.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import typer
+
+from agent_sandbox.backend import BwrapBackend, SandboxBackend, select_backend
+from agent_sandbox.bwrap import CACHE_REL, SandboxSpec, default_mask_paths
+from agent_sandbox.config import (
+    ConfigError,
+    Profile,
+    SandboxConfig,
+    load_config,
+    resolve_profile,
+)
+
+app = typer.Typer(help="Run AI agent CLIs in an outer sandbox per ~/.config/ai-policy/sandbox.json.")
+
+TOKEN_PATH = Path.home() / ".local" / "state" / "ai-policy" / "tokens" / "readonly.token"
+CLAUDE_SETTINGS = Path.home() / ".config" / "ai-policy" / "claude" / "autonomous-settings.json"
+AGY_SETTINGS = Path.home() / ".config" / "ai-policy" / "agy" / "autonomous-settings.json"
+OPENCODE_CONFIG = Path.home() / ".config" / "ai-policy" / "opencode" / "autonomous.json"
+
+_RUN_CONTEXT_SETTINGS = {
+    "allow_extra_args": True,
+    "ignore_unknown_options": True,
+    "allow_interspersed_args": False,
+}
+
+
+def _fail(message: str) -> typer.Exit:
+    typer.secho(f"agent-run: {message}", fg=typer.colors.RED, err=True)
+    return typer.Exit(1)
+
+
+def _git(cwd: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _project_root(cwd: Path) -> Path:
+    top = _git(cwd, "rev-parse", "--show-toplevel")
+    return Path(top) if top else cwd
+
+
+def _git_common_dir(cwd: Path, project_root: Path) -> Path | None:
+    common = _git(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if not common:
+        return None
+    common_path = Path(common)
+    if common_path == project_root or project_root in common_path.parents:
+        return None
+    return common_path
+
+
+def _readonly_token() -> str | None:
+    try:
+        mode = TOKEN_PATH.stat().st_mode
+    except OSError:
+        return None
+    if stat.S_IMODE(mode) & 0o077:
+        typer.secho(
+            f"agent-run: ignoring {TOKEN_PATH}: permissions too open (chmod 600 to use)",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+        return None
+    token = TOKEN_PATH.read_text().strip()
+    return token or None
+
+
+def _adapt_command(command: list[str], extra_env: dict[str, str]) -> list[str]:
+    """Engage each tool's no-prompt mode. The outer sandbox is the boundary;
+    the tool's own approvals would only add friction now.
+    """
+    tool = Path(command[0]).name
+    if tool == "claude":
+        adapted = list(command)
+        if "--settings" not in adapted and CLAUDE_SETTINGS.exists():
+            adapted += ["--settings", str(CLAUDE_SETTINGS)]
+        if "--dangerously-skip-permissions" not in adapted:
+            adapted.append("--dangerously-skip-permissions")
+        return adapted
+    if tool == "agy":
+        adapted = list(command)
+        if "--settings" not in adapted and AGY_SETTINGS.exists():
+            adapted += ["--settings", str(AGY_SETTINGS)]
+        if "--dangerously-skip-permissions" not in adapted:
+            adapted.append("--dangerously-skip-permissions")
+        # Do NOT pass --sandbox: combining it with --dangerously-skip-permissions
+        # auto-approves bypassing the sandbox itself (antigravity-cli #36).
+        return adapted
+    if tool == "opencode":
+        extra_env.setdefault("OPENCODE_CONFIG", str(OPENCODE_CONFIG))
+        # Deliberately do NOT set OPENCODE_HARDENED_MODE=1: that engages
+        # opencode's own bwrap inside our bwrap and creates nested namespaces.
+    return command
+
+
+def _resolve(profile_flag: str | None, cwd: Path) -> tuple[SandboxConfig, Profile, SandboxBackend]:
+    try:
+        config = load_config()
+        profile = resolve_profile(config, profile_flag, os.environ.get("AGENT_RUN_PROFILE"))
+        backend = select_backend(profile.backend, platform=sys.platform)
+    except (ConfigError, ValueError) as exc:
+        raise _fail(str(exc)) from exc
+    return config, profile, backend
+
+
+def _sandbox_spec(profile: Profile, cwd: Path, keep_tty: bool) -> SandboxSpec:
+    home = Path.home()
+    project_root = _project_root(cwd)
+    if project_root == home or project_root in home.parents:
+        raise _fail(
+            f"refusing to sandbox {project_root}: it contains the whole home directory; run from a project checkout"
+        )
+    (home / CACHE_REL).mkdir(parents=True, exist_ok=True)
+    extra_env: dict[str, str] = {}
+    token = _readonly_token()
+    if token:
+        extra_env["GH_TOKEN"] = token
+    return SandboxSpec(
+        home=home,
+        project_root=project_root,
+        project_write=profile.project_write,
+        profile_name=profile.name,
+        cwd=cwd,
+        git_common_dir=_git_common_dir(cwd, project_root),
+        extra_env=extra_env,
+        keep_tty=keep_tty,
+    )
+
+
+def _require_bwrap() -> None:
+    if shutil.which("bwrap") is None:
+        raise _fail("bwrap not found; it is installed by the run_once_install-sandbox-deps chezmoi script")
+
+
+@app.command(context_settings=_RUN_CONTEXT_SETTINGS)
+def run(
+    ctx: typer.Context,
+    profile: str | None = typer.Option(None, "--profile", help="Sandbox profile (default: configured default)."),
+    keep_tty: bool = typer.Option(
+        False,
+        "--keep-tty",
+        help="Keep the controlling terminal for interactive TUIs (weakens isolation: TIOCSTI injection).",
+    ),
+    show_command: bool = typer.Option(False, "--show-command", help="Print the sandbox invocation instead of running."),
+) -> None:
+    """Run a command in the sandbox: agent-run run --profile autonomous -- claude -p 'fix tests'."""
+    command = [arg for arg in ctx.args if arg != "--"]
+    if not command:
+        raise _fail("no command given; usage: agent-run run [--profile NAME] -- COMMAND [ARGS...]")
+    cwd = Path.cwd()
+    _, active, backend = _resolve(profile, cwd)
+    if isinstance(backend, BwrapBackend):
+        _require_bwrap()
+    spec = _sandbox_spec(active, cwd, keep_tty)
+    command = _adapt_command(command, spec.extra_env)
+    args = [*backend.build_args(spec, os.environ, default_mask_paths(os.getuid())), *command]
+    if show_command:
+        typer.echo(" ".join(args))
+        return
+    os.execvp(args[0], args)  # noqa: S606
+
+
+@app.command()
+def doctor(
+    profile: str = typer.Option("autonomous", "--profile", help="Profile to verify."),
+) -> None:
+    """Verify the sandbox guarantees by probing from inside it."""
+    cwd = Path.cwd()
+    _, active, backend = _resolve(profile, cwd)
+    if isinstance(backend, BwrapBackend):
+        _require_bwrap()
+    spec = _sandbox_spec(active, cwd, keep_tty=False)
+    spec.extra_env["PROBE_PROJECT"] = str(spec.project_root)
+    spec.extra_env["PROBE_PROJECT_WRITE"] = "1" if spec.project_write else "0"
+    spec.extra_env["PROBE_EXPECT_GH"] = "1" if "GH_TOKEN" in spec.extra_env else "0"
+    args = [
+        *backend.build_args(spec, os.environ, default_mask_paths(os.getuid())),
+        "bash",
+        "-c",
+        PROBE_SCRIPT,
+    ]
+    result = subprocess.run(args, check=False)
+    if result.returncode == 0:
+        typer.secho("agent-run doctor: all probes passed", fg=typer.colors.GREEN)
+    raise typer.Exit(result.returncode)
+
+
+PROBE_SCRIPT = r"""
+set -u
+fails=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; fails=$((fails+1)); }
+hidden() { if [ -e "$2" ]; then fail "$1 visible at $2"; else pass "$1 hidden"; fi; }
+hidden "ssh keys" "$HOME/.ssh"
+hidden "gpg keys" "$HOME/.gnupg"
+hidden "gh credentials" "$HOME/.config/gh"
+hidden "ai-policy token store" "$HOME/.local/state/ai-policy"
+command -v git >/dev/null 2>&1 && pass "git on PATH" || fail "git missing"
+command -v rg >/dev/null 2>&1 && pass "rg on PATH" || fail "rg missing"
+[ "$(git config --global commit.gpgsign 2>/dev/null)" = "false" ] && pass "commit signing disabled" || fail "commit signing not disabled"
+if touch /agent-sandbox-probe 2>/dev/null; then rm -f /agent-sandbox-probe; fail "root filesystem writable"; else pass "root filesystem read-only"; fi
+probe_file="$PROBE_PROJECT/.agent-sandbox-probe.$$"
+if touch "$probe_file" 2>/dev/null; then rm -f "$probe_file"; writable=1; else writable=0; fi
+if [ "$writable" = "$PROBE_PROJECT_WRITE" ]; then pass "project write=$writable as expected"; else fail "project write=$writable expected=$PROBE_PROJECT_WRITE"; fi
+if command -v gh >/dev/null 2>&1; then
+  if [ "$PROBE_EXPECT_GH" = "1" ]; then
+    gh auth status >/dev/null 2>&1 && pass "gh authenticated via injected token" || fail "gh token injected but unauthenticated"
+  else
+    gh auth status >/dev/null 2>&1 && fail "gh authenticated without injected token" || pass "gh unauthenticated"
+  fi
+fi
+if command -v curl >/dev/null 2>&1; then
+  curl -fsS -m 2 "http://${OLLAMA_HOST:-localhost:11434}/api/version" >/dev/null 2>&1 && pass "ollama reachable" || printf 'WARN: %s\n' "ollama not reachable"
+fi
+printf 'failures: %d\n' "$fails"
+exit "$fails"
+"""
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/agent_sandbox/pyproject.toml
+++ b/src/python/agent_sandbox/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "agent-sandbox"
+version = "0.0.0"
+description = "bwrap sandbox wrapper for autonomous AI agent runs"
+requires-python = ">=3.14"
+dependencies = [
+    "typer>=0.12.0",
+]
+
+[project.scripts]
+agent-run = "agent_sandbox.main:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/src/python/agent_sandbox/tests/test_backend.py
+++ b/src/python/agent_sandbox/tests/test_backend.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from agent_sandbox.backend import BwrapBackend, SeatbeltBackend, select_backend
+from agent_sandbox.bwrap import SandboxSpec
+
+
+def test_select_auto_linux_returns_bwrap():
+    assert isinstance(select_backend("auto", platform="linux"), BwrapBackend)
+
+
+def test_select_auto_darwin_returns_seatbelt():
+    assert isinstance(select_backend("auto", platform="darwin"), SeatbeltBackend)
+
+
+def test_select_auto_unknown_platform_raises():
+    with pytest.raises(ValueError, match="no auto backend"):
+        select_backend("auto", platform="freebsd")
+
+
+def test_select_explicit_bwrap_works_everywhere():
+    assert isinstance(select_backend("bwrap", platform="darwin"), BwrapBackend)
+
+
+def test_select_explicit_seatbelt_works_everywhere():
+    assert isinstance(select_backend("seatbelt", platform="linux"), SeatbeltBackend)
+
+
+def test_select_unknown_backend_raises():
+    with pytest.raises(ValueError, match="unknown backend"):
+        select_backend("docker", platform="linux")
+
+
+def test_seatbelt_build_args_raises_not_implemented(tmp_path: Path):
+    spec = SandboxSpec(
+        home=tmp_path,
+        project_root=tmp_path,
+        project_write=True,
+        profile_name="autonomous",
+        cwd=tmp_path,
+    )
+    with pytest.raises(NotImplementedError, match="Seatbelt"):
+        SeatbeltBackend().build_args(spec=spec, environ={})

--- a/src/python/agent_sandbox/tests/test_bwrap.py
+++ b/src/python/agent_sandbox/tests/test_bwrap.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+import pytest
+
+from agent_sandbox.bwrap import CACHE_REL, SandboxSpec, build_args
+
+
+def bind_pairs(args, flag):
+    pairs = []
+    for i, arg in enumerate(args):
+        if arg == flag:
+            pairs.append((args[i + 1], args[i + 2]))
+    return pairs
+
+
+def setenv_map(args):
+    env = {}
+    for i, arg in enumerate(args):
+        if arg == "--setenv":
+            env[args[i + 1]] = args[i + 2]
+    return env
+
+
+@pytest.fixture
+def home(tmp_path):
+    home = tmp_path / "home"
+    for rel in (".local/bin", ".local/share/mise", ".claude", CACHE_REL):
+        (home / rel).mkdir(parents=True)
+    (home / ".claude.json").write_text("{}")
+    return home
+
+
+@pytest.fixture
+def project(tmp_path):
+    project = tmp_path / "home" / "projects" / "demo"
+    project.mkdir(parents=True)
+    return project
+
+
+def spec_for(home, project, **overrides):
+    return SandboxSpec(
+        home=overrides.pop("home", home),
+        project_root=overrides.pop("project_root", project),
+        project_write=overrides.pop("project_write", True),
+        profile_name=overrides.pop("profile_name", "autonomous"),
+        cwd=overrides.pop("cwd", project),
+        git_common_dir=overrides.pop("git_common_dir", None),
+        extra_env=overrides.pop("extra_env", {}),
+        keep_tty=overrides.pop("keep_tty", False),
+    )
+
+
+def test_home_is_tmpfs_with_explicit_rebinds(home, project):
+    args = build_args(spec_for(home, project), {"PATH": "/usr/bin"})
+    tmpfs_targets = [args[i + 1] for i, a in enumerate(args) if a == "--tmpfs"]
+    assert str(home) in tmpfs_targets
+    assert "/tmp" in tmpfs_targets
+    ro = bind_pairs(args, "--ro-bind")
+    assert (str(home / ".local/bin"), str(home / ".local/bin")) in ro
+    assert (str(home / ".local/share/mise"), str(home / ".local/share/mise")) in ro
+    # Not created on disk, so not bound.
+    assert all(".dotfiles" not in src for src, _ in ro)
+
+
+def test_agent_state_bound_rw_and_credentials_never_bound(home, project):
+    args = build_args(spec_for(home, project), {})
+    rw = bind_pairs(args, "--bind")
+    assert (str(home / ".claude"), str(home / ".claude")) in rw
+    assert (str(home / ".claude.json"), str(home / ".claude.json")) in rw
+    joined = " ".join(args)
+    assert ".ssh" not in joined
+    assert ".gnupg" not in joined
+    assert ".config/gh" not in joined
+
+
+def test_project_bind_mode_follows_profile(home, project):
+    rw_args = build_args(spec_for(home, project, project_write=True), {})
+    ro_args = build_args(spec_for(home, project, project_write=False), {})
+    assert (str(project), str(project)) in bind_pairs(rw_args, "--bind")
+    assert (str(project), str(project)) in bind_pairs(ro_args, "--ro-bind")
+    assert (str(project), str(project)) not in bind_pairs(ro_args, "--bind")
+
+
+def test_git_common_dir_bound_for_linked_worktrees(home, project):
+    common = home / "projects" / "main-checkout" / ".git"
+    common.mkdir(parents=True)
+    args = build_args(spec_for(home, project, git_common_dir=common), {})
+    assert (str(common), str(common)) in bind_pairs(args, "--bind")
+
+
+def test_cache_is_dedicated_not_host_cache(home, project):
+    args = build_args(spec_for(home, project), {})
+    assert (str(home / CACHE_REL), str(home / ".cache")) in bind_pairs(args, "--bind")
+
+
+def test_env_is_cleared_with_allowlist_only(home, project):
+    environ = {
+        "PATH": "/usr/bin",
+        "TERM": "xterm",
+        "SSH_AUTH_SOCK": "/run/ssh.sock",
+        "GPG_TTY": "/dev/tty1",
+        "GH_TOKEN": "host-secret",
+        "OLLAMA_HOST": "localhost:11434",
+    }
+    args = build_args(spec_for(home, project), environ)
+    assert "--clearenv" in args
+    env = setenv_map(args)
+    assert env["PATH"] == "/usr/bin"
+    assert env["TERM"] == "xterm"
+    assert env["OLLAMA_HOST"] == "localhost:11434"
+    assert env["HOME"] == str(home)
+    assert env["AGENT_RUN_PROFILE"] == "autonomous"
+    assert env["GIT_CONFIG_GLOBAL"] == str(home / ".config/ai-policy/git/sandbox.gitconfig")
+    assert "SSH_AUTH_SOCK" not in env
+    assert "GPG_TTY" not in env
+    assert "GH_TOKEN" not in env
+
+
+def test_extra_env_injected(home, project):
+    args = build_args(spec_for(home, project, extra_env={"GH_TOKEN": "scoped"}), {})
+    assert setenv_map(args)["GH_TOKEN"] == "scoped"
+
+
+def test_mask_paths_are_tmpfs(home, project):
+    args = build_args(spec_for(home, project), {}, mask_paths=("/mnt", "/run/user/1000"))
+    tmpfs_targets = [args[i + 1] for i, a in enumerate(args) if a == "--tmpfs"]
+    assert "/mnt" in tmpfs_targets
+    assert "/run/user/1000" in tmpfs_targets
+
+
+def test_new_session_unless_keep_tty(home, project):
+    assert "--new-session" in build_args(spec_for(home, project), {})
+    assert "--new-session" not in build_args(spec_for(home, project, keep_tty=True), {})
+
+
+def test_chdir_to_cwd(home, project):
+    args = build_args(spec_for(home, project), {})
+    idx = args.index("--chdir")
+    assert args[idx + 1] == str(project)
+    assert Path(args[idx + 1]).is_absolute()

--- a/src/python/agent_sandbox/tests/test_config.py
+++ b/src/python/agent_sandbox/tests/test_config.py
@@ -1,0 +1,85 @@
+import json
+
+import pytest
+
+from agent_sandbox.config import ConfigError, load_config, resolve_profile
+
+BASE = {
+    "default_profile": "autonomous",
+    "profiles": {
+        "autonomous": {"enabled": True, "backend": "auto", "project_write": True, "network": "shared"},
+        "readonly": {"enabled": True, "backend": "auto", "project_write": False, "network": "shared"},
+        "disabled": {"enabled": False, "backend": "auto", "project_write": True, "network": "shared"},
+    },
+}
+
+
+def write_config(tmp_path, data):
+    path = tmp_path / "sandbox.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_load_excludes_disabled_profiles(tmp_path):
+    config = load_config(write_config(tmp_path, BASE))
+    assert set(config.profiles) == {"autonomous", "readonly"}
+    assert config.profiles["readonly"].project_write is False
+    assert config.profiles["autonomous"].backend == "auto"
+
+
+def test_load_missing_file_raises(tmp_path):
+    with pytest.raises(ConfigError, match="not found"):
+        load_config(tmp_path / "nope.json")
+
+
+def test_load_invalid_json_raises(tmp_path):
+    path = tmp_path / "sandbox.json"
+    path.write_text("{nope")
+    with pytest.raises(ConfigError, match="unreadable"):
+        load_config(path)
+
+
+def test_load_no_profiles_raises(tmp_path):
+    with pytest.raises(ConfigError, match="no enabled profiles"):
+        load_config(write_config(tmp_path, {"profiles": {}}))
+
+
+@pytest.fixture
+def config(tmp_path):
+    return load_config(write_config(tmp_path, BASE))
+
+
+def test_resolve_cli_flag_wins(config):
+    assert resolve_profile(config, "readonly", "autonomous").name == "readonly"
+
+
+def test_resolve_env_used_when_no_flag(config):
+    assert resolve_profile(config, None, "readonly").name == "readonly"
+
+
+def test_resolve_falls_back_to_default(config):
+    assert resolve_profile(config, None, None).name == "autonomous"
+
+
+def test_resolve_unknown_cli_profile_raises(config):
+    with pytest.raises(ConfigError, match="unknown profile"):
+        resolve_profile(config, "yolo", None)
+
+
+def test_resolve_unknown_env_profile_raises(config):
+    with pytest.raises(ConfigError, match="unknown profile"):
+        resolve_profile(config, None, "yolo")
+
+
+def test_resolve_missing_default_raises(tmp_path):
+    config = load_config(
+        write_config(
+            tmp_path,
+            {
+                "default_profile": "ghost",
+                "profiles": {"readonly": {"enabled": True, "backend": "auto", "project_write": False}},
+            },
+        )
+    )
+    with pytest.raises(ConfigError, match="default_profile"):
+        resolve_profile(config, None, None)

--- a/uv.lock
+++ b/uv.lock
@@ -3,11 +3,12 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-06-05T05:13:29.916490754Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [manifest]
 members = [
+    "agent-sandbox",
     "dotfiles",
     "jules-cli",
     "skill-filter",
@@ -16,6 +17,17 @@ members = [
     "termtext",
     "transcribe",
 ]
+
+[[package]]
+name = "agent-sandbox"
+version = "0.0.0"
+source = { editable = "src/python/agent_sandbox" }
+dependencies = [
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "typer", specifier = ">=0.12.0" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -248,6 +260,7 @@ name = "dotfiles"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "agent-sandbox" },
     { name = "jules-cli" },
     { name = "skill-filter" },
     { name = "termbud" },
@@ -268,6 +281,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-sandbox", editable = "src/python/agent_sandbox" },
     { name = "jules-cli", editable = "src/python/jules_cli" },
     { name = "skill-filter", editable = "src/python/skill_filter" },
     { name = "termbud", editable = "src/python/termbud" },


### PR DESCRIPTION
## Summary
- New `agent-run` CLI wraps claude/agy/opencode in bwrap so `--dangerously-skip-permissions` is safe for no-human-in-the-loop runs; HITL flows are unchanged (run the tool directly).
- The boundary is bwrap + credential absence: tmpfs over `$HOME` hides `.ssh`/`.gnupg`/`.config/gh`, OS is read-only, only the project worktree is writable, gpg-agent socket is masked so commits cannot be signed inside.
- Single source of truth is `src/chezmoi/.chezmoidata/ai/sandbox.toml`; chezmoi renders it to `~/.config/ai-policy/sandbox.json` plus per-tool autonomous fragments.
- Backend dispatch leaves room for a future macOS sandbox-exec implementation; raises `NotImplementedError` on darwin for now.
- `agy` adapter deliberately skips `--sandbox` (combining it with `--dangerously-skip-permissions` auto-approves bypassing it per antigravity-cli#36); `opencode` adapter deliberately skips `OPENCODE_HARDENED_MODE` to avoid nesting bwrap inside bwrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)