### PR TITLE
feat(wsl): enable mirrored networking in .wslconfig

### DIFF
--- a/src/chezmoi/.chezmoidata/wsl.toml
+++ b/src/chezmoi/.chezmoidata/wsl.toml
@@ -4,6 +4,12 @@
 memory = "16GB"
 swap = "2GB"
 processors = 4
+# Shares localhost between WSL and Windows so Windows-hosted services
+# (Ollama at 127.0.0.1:11434, dev servers, etc.) are reachable from inside
+# WSL without juggling the NAT gateway IP. Default WSL2 mode is "nat".
+# Known to fight with some corporate VPN clients (Cisco AnyConnect); set
+# this to "nat" in an overlay if needed.
+networkingMode = "mirrored"
 
 [wsl.experimental]
 autoMemoryReclaim = "gradual"

--- a/src/chezmoi/.chezmoitemplates/wsl/wslconfig
+++ b/src/chezmoi/.chezmoitemplates/wsl/wslconfig
@@ -5,6 +5,7 @@
 memory={{ .wsl.wsl2.memory }}
 swap={{ .wsl.wsl2.swap }}
 processors={{ .wsl.wsl2.processors }}
+networkingMode={{ .wsl.wsl2.networkingMode }}
 
 [experimental]
 autoMemoryReclaim={{ .wsl.experimental.autoMemoryReclaim }}


### PR DESCRIPTION
## Summary
- Sets `networkingMode = mirrored` in `.chezmoidata/wsl.toml`, which flows through the existing `.chezmoitemplates/wsl/wslconfig` template and the `run_onchange_after_wslconfig.sh.tmpl` writer to `%USERPROFILE%\.wslconfig`.
- Unblocks the `agent-run doctor` ollama probe (Windows-side Ollama listens only on Windows-loopback; with mirrored mode, WSL's loopback is the same loopback). Any other Windows-hosted dev service becomes reachable from WSL too.
- Overlay-friendly: override via `[data.wsl.wsl2] networkingMode = "nat"` on machines where mirrored mode conflicts with corporate VPN clients (notably Cisco AnyConnect).

**Action required after merging/applying:** `wsl --shutdown` from PowerShell to make Windows reload the new `.wslconfig`. Without that the setting sits on disk but doesn't take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)