### PR TITLE
feat(ollama): add ollama CLI to mise global tools

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -64,3 +64,11 @@ package_manager = "bun"
   [mise.global_tools.gemini-cli]
   version             = "0.42.0"
   installation_method = "mise"
+
+  # CLI talks to a remote ollama server via OLLAMA_HOST (Windows side on WSL,
+  # mirrored networking exposes it on localhost:11434). Installing here gives
+  # us `ollama list`, `ollama run`, etc. on PATH; we don't run the server in
+  # WSL — Windows-side is canonical.
+  [mise.global_tools.ollama]
+  version             = "0.30.5"
+  installation_method = "mise"


### PR DESCRIPTION
## Summary
- Adds `ollama` to `[mise.global_tools]` in `.chezmoidata/bin/mise.toml`, pinned at `0.30.5` via mise's aqua-backed registry (no custom install script needed).
- CLI talks to the Windows-side server via `OLLAMA_HOST=http://localhost:11434` — reachable now that mirrored networking landed in #644 and the doctor scheme bug landed in #645. We do NOT install a WSL-side server; Windows is canonical (GPU access).
- Expected client/server version skew warning (Windows server is 0.24.0, the latest mise registry entry is 0.30.5). API is backward compatible, so `list`/`run`/etc. work; bumping the Windows side is a separate manual step.

## Known follow-up (separate PR)
- `agent-run` ro-binds `~/.local/share/mise` and `~/.config/mise` but not `~/.local/state/mise` where mise trust state lives. Any mise shim invoked inside the sandbox from a directory with a `mise.toml` (like this repo) errors on trust. Tracking as a follow-up to keep this PR focused on the catalog addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)