### PR TITLE
fix(templates): use dig for agy installation_method so absent key is a no-op

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if eq .agy.installation_method "dotfiles.script" -}}
+{{- if eq (dig "installation_method" "none" .agy) "dotfiles.script" -}}
 #!/bin/bash
 # agy {{ .agy.version }}
 set -euo pipefail


### PR DESCRIPTION
## Summary

- `run_onchange_install-agy.sh.tmpl` used direct map access `.agy.installation_method`, which panics when the key is absent from chezmoi data
- Changed to `dig "installation_method" "none" .agy` so a missing key is a no-op, consistent with AGENTS.md requirements and the pattern used elsewhere in the repo

## Test plan

- [ ] `chezmoi update` succeeds without template errors when `.agy` map has no `installation_method` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)