### PR TITLE
feat(bin): Add pi coding agent binary

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -13,6 +13,9 @@ MISE_STATE_DIR  = "{{ .chezmoi.destDir }}/.local/state/mise"
 installation_method = "github_releases"
 
 # Static binaries available on all supported platforms
+[data.local.bin.pi]
+installation_method = "github_releases"
+
 [data.local.bin.bat]
 installation_method = "github_releases"
 

--- a/src/chezmoi/.chezmoidata/bin/pi.toml
+++ b/src/chezmoi/.chezmoidata/bin/pi.toml
@@ -1,0 +1,27 @@
+[bin.pi]
+version = "0.79.6"
+
+[bin.pi.github_releases]
+repo            = "earendil-works/pi"
+external_type   = "archive-file"
+executable      = true
+checksum_type   = "sha256"
+tag_format      = "v{version}"
+filename_format = "pi-{target}.tar.gz"
+path_format     = "pi/pi"
+url_format      = "{base}/{repo}/releases/download/{tag}/{filename}"
+
+[bin.pi.github_releases.platforms]
+darwin_arm64 = "darwin-arm64"
+darwin_amd64 = "darwin-x64"
+linux_amd64  = "linux-x64"
+linux_arm64  = "linux-arm64"
+
+[bin.pi.github_releases.checksums]
+darwin_arm64 = "ec0d7bf5c855376fb904732e702b1ad3b4fa5425bf6fe66e0fd90d1cc2f57595"
+darwin_amd64 = "b800ac6936f4d9ab93c229a2920a64e3e9fd23e45c1718b95f18e09aecd67572"
+linux_amd64  = "05000ec8f5b2a8a2df8e2f505aab89eb80552dcf6dc11680fa0f3285839bb4cf"
+linux_arm64  = "c4c6f3984e7b556a4f447c0b6a458a20d1d53bb646565cadb7a0ca080ce690d8"
+
+[bin.pi.homebrew]
+name = "pi"

--- a/src/chezmoi/.chezmoidata/bin/pi.toml
+++ b/src/chezmoi/.chezmoidata/bin/pi.toml
@@ -22,6 +22,3 @@ darwin_arm64 = "ec0d7bf5c855376fb904732e702b1ad3b4fa5425bf6fe66e0fd90d1cc2f57595
 darwin_amd64 = "b800ac6936f4d9ab93c229a2920a64e3e9fd23e45c1718b95f18e09aecd67572"
 linux_amd64  = "05000ec8f5b2a8a2df8e2f505aab89eb80552dcf6dc11680fa0f3285839bb4cf"
 linux_arm64  = "c4c6f3984e7b556a4f447c0b6a458a20d1d53bb646565cadb7a0ca080ce690d8"
-
-[bin.pi.homebrew]
-name = "pi"

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.integration
 @pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
-@pytest.mark.parametrize("binary", ["fzf", "rg", "eza", "bat", "zoxide", "btop"])
+@pytest.mark.parametrize("binary", ["fzf", "rg", "eza", "bat", "zoxide", "btop", "pi"])
 def test_cli_tool_available(host, binary, shell_cmd):
     """Verify each CLI binary is on PATH in bash and zsh."""
     if binary == "btop" and host.system_info.type == "darwin":

--- a/tests/integration/test_mise.py
+++ b/tests/integration/test_mise.py
@@ -15,3 +15,11 @@ def test_gemini_on_path(host, shell_cmd):
     """Verify that gemini is on PATH in bash and zsh login shells."""
     result = host.run(f"{shell_cmd} 'command -v gemini'")
     assert result.rc == 0, f"gemini not found via {shell_cmd!r}.\nstderr: {result.stderr}"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
+def test_pi_on_path(host, shell_cmd):
+    """Verify that pi is on PATH in bash and zsh login shells."""
+    result = host.run(f"{shell_cmd} 'command -v pi'")
+    assert result.rc == 0, f"pi not found via {shell_cmd!r}.\nstderr: {result.stderr}"

--- a/tests/integration/test_mise.py
+++ b/tests/integration/test_mise.py
@@ -15,11 +15,3 @@ def test_gemini_on_path(host, shell_cmd):
     """Verify that gemini is on PATH in bash and zsh login shells."""
     result = host.run(f"{shell_cmd} 'command -v gemini'")
     assert result.rc == 0, f"gemini not found via {shell_cmd!r}.\nstderr: {result.stderr}"
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
-def test_pi_on_path(host, shell_cmd):
-    """Verify that pi is on PATH in bash and zsh login shells."""
-    result = host.run(f"{shell_cmd} 'command -v pi'")
-    assert result.rc == 0, f"pi not found via {shell_cmd!r}.\nstderr: {result.stderr}"


### PR DESCRIPTION
Adds the `@earendil-works/pi` interactive coding agent CLI to the managed binary list. This uses the `github_releases` installation method for native static execution without relying on `npm` or Node modules.

* Created `pi.toml` configuration to specify platform variants, extracting `pi/pi` from the release archives.
* Included the `[data.local.bin.pi]` flag in `.chezmoi.toml.tmpl` to enable it natively via chezmoi externals.

---
*PR created automatically by Jules for task [5397181592697137877](https://jules.google.com/task/5397181592697137877) started by @mkobit*