### PR TITLE
fix: make unidiff_patch optional in GitPatch model

### DIFF
--- a/src/python/jules_cli/jules_cli/activity.py
+++ b/src/python/jules_cli/jules_cli/activity.py
@@ -84,7 +84,7 @@ class SessionCompleted(BaseModel):
 class GitPatch(BaseModel):
     """A patch in Git format."""
 
-    unidiff_patch: str
+    unidiff_patch: str | None = None
     base_commit_id: str | None = None
     suggested_commit_message: str | None = None
     model_config = frozen_config


### PR DESCRIPTION
Fixes a Pydantic validation bug when a session contains an activity where `artifacts[].changeSet.gitPatch` is produced for a no-op change. The API returns the `gitPatch` object without a `unidiffPatch` body in these cases, causing a validation error when listing activities.

Changing `unidiff_patch` to `str | None = None` resolves the `ValidationError` and allows inspecting sessions that produced a "no files modified" outcome.

---
*PR created automatically by Jules for task [599972678170677066](https://jules.google.com/task/599972678170677066) started by @mkobit*