### PR TITLE
fix(git): apply personal identity unconditionally on the base layer

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -89,3 +89,14 @@ installation_method = "mise"
 
 [data.local.mise.global_tools.ollama]
 installation_method = "mise"
+
+# Git personal identity directive — turn on personal identity on this machine.
+# Identity values (name/email/signing_key) live in .chezmoidata/git.toml as
+# data. Overlays restrict where personal applies by defining
+# `[data.git.personal.scopes]` as a label -> gitdir-pattern map (e.g.
+# `personal = "~/personal/"`); when any scope is present the renderer emits
+# `[includeIf "gitdir:<pattern>"]` blocks instead of an unconditional
+# `[include]`. Base layer (personal machine) leaves scopes empty so every
+# repo — including fresh `git init` with no remote — picks up identity.
+[data.git.personal]
+enabled = true

--- a/src/chezmoi/.chezmoidata/git.toml
+++ b/src/chezmoi/.chezmoidata/git.toml
@@ -1,6 +1,8 @@
-# Git personal configuration - all-or-nothing feature flag
+# Personal git identity (data — the "who I am" facts). The on/off directive
+# and any per-machine scope restriction live in `.chezmoi.toml.tmpl` under
+# `[data.git.personal]`. Overlays can override individual fields here by
+# setting `[data.git.personal] name = "…"` etc. in their own chezmoi.toml.tmpl.
 [git.personal]
-enabled = true
 name = "Mike Kobit"
 email = "mkobit@gmail.com"
 signing_key = "0BCB5C5A05188FFC"

--- a/src/chezmoi/dot_dotfiles/git/config.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/config.tmpl
@@ -23,9 +23,22 @@
 [includeIf "hasconfig:remote.*.url:git@github.com:*/**"]
   path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/prune.gitconfig
 
-# Personal configuration
+# Personal configuration — unconditional on the base layer so fresh `git init`
+# repos (no remote yet, any directory) still get user.name/email/signing.
+# Overlays restrict by defining [git.personal.scopes] in chezmoi data.
 {{- if .git.personal.enabled }}
+{{-   $scopes := dig "git" "personal" "scopes" (dict) . }}
+{{-   if $scopes }}
+{{-     range $name, $path := $scopes }}
+[includeIf "gitdir:{{ $path }}"]
+  path = {{ $.chezmoi.destDir }}/.dotfiles/git/snippets/personal.gitconfig
+  path = {{ $.chezmoi.destDir }}/.dotfiles/git/snippets/github.gitconfig
+  path = {{ $.chezmoi.destDir }}/.dotfiles/git/snippets/init.gitconfig
+{{-     end }}
+{{-   else }}
+[include]
   path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/personal.gitconfig
   path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/github.gitconfig
   path = {{ .chezmoi.destDir }}/.dotfiles/git/snippets/init.gitconfig
+{{-   end }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Fix `~/.dotfiles/git/config` structural bug where the personal `path =` entries dangled under the prior `[includeIf \"hasconfig:remote.*.url:git@github.com:*/**\"]` block. As a result, `user.name`/`user.email`/`user.signingkey` only loaded for repos with an SSH github.com remote — a fresh `git init` (no remote) had no identity and `git commit` failed with *Please tell me who you are*.
- On the base (personal-machine) layer, personal identity now applies unconditionally so any local repo — no remote required, in any directory — picks it up. Overlays can narrow by setting `[data.git.personal.scopes]` as a label → `gitdir:`-pattern map; when any scope is present the renderer emits one `[includeIf \"gitdir:<pattern>\"]` block per entry, overlay-friendly per AGENTS.md.
- Move the `enabled = true` flag from `.chezmoidata/git.toml` to `.chezmoi.toml.tmpl` under `[data.git.personal]`. Identity values (`name`, `email`, `signing_key`) stay in `.chezmoidata/` as data; the on/off directive belongs in the command-and-control file alongside the BOM.

## Test plan

- [x] Render: `chezmoi execute-template --source src/chezmoi < src/chezmoi/dot_dotfiles/git/config.tmpl` emits a properly-headered unconditional `[include]` block on the base layer.
- [x] Apply: `chezmoi init && chezmoi apply ~/.dotfiles/git/config`; `git config --list --show-origin` shows `personal.gitconfig` loaded.
- [x] Behavior: fresh `git init` in `~/workspace/scratch/test-...` (no remote, under home) → `user.name`, `user.email`, `user.signingkey`, `commit.gpgsign` all set.
- [x] Behavior: fresh `git init` in `/tmp/test-...` (no remote, outside home) → identity still loads (proves unconditional, not gitdir-gated).
- [x] Overlay simulation: with `[data.git.personal.scopes] work = \"~/work/\"` injected, renderer switches to `[includeIf \"gitdir:~/work/\"]` per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)