### PR TITLE
refactor(ai): render sandbox config as TOML and adopt pydantic schema

### DIFF
--- a/src/chezmoi/AGENTS.md
+++ b/src/chezmoi/AGENTS.md
@@ -10,6 +10,10 @@ This directory contains the Chezmoi source state for dotfiles management.
 - `.chezmoitemplates/`: Shared template fragments.
 - `dot_*/`: Files that will be deployed to the user's home directory (e.g., `dot_config` -> `~/.config`).
 
+## Notable cross-cutting features
+
+- **AI agent sandbox** (`agent-run`, see `src/python/agent_sandbox/AGENTS.md`): autonomous agent CLI runs are wrapped by `agent-run` reading `.chezmoidata/ai/sandbox.toml`, rendered to `~/.config/ai-policy/sandbox.toml` plus per-tool fragments under `dot_config/ai-policy/`.
+
 ## Script Conventions
 
 ### Sourcing Shared Libraries

--- a/src/chezmoi/dot_config/ai-policy/sandbox.json.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/sandbox.json.tmpl
@@ -1,1 +1,0 @@
-{{- dig "ai" "sandbox" (dict) . | toPrettyJson -}}

--- a/src/chezmoi/dot_config/ai-policy/sandbox.toml.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/sandbox.toml.tmpl
@@ -1,0 +1,4 @@
+{{- /* Sandbox profile config consumed by agent-run.
+       Source of truth: src/chezmoi/.chezmoidata/ai/sandbox.toml.
+       Overlays extend or override via [data.ai.sandbox.*]. */ -}}
+{{- dig "ai" "sandbox" (dict) . | toToml -}}

--- a/src/python/agent_sandbox/AGENTS.md
+++ b/src/python/agent_sandbox/AGENTS.md
@@ -1,0 +1,50 @@
+## Purpose
+
+`agent-run` wraps AI agent CLIs (claude, agy, opencode) in an outer sandbox so no-human-in-the-loop runs can use each tool's `--dangerously-skip-permissions`-equivalent without risking credential exfiltration, signed-commit forgery, or destruction of the home directory.
+
+## Mode split
+
+- **HITL.**
+Run the tool directly (`claude`, `agy`, `opencode`).
+Each tool's own approval prompts are the UX boundary.
+Nothing in this package applies.
+- **Autonomous.**
+`agent-run run --profile autonomous -- TOOL ARGS`.
+Outer bwrap (Linux/WSL) is the security boundary; each adapter flips the tool's bypass flag so the inner approval prompts don't fire.
+The tool's settings file inside the sandbox is *not* trusted — the OS-level isolation is.
+
+## Files in the package
+
+- `agent_sandbox/config.py` — pydantic model for `~/.config/ai-policy/sandbox.toml` plus profile resolution.
+Resolution order: `--profile` CLI flag > `$AGENT_RUN_PROFILE` > `default_profile` from config.
+Never reads from the project tree (so a hostile repo cannot upgrade its own capabilities).
+- `agent_sandbox/backend.py` — `SandboxBackend` `Protocol` plus `BwrapBackend` (implemented) and `SeatbeltBackend` (stub for future macOS support).
+- `agent_sandbox/bwrap.py` — bwrap argv builder.
+Bind table: `/` ro, `$HOME` tmpfs (default-deny), explicit re-binds for the toolchain, agent state dirs, and the project worktree.
+- `agent_sandbox/main.py` — typer `app` exposing `run` and `doctor`.
+Per-tool adapters (`claude`, `agy`, `opencode`) live in `_adapt_command`.
+
+## Deliberate omissions
+
+- **No global PreToolUse guard hook** — earlier design ripped out because the agent's own config files are agent-writable; only the OS-level boundary is real.
+- **No `--sandbox` flag passed to `agy`** — antigravity-cli#36: combining it with `--dangerously-skip-permissions` auto-approves bypassing it.
+- **No `OPENCODE_HARDENED_MODE=1`** — it would engage opencode's own bwrap inside our bwrap and create nested namespaces.
+- **No per-repo configuration** — profile resolution does not look at git remote, marker files, or `.agent-run` files in the project.
+- **No write credentials inside the sandbox** — `~/.ssh`, `~/.gnupg`, `~/.config/gh`, and `/run/user/<uid>` are masked.
+A read-only `gh` PAT at `~/.local/state/ai-policy/tokens/readonly.token` (chmod 600 required) is injected as `GH_TOKEN` if present.
+- **No macOS implementation yet** — `SeatbeltBackend.build_args` raises `NotImplementedError`; sketch is in `.claude/plans/` of how a Seatbelt profile would look.
+
+## Verification
+
+- `uv run pytest src/python/agent_sandbox` — unit coverage for config, backend dispatch, and bwrap argv.
+- `agent-run doctor --profile autonomous` — probes inside the sandbox confirm credentials are hidden, root is read-only, project is writable, and commit signing is disabled.
+- `agent-run doctor --profile readonly` — same probes plus project read-only assertion.
+
+## When extending
+
+- Add per-tool adapters in `_adapt_command` keyed on `Path(command[0]).name`.
+- Add new RW or RO home paths in `bwrap.py` (`RW_HOME_PATHS` / `RO_HOME_PATHS`) when a tool needs persistent state inside the sandbox.
+Bind defensively — if the path doesn't exist on the host, the bwrap step is skipped, so adding speculative candidate paths is cheap.
+- Add new profile fields by editing `config.py` (pydantic model) and the corresponding chezmoi data in `src/chezmoi/.chezmoidata/ai/sandbox.toml`.
+The model uses `extra="forbid"` on `Profile`, so unknown keys fail closed.
+- New backends implement the `SandboxBackend` Protocol and register in `select_backend`.

--- a/src/python/agent_sandbox/agent_sandbox/config.py
+++ b/src/python/agent_sandbox/agent_sandbox/config.py
@@ -1,60 +1,74 @@
 """Sandbox profile resolution for agent-run.
 
-The config is rendered by chezmoi from .chezmoidata/ai/sandbox.toml. Schema
-deliberately small: profiles are just bind-table decisions. No bash rules,
-no per-repo overrides — a malicious repo must not be able to upgrade its
-own capabilities, so profile resolution never reads from the project tree.
+The config is rendered by chezmoi from .chezmoidata/ai/sandbox.toml to
+~/.config/ai-policy/sandbox.toml. Schema deliberately small: profiles are
+just bind-table decisions. No bash rules, no per-repo overrides — a
+malicious repo must not be able to upgrade its own capabilities, so
+profile resolution never reads from the project tree.
 """
 
-import json
-from dataclasses import dataclass
+import tomllib
 from pathlib import Path
+from typing import Any, Literal
 
-CONFIG_PATH = Path.home() / ".config" / "ai-policy" / "sandbox.json"
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+CONFIG_PATH = Path.home() / ".config" / "ai-policy" / "sandbox.toml"
+
+Backend = Literal["auto", "bwrap", "seatbelt"]
+Network = Literal["shared", "none"]
 
 
 class ConfigError(Exception):
     pass
 
 
-@dataclass(frozen=True)
-class Profile:
+class Profile(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     name: str
-    backend: str
-    project_write: bool
-    network: str
+    backend: Backend = "auto"
+    project_write: bool = False
+    network: Network = "shared"
 
 
-@dataclass(frozen=True)
-class SandboxConfig:
-    default_profile: str
-    profiles: dict[str, Profile]
+class SandboxConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    default_profile: str = "autonomous"
+    profiles: dict[str, Profile] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _project_profile_names_and_filter_disabled(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        raw_profiles = data.get("profiles") or {}
+        if not isinstance(raw_profiles, dict):
+            return data
+        projected = {
+            name: {k: v for k, v in (entry or {}).items() if k != "enabled"} | {"name": name}
+            for name, entry in raw_profiles.items()
+            if not isinstance(entry, dict) or entry.get("enabled") is not False
+        }
+        return {**data, "profiles": projected}
 
 
 def load_config(path: Path | None = None) -> SandboxConfig:
     config_path = path if path is not None else CONFIG_PATH
     try:
-        raw = json.loads(config_path.read_text())
+        raw = tomllib.loads(config_path.read_text())
     except FileNotFoundError as exc:
         raise ConfigError(f"sandbox config not found: {config_path} (run `chezmoi apply` to deploy it)") from exc
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, tomllib.TOMLDecodeError) as exc:
         raise ConfigError(f"unreadable sandbox config {config_path}: {exc}") from exc
-    profiles = {
-        name: Profile(
-            name=name,
-            backend=data.get("backend", "auto"),
-            project_write=bool(data.get("project_write", False)),
-            network=data.get("network", "shared"),
-        )
-        for name, data in raw.get("profiles", {}).items()
-        if data.get("enabled") is not False
-    }
-    if not profiles:
+    try:
+        config = SandboxConfig.model_validate(raw)
+    except ValidationError as exc:
+        raise ConfigError(f"invalid sandbox config {config_path}: {exc}") from exc
+    if not config.profiles:
         raise ConfigError(f"no enabled profiles in {config_path}")
-    return SandboxConfig(
-        default_profile=raw.get("default_profile", "autonomous"),
-        profiles=profiles,
-    )
+    return config
 
 
 def resolve_profile(

--- a/src/python/agent_sandbox/pyproject.toml
+++ b/src/python/agent_sandbox/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.0.0"
 description = "bwrap sandbox wrapper for autonomous AI agent runs"
 requires-python = ">=3.14"
 dependencies = [
-    "typer>=0.12.0",
+    "pydantic>=2.0.0",
+    "typer>=0.15.1",
 ]
 
 [project.scripts]

--- a/src/python/agent_sandbox/tests/test_config.py
+++ b/src/python/agent_sandbox/tests/test_config.py
@@ -1,27 +1,41 @@
-import json
+import tomllib
 
 import pytest
+from pydantic import ValidationError
 
-from agent_sandbox.config import ConfigError, load_config, resolve_profile
+from agent_sandbox.config import ConfigError, Profile, SandboxConfig, load_config, resolve_profile
 
-BASE = {
-    "default_profile": "autonomous",
-    "profiles": {
-        "autonomous": {"enabled": True, "backend": "auto", "project_write": True, "network": "shared"},
-        "readonly": {"enabled": True, "backend": "auto", "project_write": False, "network": "shared"},
-        "disabled": {"enabled": False, "backend": "auto", "project_write": True, "network": "shared"},
-    },
-}
+BASE_TOML = """
+default_profile = "autonomous"
+
+[profiles.autonomous]
+enabled = true
+backend = "auto"
+project_write = true
+network = "shared"
+
+[profiles.readonly]
+enabled = true
+backend = "auto"
+project_write = false
+network = "shared"
+
+[profiles.disabled]
+enabled = false
+backend = "auto"
+project_write = true
+network = "shared"
+"""
 
 
-def write_config(tmp_path, data):
-    path = tmp_path / "sandbox.json"
-    path.write_text(json.dumps(data))
+def write_config(tmp_path, text):
+    path = tmp_path / "sandbox.toml"
+    path.write_text(text)
     return path
 
 
 def test_load_excludes_disabled_profiles(tmp_path):
-    config = load_config(write_config(tmp_path, BASE))
+    config = load_config(write_config(tmp_path, BASE_TOML))
     assert set(config.profiles) == {"autonomous", "readonly"}
     assert config.profiles["readonly"].project_write is False
     assert config.profiles["autonomous"].backend == "auto"
@@ -29,44 +43,67 @@ def test_load_excludes_disabled_profiles(tmp_path):
 
 def test_load_missing_file_raises(tmp_path):
     with pytest.raises(ConfigError, match="not found"):
-        load_config(tmp_path / "nope.json")
+        load_config(tmp_path / "nope.toml")
 
 
-def test_load_invalid_json_raises(tmp_path):
-    path = tmp_path / "sandbox.json"
-    path.write_text("{nope")
+def test_load_invalid_toml_raises(tmp_path):
+    path = write_config(tmp_path, "this = is not [ valid toml")
     with pytest.raises(ConfigError, match="unreadable"):
+        load_config(path)
+
+
+def test_load_unknown_backend_raises(tmp_path):
+    path = write_config(
+        tmp_path,
+        'default_profile = "x"\n[profiles.x]\nenabled = true\nbackend = "docker"\nproject_write = true\n',
+    )
+    with pytest.raises(ConfigError, match="invalid sandbox config"):
+        load_config(path)
+
+
+def test_load_unknown_profile_key_raises(tmp_path):
+    path = write_config(
+        tmp_path,
+        'default_profile = "x"\n[profiles.x]\nenabled = true\nbackend = "auto"\nproject_write = true\nsurprise = "nope"\n',
+    )
+    with pytest.raises(ConfigError, match="invalid sandbox config"):
         load_config(path)
 
 
 def test_load_no_profiles_raises(tmp_path):
     with pytest.raises(ConfigError, match="no enabled profiles"):
-        load_config(write_config(tmp_path, {"profiles": {}}))
+        load_config(write_config(tmp_path, 'default_profile = "x"\n'))
+
+
+def test_profile_is_frozen():
+    p = Profile(name="autonomous", backend="auto", project_write=True, network="shared")
+    with pytest.raises(ValidationError):
+        p.project_write = False  # type: ignore[misc]
 
 
 @pytest.fixture
 def config(tmp_path):
-    return load_config(write_config(tmp_path, BASE))
+    return load_config(write_config(tmp_path, BASE_TOML))
 
 
-def test_resolve_cli_flag_wins(config):
+def test_resolve_cli_flag_wins(config: SandboxConfig):
     assert resolve_profile(config, "readonly", "autonomous").name == "readonly"
 
 
-def test_resolve_env_used_when_no_flag(config):
+def test_resolve_env_used_when_no_flag(config: SandboxConfig):
     assert resolve_profile(config, None, "readonly").name == "readonly"
 
 
-def test_resolve_falls_back_to_default(config):
+def test_resolve_falls_back_to_default(config: SandboxConfig):
     assert resolve_profile(config, None, None).name == "autonomous"
 
 
-def test_resolve_unknown_cli_profile_raises(config):
+def test_resolve_unknown_cli_profile_raises(config: SandboxConfig):
     with pytest.raises(ConfigError, match="unknown profile"):
         resolve_profile(config, "yolo", None)
 
 
-def test_resolve_unknown_env_profile_raises(config):
+def test_resolve_unknown_env_profile_raises(config: SandboxConfig):
     with pytest.raises(ConfigError, match="unknown profile"):
         resolve_profile(config, None, "yolo")
 
@@ -75,11 +112,15 @@ def test_resolve_missing_default_raises(tmp_path):
     config = load_config(
         write_config(
             tmp_path,
-            {
-                "default_profile": "ghost",
-                "profiles": {"readonly": {"enabled": True, "backend": "auto", "project_write": False}},
-            },
+            'default_profile = "ghost"\n[profiles.readonly]\nenabled = true\nbackend = "auto"\nproject_write = false\n',
         )
     )
     with pytest.raises(ConfigError, match="default_profile"):
         resolve_profile(config, None, None)
+
+
+def test_round_trip_with_tomllib(tmp_path):
+    rendered = tomllib.loads(BASE_TOML)
+    assert rendered["profiles"]["autonomous"]["backend"] == "auto"
+    config = SandboxConfig.model_validate(rendered)
+    assert config.profiles["autonomous"].network == "shared"

--- a/uv.lock
+++ b/uv.lock
@@ -23,11 +23,15 @@ name = "agent-sandbox"
 version = "0.0.0"
 source = { editable = "src/python/agent_sandbox" }
 dependencies = [
+    { name = "pydantic" },
     { name = "typer" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typer", specifier = ">=0.12.0" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "typer", specifier = ">=0.15.1" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
## Summary
- Render `~/.config/ai-policy/sandbox.toml` instead of `sandbox.json` — symmetric with the `.chezmoidata/ai/sandbox.toml` source format. agent-run reads via stdlib `tomllib`.
- Adopt pydantic for the `Profile` / `SandboxConfig` schema with `Literal["auto", "bwrap", "seatbelt"]` for `backend` and `extra="forbid"` on `Profile`, so typos like `backend = "docker"` or `surprise = "nope"` now fail loudly at load time instead of being silently dropped.
- Bump `typer` minimum to `>=0.15.1` to match the house convention from `src/python/AGENTS.md`.
- Add `src/python/agent_sandbox/AGENTS.md` documenting the package's mode split, file roles, deliberate omissions (no global guard hook, no `agy --sandbox`, no nested hardened mode), and how to extend it. Add a one-liner to `src/chezmoi/AGENTS.md` so the cross-cutting feature is discoverable from the chezmoi-side entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)