### PR TITLE
feat(ai): centralize agent guidelines into shared chezmoi data

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/guidelines.toml
+++ b/src/chezmoi/.chezmoidata/ai/guidelines.toml
@@ -1,0 +1,25 @@
+# Universal agent guidelines — shared across all AI coding tools.
+# Consumed by dot_claude/CLAUDE.md.tmpl, dot_codex/AGENTS.md.tmpl, and goose.
+# Keep this tight — injected into every conversation turn.
+
+[[ai.guidelines.sections]]
+content = """
+## Writing style
+- Sentence case: headings, commits, PR titles, UI labels — always.
+- Prose and documentation: one sentence per line.
+- Codify tools, commands, and syntax with target output markup.
+- Source links (docs, code, issues) in PR descriptions, Slack drafts, and research summaries.
+- Voice for drafted messages: lowercase body (capitalize proper nouns only), no filler adjectives, front-load the action, fact-driven.
+- Example — instead of "We introduced a shared config to ensure consistency across tools" → "creates `guidelines.toml` as single source for all tools, one-line changes propagate everywhere"."""
+
+[[ai.guidelines.sections]]
+content = """
+## Approach
+- State assumptions before implementing; if multiple interpretations exist, surface them rather than picking silently.
+- Ask rather than guess.
+- Minimum code for the task; no speculative features or abstractions."""
+
+[[ai.guidelines.sections]]
+content = """
+## Tools
+- `fd` over `find`; `rg` over `grep`."""

--- a/src/chezmoi/dot_claude/CLAUDE.md
+++ b/src/chezmoi/dot_claude/CLAUDE.md
@@ -1,8 +1,0 @@
-# Preferences
-
-- Always write titles in sentence case.
-- Write documentation (README, HTML, Markdown, AsciiDoc, RST, and other formats) with one sentence per line.
-- Prefer `fd` over `find`.
-- Prefer `rg` over `grep`.
-- Prefer available agentic file searching and read tools over CLI tools when available.
-- Prefer strict TypeScript configuration.

--- a/src/chezmoi/dot_claude/CLAUDE.md.tmpl
+++ b/src/chezmoi/dot_claude/CLAUDE.md.tmpl
@@ -1,0 +1,4 @@
+# Agent guidelines
+{{ range .ai.guidelines.sections }}
+{{ .content }}
+{{ end -}}

--- a/src/chezmoi/dot_codex/AGENTS.md
+++ b/src/chezmoi/dot_codex/AGENTS.md
@@ -1,8 +1,0 @@
-# Preferences
-
-- Always write titles in sentence case.
-- Write documentation (README, HTML, Markdown, AsciiDoc, RST, and other formats) with one sentence per line.
-- Prefer `fd` over `find`.
-- Prefer `rg` over `grep`.
-- Prefer available agentic file searching and read tools over CLI tools when available.
-- Prefer strict TypeScript configuration.

--- a/src/chezmoi/dot_codex/AGENTS.md.tmpl
+++ b/src/chezmoi/dot_codex/AGENTS.md.tmpl
@@ -1,0 +1,4 @@
+# Agent guidelines
+{{ range .ai.guidelines.sections }}
+{{ .content }}
+{{ end -}}


### PR DESCRIPTION
creates `guidelines.toml` as single source for all AI tool instruction files, rendered via templates into `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`. one-line changes propagate to all tools.

replaces static duplicate files with templates consuming `.chezmoidata/ai/guidelines.toml` sections array.


Committed-By-Agent: claude