### PR TITLE
fix(ci): pin jdx/mise-action to mise 2026.5.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@v4.0.1
+        with:
+          # Pin to match .chezmoidata/bin/mise.toml. Without this, the
+          # action falls back to a default that has been yanked from
+          # upstream (mise v2026.6.7 returned 404 on 2026-06-14).
+          version: 2026.5.16
       - name: Restore uv cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
@@ -66,6 +71,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: jdx/mise-action@v4.0.1
+        with:
+          # Pin to match .chezmoidata/bin/mise.toml. Without this, the
+          # action falls back to a default that has been yanked from
+          # upstream (mise v2026.6.7 returned 404 on 2026-06-14).
+          version: 2026.5.16
       - name: Restore uv cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:


### PR DESCRIPTION
## Summary
- `jdx/mise-action@v4.0.1`'s default mise version (v2026.6.7) returned 404 from GitHub on 2026-06-14 — upstream yanked the release. CI failed on every PR opened after the yank.
- Pin both lint and test jobs to `2026.5.16` so they match the version `.chezmoidata/bin/mise.toml` deploys locally. Future yanks affect us less because we're explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)