### PR TITLE
fix(ai): bind mise trust state in sandbox + align lockfile docs to reality

### DIFF
--- a/src/chezmoi/dot_config/mise/AGENTS.md
+++ b/src/chezmoi/dot_config/mise/AGENTS.md
@@ -16,10 +16,9 @@
 
 ## Lockfile
 
-`mise.lock` in this directory is the global lockfile managed by chezmoi.
-It pins checksums for all global tools across all platforms.
-Locking is **enforced during deployment** via `MISE_LOCKED=1` in the `run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl` script.
-However, the deployed `config.toml` defaults to `locked = false` to ensure that local projects are not forced to use lockfiles by default.
+`~/.config/mise/mise.lock` is regenerated locally by `mise lock` and is **not tracked in this repo** — `.chezmoiignore` blocks it (`**/.config/mise/mise.lock`) so per-machine drift doesn't pollute the chezmoi diff.
+Locking is **enforced during deployment** via `MISE_LOCKED=1` in the `run_after_onchange_06_trust-install-global-mise-tools.sh.tmpl` script, so whatever lockfile is locally present is honored at install time.
+The deployed `config.toml` defaults to `locked = false` so local projects aren't forced to use lockfiles by default.
 
 ### Updating tools and relocking
 
@@ -37,7 +36,3 @@ Do not substitute alternative commands — especially in Jules, where `mise lock
    MISE_LOCKED=0 mise -C ~ lock --global
    ```
    The `-C ~` flag is required — running from the dotfiles repo root causes global-only tools (e.g. `uv`) to be excluded because the local `.mise.toml` claims them.
-4. Copy the lockfile back to the chezmoi source:
-   ```
-   chezmoi add ~/.config/mise/mise.lock
-   ```

--- a/src/python/agent_sandbox/agent_sandbox/bwrap.py
+++ b/src/python/agent_sandbox/agent_sandbox/bwrap.py
@@ -12,9 +12,13 @@ from pathlib import Path
 ENV_PASSTHROUGH = ("TERM", "LANG", "LC_ALL", "COLORTERM", "OLLAMA_HOST")
 
 # Read-only toolchain and config mounts re-exposed under the tmpfs home.
+# .local/state/mise carries mise's trust state for project-local mise.toml
+# files; without it, any mise shim invoked inside the sandbox from a
+# directory that has a local mise.toml (like this repo) errors on trust.
 RO_HOME_PATHS = (
     ".local/bin",
     ".local/share/mise",
+    ".local/state/mise",
     ".config/mise",
     ".dotfiles",
     ".config/ai-policy",


### PR DESCRIPTION
## Summary
- **Sandbox mise trust bind:** add `~/.local/state/mise` to `RO_HOME_PATHS` in `agent_sandbox/bwrap.py`. Without it, any mise shim invoked inside `agent-run` from a directory with a local `mise.toml` (this repo, any project) errors on trust. Verified: `agent-run run -- bash -c 'ollama --version'` now works inside this repo.
- **Lockfile docs alignment:** `dot_config/mise/AGENTS.md` told future-me to `chezmoi add ~/.config/mise/mise.lock` even though `.chezmoiignore` actively blocks it. Updated the section to describe what actually happens (lockfile is locally regenerated, not tracked, `MISE_LOCKED=1` enforces install consistency with whatever's locally present). The architectural question of whether to *start* tracking the lockfile is deliberately deferred.

Both changes are isolated and don't touch how mise resolves global vs project configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)