### PR TITLE
fix(ai): handle OLLAMA_HOST with scheme in agent-run doctor probe

### DIFF
--- a/src/python/agent_sandbox/agent_sandbox/main.py
+++ b/src/python/agent_sandbox/agent_sandbox/main.py
@@ -238,7 +238,9 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 if command -v curl >/dev/null 2>&1; then
-  curl -fsS -m 2 "http://${OLLAMA_HOST:-localhost:11434}/api/version" >/dev/null 2>&1 && pass "ollama reachable" || printf 'WARN: %s\n' "ollama not reachable"
+  ollama_url="${OLLAMA_HOST:-localhost:11434}"
+  case "$ollama_url" in http://*|https://*) ;; *) ollama_url="http://$ollama_url" ;; esac
+  curl -fsS -m 2 "${ollama_url}/api/version" >/dev/null 2>&1 && pass "ollama reachable" || printf 'WARN: %s\n' "ollama not reachable"
 fi
 printf 'failures: %d\n' "$fails"
 exit "$fails"


### PR DESCRIPTION
## Summary
- The doctor probe prepended `http://` to `\$OLLAMA_HOST` even when the env var already included the scheme — producing `http://http://localhost:11434/api/version` and a `Could not resolve host: http` curl failure. Real-world: my shell exports `OLLAMA_HOST=http://localhost:11434`, so the probe always WARN'd even with ollama running.
- Fix is a 2-line case statement that leaves the URL alone if it already starts with `http://` or `https://`, otherwise prepends `http://`. Verified locally: doctor now reports `PASS: ollama reachable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)