### PR TITLE
feat(ai): support overlay-injected environment and workflow sections

### DIFF
--- a/src/chezmoi/dot_claude/CLAUDE.md.tmpl
+++ b/src/chezmoi/dot_claude/CLAUDE.md.tmpl
@@ -2,3 +2,17 @@
 {{ range .ai.guidelines.sections }}
 {{ .content }}
 {{ end -}}
+{{- $env := dig "ai" "agent_context" "environment" "" . -}}
+{{- $wf := dig "ai" "agent_context" "workflows" "" . -}}
+{{- if $env }}
+
+# Environment
+
+{{ $env | trim }}
+{{- end -}}
+{{- if $wf }}
+
+# Workflows
+
+{{ $wf | trim }}
+{{- end }}

--- a/src/chezmoi/dot_codex/AGENTS.md.tmpl
+++ b/src/chezmoi/dot_codex/AGENTS.md.tmpl
@@ -2,3 +2,17 @@
 {{ range .ai.guidelines.sections }}
 {{ .content }}
 {{ end -}}
+{{- $env := dig "ai" "agent_context" "environment" "" . -}}
+{{- $wf := dig "ai" "agent_context" "workflows" "" . -}}
+{{- if $env }}
+
+# Environment
+
+{{ $env | trim }}
+{{- end -}}
+{{- if $wf }}
+
+# Workflows
+
+{{ $wf | trim }}
+{{- end }}


### PR DESCRIPTION
Extend CLAUDE.md.tmpl and AGENTS.md.tmpl to conditionally render environment and workflow sections from data.ai.agent_context. Overlay supplies these via .chezmoi.toml.tmpl keyed by environment type; without overlay data the sections are absent.


Committed-By-Agent: claude