### PR TITLE
refactor(mise): split global_tools catalog from BOM, add ollama as first user

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -62,3 +62,30 @@ installation_method = {{ if eq .chezmoi.os "linux" }}"github_releases"{{ else }}
 
 [data.local.bin.gh]
 installation_method = "github_releases"
+
+# Mise global tools BOM. Catalog (versions, metadata) lives in
+# .chezmoidata/bin/mise.toml; per-machine opt-in is here.
+# Mirror of .local.bin.* convention but for mise-managed tools.
+[data.local.mise.global_tools.python]
+installation_method = "mise"
+
+[data.local.mise.global_tools.pnpm]
+installation_method = "mise"
+
+[data.local.mise.global_tools.java]
+installation_method = "mise"
+
+[data.local.mise.global_tools.rust]
+installation_method = "mise"
+
+[data.local.mise.global_tools.bun]
+installation_method = "mise"
+
+[data.local.mise.global_tools.node]
+installation_method = "mise"
+
+[data.local.mise.global_tools.gemini-cli]
+installation_method = "mise"
+
+[data.local.mise.global_tools.ollama]
+installation_method = "mise"

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -37,30 +37,34 @@ package_manager = "bun"
 
 [mise.global_tools]
 
+# Catalog only — version + tool-specific metadata. Per-machine opt-in
+# (installation_method) lives in the BOM at
+# [data.local.mise.global_tools.<tool>] in .chezmoi.toml.tmpl, matching
+# the .local.bin.* convention. Overlays can flip individual tools off by
+# setting installation_method = "none" in their own BOM entry.
+
   [mise.global_tools.python]
-  version             = "3.14.4"
-  installation_method = "mise"
+  version = "3.14.4"
 
   [mise.global_tools.pnpm]
-  version             = "10.33.0"
-  installation_method = "mise"
+  version = "10.33.0"
 
   [mise.global_tools.java]
-  version             = "temurin-21.0.2+13.0.LTS"
-  installation_method = "mise"
+  version = "temurin-21.0.2+13.0.LTS"
 
   [mise.global_tools.rust]
-  version             = "1.95.0"
-  installation_method = "mise"
+  version = "1.95.0"
 
   [mise.global_tools.bun]
-  version             = "1.3.13"
-  installation_method = "mise"
+  version = "1.3.13"
 
   [mise.global_tools.node]
-  version             = "22.14.0"
-  installation_method = "mise"
+  version = "22.14.0"
 
   [mise.global_tools.gemini-cli]
-  version             = "0.42.0"
-  installation_method = "mise"
+  version = "0.42.0"
+
+  # CLI for the Windows-side ollama server (reachable via mirrored networking).
+  # No WSL-side server — Windows install is canonical.
+  [mise.global_tools.ollama]
+  version = "0.30.5"

--- a/src/chezmoi/dot_config/mise/AGENTS.md
+++ b/src/chezmoi/dot_config/mise/AGENTS.md
@@ -7,8 +7,11 @@
 
 ## Configuration
 
-- **Global tools**: Defined in `src/chezmoi/.chezmoidata/mise.toml` under `[mise.global_tools]`.
-- **Settings**: Also in `src/chezmoi/.chezmoidata/mise.toml` under `[mise.settings]`.
+- **Global tools catalog** (versions, postinstall hooks): `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.global_tools.<tool>]`.
+- **Global tools BOM** (per-machine opt-in via `installation_method`): `src/chezmoi/.chezmoi.toml.tmpl` under `[data.local.mise.global_tools.<tool>]`.
+  Catalog entries are inert until a BOM entry opts in (`installation_method = "mise"`).
+  Mirrors the `.local.bin.*` convention.
+- **Settings**: `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.settings]`.
 - **Shell**: Automatically hooked into `.zshrc` / `.bashrc`.
 
 ## Lockfile
@@ -23,7 +26,8 @@ However, the deployed `config.toml` defaults to `locked = false` to ensure that 
 Follow these steps exactly when updating any mise-managed tool version.
 Do not substitute alternative commands — especially in Jules, where `mise lock` destroys the shell session permanently and irrevocably.
 
-1. Update the version in `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.global_tools.<tool>]`.
+1. Update the version in `src/chezmoi/.chezmoidata/bin/mise.toml` under `[mise.global_tools.<tool>]` (catalog).
+   New tools also require a BOM entry in `src/chezmoi/.chezmoi.toml.tmpl` under `[data.local.mise.global_tools.<tool>]` with `installation_method = "mise"`, followed by `chezmoi init` to propagate.
 2. Apply the config to the home directory:
    ```
    chezmoi apply ~/.config/mise/config.toml

--- a/src/chezmoi/dot_config/mise/config.toml.tmpl
+++ b/src/chezmoi/dot_config/mise/config.toml.tmpl
@@ -1,7 +1,10 @@
-{{- /* Build enabled tools map - only include tools with installation_method = "mise" */ -}}
+{{- /* Build enabled tools map. Catalog (version etc.) is at
+       .mise.global_tools.<tool>; installation_method is read from the BOM
+       at .local.mise.global_tools.<tool>.installation_method. */ -}}
+{{- $bom := dig "local" "mise" "global_tools" (dict) . -}}
 {{- $tools := dict -}}
 {{- range $tool, $config := .mise.global_tools -}}
-  {{- if eq (dig "installation_method" "" $config) "mise" -}}
+  {{- if eq (dig $tool "installation_method" "" $bom) "mise" -}}
     {{- if hasKey $config "postinstall" -}}
       {{- $_ := set $tools $tool (dict "version" $config.version "postinstall" $config.postinstall) -}}
     {{- else -}}
@@ -13,7 +16,7 @@
 {{- /* Build filtered settings map - omit sub-keys tied to disabled tools */ -}}
 {{- $settings := dict -}}
 {{- range $k, $v := .mise.settings -}}
-  {{- if and (eq $k "npm") (eq (dig "global_tools" "bun" "installation_method" "" $.mise) "none") -}}
+  {{- if and (eq $k "npm") (ne (dig "bun" "installation_method" "" $bom) "mise") -}}
     {{- $filtered := omit $v "package_manager" -}}
     {{- if $filtered -}}{{- $_ := set $settings $k $filtered -}}{{- end -}}
   {{- else -}}

--- a/src/chezmoi/dot_config/mise/tasks/executable_install-gemini-extensions.tmpl
+++ b/src/chezmoi/dot_config/mise/tasks/executable_install-gemini-extensions.tmpl
@@ -1,5 +1,5 @@
-{{- $geminiCli := index .mise.global_tools "gemini-cli" -}}
-{{- if ne $geminiCli.installation_method "none" -}}
+{{- $geminiMethod := dig "local" "mise" "global_tools" "gemini-cli" "installation_method" "" . -}}
+{{- if ne $geminiMethod "none" -}}
 #!/usr/bin/env bash
 # mise description="Installs Gemini CLI extensions"
 

--- a/src/chezmoi/dot_gemini/settings.json.tmpl
+++ b/src/chezmoi/dot_gemini/settings.json.tmpl
@@ -1,5 +1,5 @@
-{{- $geminiTool := index .mise.global_tools "gemini-cli" -}}
-{{- if eq $geminiTool.installation_method "mise" -}}
+{{- $geminiMethod := dig "local" "mise" "global_tools" "gemini-cli" "installation_method" "" . -}}
+{{- if eq $geminiMethod "mise" -}}
 {{-   $settings := dict
         "model" (dict "name" .gemini.model)
         "telemetry" (dict "enabled" .gemini.telemetry.enabled "logPrompts" .gemini.telemetry.log_prompts)


### PR DESCRIPTION
## Summary
- Mise global tools had `installation_method` baked into the catalog (`.chezmoidata/bin/mise.toml`) — the same anti-pattern we deliberately avoided for `.local.bin.*`. Moves all eight per-machine opt-ins (python, pnpm, java, rust, bun, node, gemini-cli, ollama) into `.chezmoi.toml.tmpl` as `[data.local.mise.global_tools.<tool>]` blocks.
- Catalog data (`version`, `postinstall`) stays in `.chezmoidata/bin/mise.toml`. The two namespaces no longer collide.
- **Adds ollama (0.30.5)** as the first tool using the new pattern. Talks to the Windows-side server via `OLLAMA_HOST=http://localhost:11434` — reachable now that `.wslconfig` enables mirrored networking (#644) and the doctor probe handles URLs with scheme (#645).
- Three consumer templates updated to read `installation_method` from the BOM path: `dot_config/mise/config.toml.tmpl`, `dot_gemini/settings.json.tmpl`, `dot_config/mise/tasks/executable_install-gemini-extensions.tmpl`.
- AGENTS.md updated to point future-me at the new BOM location.

**Heads-up:** after merging, `chezmoi init` is required once per machine to re-render the user's `~/.config/chezmoi/chezmoi.toml` with the new BOM blocks. `chezmoi apply` alone won't pick them up because `.chezmoi.toml.tmpl` is template-evaluated only at init time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)