### PR TITLE
fix(templates): use dig defaults so absent installation_method is a n…

### DIFF
--- a/src/chezmoi/.chezmoiignore.tmpl
+++ b/src/chezmoi/.chezmoiignore.tmpl
@@ -28,7 +28,7 @@
 **/expected_*
 **/test_data.toml
 
-{{- if ne .npmrc.installation_method "chezmoi" }}
+{{- if ne (dig "npmrc" "installation_method" "chezmoi" .) "chezmoi" }}
 .npmrc
 {{- end }}
 

--- a/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_once_uninstall-ghostty.sh.tmpl
@@ -1,5 +1,5 @@
 {{- $method := dig "packages" "ghostty" "installation_method" "none" . -}}
-{{- if eq $method "none" }}#!/usr/bin/env bash
+{{- if eq $method "uninstall" }}#!/usr/bin/env bash
 
 source "{{ .chezmoi.sourceDir }}/.chezmoitemplates/shell/logging.sh"
 

--- a/src/chezmoi/dot_local/share/fonts/.chezmoiexternals/fonts.toml.tmpl
+++ b/src/chezmoi/dot_local/share/fonts/.chezmoiexternals/fonts.toml.tmpl
@@ -1,7 +1,7 @@
 {{- $base := dig "github_releases" "base_url" "https://github.com" $ -}}
 {{- $config := dict -}}
 {{- range $key, $font := .fonts -}}
-  {{- if eq $font.installation_method "chezmoi_external" -}}
+  {{- if eq (dig "installation_method" "" $font) "chezmoi_external" -}}
     {{- $target := printf "NerdFonts/%s" $font.name -}}
     {{- $fontConfig := dict
         "type"     "archive"


### PR DESCRIPTION
…o-op

PR #654 moved installation_method values from .chezmoidata/ files into .chezmoi.toml.tmpl. Templates that accessed those values via direct map lookup (`.npmrc.installation_method`, `$font.installation_method`) now crash when an overlay replaces .chezmoi.toml.tmpl without replicating every data key.

Per AGENTS.md: scripts reading installation_method must use `dig "installation_method" "none" $tool` so a missing key is a no-op.

Also fix uninstall-ghostty.sh.tmpl: "none" means "not installed here" and must not trigger an uninstall. An explicit "uninstall" value is required to trigger removal, consistent with the local_bin_tools pattern.


Committed-By-Agent: claude