### PR TITLE
feat(ai): nesting refusal + network=none air-gapped sandbox profile

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/sandbox.toml
+++ b/src/chezmoi/.chezmoidata/ai/sandbox.toml
@@ -32,3 +32,15 @@ backend = "auto"
 # Project mounted read-only — for audit / read-only inspection runs.
 project_write = false
 network = "shared"
+
+[ai.sandbox.profiles.autonomous-airgapped]
+enabled = true
+backend = "auto"
+# Trust the project enough to write but not enough to phone home.
+# Useful for running tests/builds on untrusted code (npm test, cargo test,
+# pytest) where you've already vendored dependencies and don't want any
+# possibility of exfiltration via curl/wget/sockets.
+project_write = true
+# --unshare-net inside bwrap: no model APIs, no ollama, no registry
+# fetches. If the build needs the network, the test will fail loudly.
+network = "none"

--- a/src/python/agent_sandbox/agent_sandbox/bwrap.py
+++ b/src/python/agent_sandbox/agent_sandbox/bwrap.py
@@ -55,6 +55,9 @@ class SandboxSpec:
     git_common_dir: Path | None = None
     extra_env: dict[str, str] = field(default_factory=dict)
     tty: bool = False
+    # "shared" reuses the host netns; "none" adds --unshare-net for an
+    # air-gapped sandbox (no model APIs, no exfiltration, no apt/npm/cargo).
+    network: str = "shared"
 
 
 def default_mask_paths(uid: int) -> tuple[str, ...]:
@@ -76,6 +79,8 @@ def build_args(spec: SandboxSpec, environ: Mapping[str, str], mask_paths: Sequen
     if not spec.tty:
         # Prevents TIOCSTI input injection into the host terminal.
         args.append("--new-session")
+    if spec.network == "none":
+        args.append("--unshare-net")
     # /tmp here is the bwrap mount target for a fresh tmpfs, not insecure temp use.
     args += ["--ro-bind", "/", "/", "--dev", "/dev", "--proc", "/proc", "--tmpfs", "/tmp"]  # noqa: S108
     for path in mask_paths:
@@ -103,6 +108,9 @@ def build_args(spec: SandboxSpec, environ: Mapping[str, str], mask_paths: Sequen
             args += ["--setenv", key, value]
     env = {
         "AGENT_RUN_PROFILE": spec.profile_name,
+        # Marker for nesting detection: agent-run refuses to start when it
+        # sees this set, since it means we're already inside a sandbox.
+        "AGENT_RUN_IN_SANDBOX": "1",
         "GIT_CONFIG_GLOBAL": str(home / ".config/ai-policy/git/sandbox.gitconfig"),
         **spec.extra_env,
     }

--- a/src/python/agent_sandbox/agent_sandbox/main.py
+++ b/src/python/agent_sandbox/agent_sandbox/main.py
@@ -130,6 +130,14 @@ def _resolve(profile_flag: str | None, cwd: Path) -> tuple[SandboxConfig, Profil
     return config, profile, backend
 
 
+def _refuse_if_nested() -> None:
+    if os.environ.get("AGENT_RUN_IN_SANDBOX") == "1":
+        raise _fail(
+            "refusing nested agent-run invocation: already inside a sandbox "
+            "(AGENT_RUN_IN_SANDBOX=1). Exit and rerun on the host."
+        )
+
+
 def _sandbox_spec(profile: Profile, cwd: Path, *, tty: bool) -> SandboxSpec:
     home = Path.home()
     project_root = _project_root(cwd)
@@ -151,6 +159,7 @@ def _sandbox_spec(profile: Profile, cwd: Path, *, tty: bool) -> SandboxSpec:
         git_common_dir=_git_common_dir(cwd, project_root),
         extra_env=extra_env,
         tty=tty,
+        network=profile.network,
     )
 
 
@@ -172,6 +181,7 @@ def run(
     show_command: bool = typer.Option(False, "--show-command", help="Print the sandbox invocation instead of running."),
 ) -> None:
     """Run a command in the sandbox: agent-run run -t --profile autonomous -- claude."""
+    _refuse_if_nested()
     command = [arg for arg in ctx.args if arg != "--"]
     if not command:
         raise _fail("no command given; usage: agent-run run [-t] [--profile NAME] -- COMMAND [ARGS...]")
@@ -193,6 +203,7 @@ def doctor(
     profile: str = typer.Option("autonomous", "--profile", help="Profile to verify."),
 ) -> None:
     """Verify the sandbox guarantees by probing from inside it."""
+    _refuse_if_nested()
     cwd = Path.cwd()
     _, active, backend = _resolve(profile, cwd)
     if isinstance(backend, BwrapBackend):
@@ -201,6 +212,7 @@ def doctor(
     spec.extra_env["PROBE_PROJECT"] = str(spec.project_root)
     spec.extra_env["PROBE_PROJECT_WRITE"] = "1" if spec.project_write else "0"
     spec.extra_env["PROBE_EXPECT_GH"] = "1" if "GH_TOKEN" in spec.extra_env else "0"
+    spec.extra_env["PROBE_NETWORK"] = spec.network
     args = [
         *backend.build_args(spec, os.environ, default_mask_paths(os.getuid())),
         "bash",
@@ -238,9 +250,15 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 if command -v curl >/dev/null 2>&1; then
-  ollama_url="${OLLAMA_HOST:-localhost:11434}"
-  case "$ollama_url" in http://*|https://*) ;; *) ollama_url="http://$ollama_url" ;; esac
-  curl -fsS -m 2 "${ollama_url}/api/version" >/dev/null 2>&1 && pass "ollama reachable" || printf 'WARN: %s\n' "ollama not reachable"
+  if [ "$PROBE_NETWORK" = "none" ]; then
+    # Air-gapped profile: any outbound TCP should fail fast. Probe a reliable
+    # public endpoint; success here means --unshare-net is not engaging.
+    curl -fsS -m 2 "https://api.github.com/zen" >/dev/null 2>&1 && fail "network reachable on air-gapped profile" || pass "network unreachable (air-gapped)"
+  else
+    ollama_url="${OLLAMA_HOST:-localhost:11434}"
+    case "$ollama_url" in http://*|https://*) ;; *) ollama_url="http://$ollama_url" ;; esac
+    curl -fsS -m 2 "${ollama_url}/api/version" >/dev/null 2>&1 && pass "ollama reachable" || printf 'WARN: %s\n' "ollama not reachable"
+  fi
 fi
 printf 'failures: %d\n' "$fails"
 exit "$fails"

--- a/src/python/agent_sandbox/tests/test_bwrap.py
+++ b/src/python/agent_sandbox/tests/test_bwrap.py
@@ -47,6 +47,7 @@ def spec_for(home, project, **overrides):
         git_common_dir=overrides.pop("git_common_dir", None),
         extra_env=overrides.pop("extra_env", {}),
         tty=overrides.pop("tty", False),
+        network=overrides.pop("network", "shared"),
     )
 
 
@@ -110,6 +111,7 @@ def test_env_is_cleared_with_allowlist_only(home, project):
     assert env["OLLAMA_HOST"] == "localhost:11434"
     assert env["HOME"] == str(home)
     assert env["AGENT_RUN_PROFILE"] == "autonomous"
+    assert env["AGENT_RUN_IN_SANDBOX"] == "1"
     assert env["GIT_CONFIG_GLOBAL"] == str(home / ".config/ai-policy/git/sandbox.gitconfig")
     assert "SSH_AUTH_SOCK" not in env
     assert "GPG_TTY" not in env
@@ -138,3 +140,13 @@ def test_chdir_to_cwd(home, project):
     idx = args.index("--chdir")
     assert args[idx + 1] == str(project)
     assert Path(args[idx + 1]).is_absolute()
+
+
+def test_network_shared_does_not_unshare(home, project):
+    args = build_args(spec_for(home, project, network="shared"), {})
+    assert "--unshare-net" not in args
+
+
+def test_network_none_unshares_net(home, project):
+    args = build_args(spec_for(home, project, network="none"), {})
+    assert "--unshare-net" in args


### PR DESCRIPTION
## Summary
- **Nesting refusal:** `AGENT_RUN_IN_SANDBOX=1` injected into the sandbox env; `agent-run run` and `agent-run doctor` check for it at the top and refuse cleanly. Stops a compromised tool inside from launching a fresh `agent-run` with a different profile.
- **Network = "none" profile field:** when set, `bwrap` gets `--unshare-net`. Adds a new `autonomous-airgapped` profile for "trust the project enough to write, not enough to phone home" — ideal for running `cargo test` / `npm test` / `pytest` on untrusted code where deps are vendored.
- **Doctor probe extended:** on `network="none"`, asserts outbound TCP fails (probes `api.github.com/zen` with 2s timeout); on `shared`, keeps existing ollama check.

Verified locally: `doctor --profile autonomous` PASS, `doctor --profile autonomous-airgapped` PASS, `AGENT_RUN_IN_SANDBOX=1 agent-run run/doctor` refuses with clear error, airgapped curl gets `Could not resolve host`. 33 unit tests green.

A shadow-binary-with-`/dev/null` mechanism was prototyped and dropped — `bwrap` can't rebind over a ro-bound parent and the agent-run binary's symlink target is already unreachable due to the home tmpfs, so the env-var check is the load-bearing defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)