### PR TITLE
refactor: decouple configuration directives into chezmoi.toml.tmpl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,22 +64,24 @@ When a tool extracts a full directory tree rather than a single binary, it needs
 
 ## Data and templates
 
-All configuration data lives in `.chezmoidata/`.
-Config values set in `.chezmoi.toml.tmpl` take precedence over `.chezmoidata/` for the same key path.
-Use `dig` for safe key traversal — direct map access fails in strict mode when a key is absent.
+`.chezmoidata/` is the capability catalog — environment-neutral tool metadata, catalog entries, and structural additive data (config fragment registrations, plugin arrays, keybinds).
+`.chezmoi.toml.tmpl` is the control plane — `installation_method` declarations, opt-in/opt-out decisions, and any logic requiring Go template conditionals.
+Template values take precedence over `.chezmoidata/` for the same key path.
+Scripts that read `installation_method` must use `dig "installation_method" "none" $tool` so a missing key is a no-op, not an accidental install or uninstall.
 Access hyphenated keys with `index` rather than dot notation.
 
 ## Overlay compatibility
 
 This repo is designed to be composed with an overlay — a separate chezmoi source tree that layers environment-specific configuration on top.
-The overlay wins all file collisions; individual data values are overridden via `[data.*]` entries in the overlay's `.chezmoi.toml.tmpl` or additional `.chezmoidata/` files.
+The overlay wins all file collisions, including `.chezmoi.toml.tmpl` — the overlay's init template completely replaces this one.
 
 When adding features, keep them overlay-friendly:
 
-- Put all defaults in `.chezmoidata/` so overlays have a stable override target.
+- `installation_method` decisions belong in `.chezmoi.toml.tmpl`; overlays re-declare them in their own init template.
+- Capability data (catalog entries, structural config) belongs in `.chezmoidata/` — overlays extend by adding keys, not editing base files.
 - Use generic key names — describe the concept, not the environment.
-- Use `dig` for any key an overlay might omit so absence is a no-op, not a template error.
-- Loop over maps (`range $k, $v := .feature.items`) for injectable content so overlays extend by adding keys, not editing base files.
+- Use `dig` with a safe default for any key an overlay might omit so absence is a no-op.
+- Loop over maps (`range $k, $v := .feature.items`) for injectable content.
 - Keep all source files and data environment-neutral; machine-specific values belong in the overlay.
 
 ## Troubleshooting package installations

--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -100,3 +100,52 @@ installation_method = "mise"
 # repo — including fresh `git init` with no remote — picks up identity.
 [data.git.personal]
 enabled = true
+
+# Packages & Frameworks Installation Methods
+[data.packages.ghostty]
+installation_method = {{ if eq .chezmoi.os "darwin" }}"homebrew"{{ else }}"snap"{{ end }}
+
+[data.packages.eza]
+installation_method = {{ if eq .chezmoi.os "darwin" }}"homebrew"{{ else }}"chezmoi_external"{{ end }}
+
+[data.packages.ollama]
+installation_method = {{ if eq .chezmoi.os "linux" }}"dotfiles.script"{{ else }}"none"{{ end }}
+
+[data.packages.hammerspoon]
+installation_method = "homebrew"
+
+# Local Python Tools (via uv) Installation Methods
+[data.local_bin_tools.claude_statusline]
+installation_method = "uninstall"
+
+[data.local_bin_tools.termstatus]
+installation_method = "dotfiles.uv"
+
+[data.local_bin_tools.jules]
+installation_method = "dotfiles.uv"
+
+[data.local_bin_tools.transcribe]
+installation_method = "dotfiles.uv"
+
+[data.local_bin_tools.termbud]
+installation_method = "dotfiles.uv"
+
+[data.local_bin_tools.agent_run]
+installation_method = "dotfiles.uv"
+
+# Fonts Installation Methods
+[data.fonts.fira_mono]
+installation_method = "chezmoi_external"
+
+[data.fonts.jetbrains_mono]
+installation_method = "chezmoi_external"
+
+# External Scripts & Configs Installation Methods
+[data.claude_code]
+installation_method = "dotfiles.script"
+
+[data.agy]
+installation_method = "dotfiles.script"
+
+[data.npmrc]
+installation_method = "chezmoi"

--- a/src/chezmoi/.chezmoidata/agy.toml
+++ b/src/chezmoi/.chezmoidata/agy.toml
@@ -1,4 +1,3 @@
 [agy]
-installation_method = "dotfiles.script"
 # Update to trigger reinstall; installer always fetches latest from the manifest service
 version             = "1.0.2"

--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -1,5 +1,4 @@
 [claude_code]
-installation_method = "dotfiles.script"
 version = "2.1.126"
 
 # Deployment config → managed via modify_settings.json.tmpl → ~/.claude/settings.json

--- a/src/chezmoi/.chezmoidata/fonts/fonts.toml
+++ b/src/chezmoi/.chezmoidata/fonts/fonts.toml
@@ -2,10 +2,8 @@
 name = "FiraMono"
 version = "v3.4.0"
 sha256 = "2e4adc97fefdfa2ad70a6e6e79bc0418acd401a305bcb5fcd848a84e03e35a74"
-installation_method = "chezmoi_external"
 
 [fonts.jetbrains_mono]
 name = "JetBrainsMono"
 version = "v3.4.0"
 sha256 = "ef552a3e638f25125c6ad4c51176a6adcdce295ab1d2ffacf0db060caf8c1582"
-installation_method = "chezmoi_external"

--- a/src/chezmoi/.chezmoidata/local_bin_tools.toml
+++ b/src/chezmoi/.chezmoidata/local_bin_tools.toml
@@ -5,30 +5,24 @@
 
 # Renamed to termstatus; the non-uv method triggers the uninstall branch.
 [local_bin_tools.claude_statusline]
-installation_method = "uninstall"
 package_name = "claude-statusline"
 
 [local_bin_tools.termstatus]
-installation_method = "dotfiles.uv"
 source_dir = "src/python/termstatus"
 package_name = "termstatus"
 
 [local_bin_tools.jules]
-installation_method = "dotfiles.uv"
 source_dir = "src/python/jules_cli"
 package_name = "jules-cli"
 
 [local_bin_tools.transcribe]
-installation_method = "dotfiles.uv"
 source_dir = "src/python/transcribe"
 package_name = "transcribe"
 
 [local_bin_tools.termbud]
-installation_method = "dotfiles.uv"
 source_dir = "src/python/termbud"
 package_name = "termbud"
 
 [local_bin_tools.agent_run]
-installation_method = "dotfiles.uv"
 source_dir = "src/python/agent_sandbox"
 package_name = "agent-sandbox"

--- a/src/chezmoi/.chezmoidata/npmrc.toml
+++ b/src/chezmoi/.chezmoidata/npmrc.toml
@@ -1,2 +1,0 @@
-[npmrc]
-installation_method = "chezmoi"

--- a/src/chezmoi/.chezmoidata/packages/eza.toml
+++ b/src/chezmoi/.chezmoidata/packages/eza.toml
@@ -1,7 +1,3 @@
-[packages.eza.installation_method]
-darwin = "homebrew"
-linux  = "chezmoi_external"
-
 [packages.eza.package.homebrew]
 name = "eza"
 type = "formula"

--- a/src/chezmoi/.chezmoidata/packages/ghostty.toml
+++ b/src/chezmoi/.chezmoidata/packages/ghostty.toml
@@ -1,7 +1,3 @@
-[packages.ghostty.installation_method]
-darwin = "homebrew"
-linux  = "snap"
-
 [packages.ghostty.package.homebrew]
 name = "ghostty"
 type = "cask"

--- a/src/chezmoi/.chezmoidata/packages/hammerspoon.toml
+++ b/src/chezmoi/.chezmoidata/packages/hammerspoon.toml
@@ -1,5 +1,3 @@
-[packages.hammerspoon]
-installation_method = "homebrew"
 
 [packages.hammerspoon.package.homebrew]
 name = "hammerspoon"

--- a/src/chezmoi/.chezmoidata/packages/ollama.toml
+++ b/src/chezmoi/.chezmoidata/packages/ollama.toml
@@ -1,2 +1,0 @@
-[packages.ollama.installation_method]
-linux = "dotfiles.script"

--- a/src/chezmoi/.chezmoiscripts/run_once_install-ollama.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_install-ollama.sh.tmpl
@@ -1,4 +1,4 @@
-{{- $method := dig "packages" "ollama" "installation_method" .chezmoi.os "none" . -}}
+{{- $method := dig "packages" "ollama" "installation_method" "none" . -}}
 {{- if eq $method "dotfiles.script" -}}
 #!/usr/bin/env bash
 set -euo pipefail

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -1,4 +1,4 @@
-{{- $method := dig "packages" "ghostty" "installation_method" .chezmoi.os "none" . -}}
+{{- $method := dig "packages" "ghostty" "installation_method" "none" . -}}
 {{- if eq $method "none" }}#!/usr/bin/env bash
 
 source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
@@ -15,10 +15,11 @@ fi
 "$MISE" trust "{{ $root }}/mise.toml"
 
 {{ range $name, $tool := (default dict (get . "local_bin_tools")) -}}
-{{- if eq $tool.installation_method "dotfiles.uv" }}
+{{- $method := dig "installation_method" "none" $tool -}}
+{{- if eq $method "dotfiles.uv" }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
   "$MISE" exec --cd "{{ $root }}" -- uv tool install --force --editable "{{ $root }}/{{ $tool.source_dir }}"
-{{- else if ne $tool.installation_method "none" }}
+{{- else if eq $method "uninstall" }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
   "$MISE" exec --cd "{{ $root }}" -- uv tool uninstall {{ index $tool "package_name" }} 2>/dev/null || true
 {{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
@@ -1,13 +1,7 @@
 {{- if eq .chezmoi.os "linux" -}}
 {{- $aptPkgs := list -}}
 {{- range $name, $tool := .packages -}}
-{{-   $im := dig "installation_method" "" $tool -}}
-{{-   $method := "" -}}
-{{-   if kindIs "string" $im -}}
-{{-     $method = $im -}}
-{{-   else if kindIs "map" $im -}}
-{{-     $method = dig "linux" "" $im -}}
-{{-   end -}}
+{{-   $method := dig "installation_method" "" $tool -}}
 {{-   if eq $method "apt" -}}
 {{-     $aptPkgs = append $aptPkgs $name -}}
 {{-   end -}}

--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-snap-packages.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-snap-packages.sh.tmpl
@@ -2,13 +2,7 @@
 {{- /* Build snap package list from packages namespace */ -}}
 {{- $snapPkgs := list -}}
 {{- range $name, $tool := .packages -}}
-{{-   $im := dig "installation_method" "" $tool -}}
-{{-   $method := "" -}}
-{{-   if kindIs "string" $im -}}
-{{-     $method = $im -}}
-{{-   else if kindIs "map" $im -}}
-{{-     $method = dig "linux" "" $im -}}
-{{-   end -}}
+{{-   $method := dig "installation_method" "" $tool -}}
 {{-   if eq $method "snap" -}}
 {{-     $snapPkgs = append $snapPkgs $name -}}
 {{-   end -}}


### PR DESCRIPTION
I have completed the requested task by moving the `installation_method` and platform-specific install logic out of the data capabilities model (`.chezmoidata/`) and into the base `chezmoi init` template (`.chezmoi.toml.tmpl`).

1. Added `installation_method` values for Python tools (`local_bin_tools`), Fonts, and global scripts to `.chezmoi.toml.tmpl`.
2. Translated platform-specific logic (e.g., for `ghostty`, `eza`, `ollama`) from the data `.toml` files into standard Go template conditionals (`{{ if eq .chezmoi.os "darwin" }}`) inside `.chezmoi.toml.tmpl`.
3. Stripped out the `installation_method` keys from all corresponding files in `.chezmoidata/` and verified they remain valid TOML.

Due to a sandbox environment failure (`Internal error occurred when running command`), I could not locally submit the git branch or run the final test execution, but all code changes have been validated syntactically and logically on disk.

---
*PR created automatically by Jules for task [7492595441315109223](https://jules.google.com/task/7492595441315109223) started by @mkobit*