### PR TITLE
feat(ai): add home_rw / home_mask profile fields and chezmoi profile

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/sandbox.toml
+++ b/src/chezmoi/.chezmoidata/ai/sandbox.toml
@@ -44,3 +44,21 @@ project_write = true
 # --unshare-net inside bwrap: no model APIs, no ollama, no registry
 # fetches. If the build needs the network, the test will fail loudly.
 network = "none"
+
+[ai.sandbox.profiles.chezmoi]
+enabled = true
+backend = "auto"
+# For working on the dotfiles repo itself: needs rw access to the home
+# subdirs chezmoi manages so `chezmoi diff` / `chezmoi apply --dry-run`
+# can run and verify template renders. Only invoke this profile from
+# inside the dotfiles repo — running it on a random project gives a
+# malicious agent rw access to most of your $HOME.
+project_write = true
+network = "shared"
+# Broad re-exposes: chezmoi templates can target anywhere under .config,
+# .local/share, .local/bin, .local/state. Top-level credential dirs
+# (.ssh, .gnupg) stay tmpfs-masked because they're not in this list.
+home_rw = [".config", ".local/share", ".local/bin", ".local/state"]
+# gh tokens live under .config/gh which would otherwise be exposed by
+# the .config rw bind. Mask explicitly to keep the credential boundary.
+home_mask = [".config/gh"]

--- a/src/python/agent_sandbox/agent_sandbox/bwrap.py
+++ b/src/python/agent_sandbox/agent_sandbox/bwrap.py
@@ -58,6 +58,10 @@ class SandboxSpec:
     # "shared" reuses the host netns; "none" adds --unshare-net for an
     # air-gapped sandbox (no model APIs, no exfiltration, no apt/npm/cargo).
     network: str = "shared"
+    # Profile-supplied paths under $HOME to expose rw / mask. See
+    # config.Profile.home_rw / home_mask for the schema rationale.
+    home_rw: tuple[str, ...] = ()
+    home_mask: tuple[str, ...] = ()
 
 
 def default_mask_paths(uid: int) -> tuple[str, ...]:
@@ -95,6 +99,14 @@ def build_args(spec: SandboxSpec, environ: Mapping[str, str], mask_paths: Sequen
         if path.exists():
             args += ["--bind", str(path), str(path)]
     args += ["--bind", str(home / CACHE_REL), str(home / ".cache")]
+    # Profile-supplied broad rw exposes (e.g. .config for the chezmoi profile).
+    # Run before home_mask so credential subdirs are tmpfs-masked on top.
+    for rel in spec.home_rw:
+        path = home / rel
+        if path.exists():
+            args += ["--bind", str(path), str(path)]
+    for rel in spec.home_mask:
+        args += ["--tmpfs", str(home / rel)]
     project_bind = "--bind" if spec.project_write else "--ro-bind"
     args += [project_bind, str(spec.project_root), str(spec.project_root)]
     if spec.git_common_dir is not None:

--- a/src/python/agent_sandbox/agent_sandbox/config.py
+++ b/src/python/agent_sandbox/agent_sandbox/config.py
@@ -30,6 +30,15 @@ class Profile(BaseModel):
     backend: Backend = "auto"
     project_write: bool = False
     network: Network = "shared"
+    # Paths under $HOME to re-expose rw after the tmpfs default-deny.
+    # Empty for most profiles; broad for the `chezmoi` profile that needs
+    # to test deploying templates by running `chezmoi apply`.
+    home_rw: tuple[str, ...] = ()
+    # Paths to tmpfs-mask after home_rw, for credential dirs nested inside
+    # an otherwise rw-exposed parent (e.g., ~/.config/gh when ~/.config is
+    # bound rw). Paths not under any home_rw entry are already masked by
+    # the home tmpfs and don't need to be listed here.
+    home_mask: tuple[str, ...] = ()
 
 
 class SandboxConfig(BaseModel):

--- a/src/python/agent_sandbox/agent_sandbox/main.py
+++ b/src/python/agent_sandbox/agent_sandbox/main.py
@@ -160,6 +160,8 @@ def _sandbox_spec(profile: Profile, cwd: Path, *, tty: bool) -> SandboxSpec:
         extra_env=extra_env,
         tty=tty,
         network=profile.network,
+        home_rw=tuple(profile.home_rw),
+        home_mask=tuple(profile.home_mask),
     )
 
 

--- a/src/python/agent_sandbox/tests/test_bwrap.py
+++ b/src/python/agent_sandbox/tests/test_bwrap.py
@@ -48,6 +48,8 @@ def spec_for(home, project, **overrides):
         extra_env=overrides.pop("extra_env", {}),
         tty=overrides.pop("tty", False),
         network=overrides.pop("network", "shared"),
+        home_rw=overrides.pop("home_rw", ()),
+        home_mask=overrides.pop("home_mask", ()),
     )
 
 
@@ -150,3 +152,34 @@ def test_network_shared_does_not_unshare(home, project):
 def test_network_none_unshares_net(home, project):
     args = build_args(spec_for(home, project, network="none"), {})
     assert "--unshare-net" in args
+
+
+def test_home_rw_binds_existing_paths(home, project):
+    (home / ".config").mkdir()
+    (home / ".local/state").mkdir(parents=True)
+    args = build_args(spec_for(home, project, home_rw=(".config", ".local/state", ".nonexistent")), {})
+    rw = bind_pairs(args, "--bind")
+    assert (str(home / ".config"), str(home / ".config")) in rw
+    assert (str(home / ".local/state"), str(home / ".local/state")) in rw
+    # Skipped because the dir doesn't exist on disk; mirrors RW_HOME_PATHS behavior.
+    assert all(".nonexistent" not in src for src, _ in rw)
+
+
+def test_home_mask_tmpfs_overrides_home_rw(home, project):
+    (home / ".config").mkdir()
+    args = build_args(spec_for(home, project, home_rw=(".config",), home_mask=(".config/gh",)), {})
+    rw = bind_pairs(args, "--bind")
+    tmpfs_targets = [args[i + 1] for i, a in enumerate(args) if a == "--tmpfs"]
+    assert (str(home / ".config"), str(home / ".config")) in rw
+    assert str(home / ".config/gh") in tmpfs_targets
+    # Mask must appear AFTER the bind so it takes effect.
+    bind_idx = next(i for i, a in enumerate(args) if a == "--bind" and args[i + 1] == str(home / ".config"))
+    tmpfs_idx = next(i for i, a in enumerate(args) if a == "--tmpfs" and args[i + 1] == str(home / ".config/gh"))
+    assert bind_idx < tmpfs_idx
+
+
+def test_home_rw_empty_by_default(home, project):
+    args = build_args(spec_for(home, project), {})
+    rw = bind_pairs(args, "--bind")
+    # ~/.config is not among the standard RW_HOME_PATHS, only via home_rw.
+    assert (str(home / ".config"), str(home / ".config")) not in rw


### PR DESCRIPTION
## Summary
- New `Profile` schema fields:
  - `home_rw: tuple[str, ...]` — paths under \$HOME to bind rw after the default-deny tmpfs.
  - `home_mask: tuple[str, ...]` — paths to tmpfs-mask after `home_rw`, for credentials nested inside an otherwise rw-exposed parent.
- New `chezmoi` profile uses both: rw exposes `.config`, `.local/share`, `.local/bin`, `.local/state` so `chezmoi diff` / `chezmoi apply --dry-run` can verify template renders, while `.config/gh` stays masked. Top-level credential dirs (`.ssh`, `.gnupg`) stay masked via the home tmpfs.
- Verified locally: `~/.config/mise` visible inside the `chezmoi`-profile sandbox, `~/.config/gh` empty (tmpfs-masked), `~/.ssh` "no such file" (still masked).
- 36 unit tests green, including new coverage for home_rw existing-path filtering and home_mask ordering after the bind.

## Known follow-up (separate PR)
DNS resolution is broken inside the sandbox on WSL2 with mirrored networking — `/etc/resolv.conf` doesn't exist inside, so external hostname lookups fail (`Could not resolve host: api.github.com`). This affects every `network = "shared"` profile, not just `chezmoi`. Likely needs a `--ro-bind /etc/resolv.conf` or equivalent (or to follow the symlink the host uses). Tracking separately to keep this PR focused on the profile schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)