### PR TITLE
fix(termstatus): gracefully adapt terminal panel to narrow widths

### DIFF
--- a/src/python/termstatus/termstatus/render.py
+++ b/src/python/termstatus/termstatus/render.py
@@ -119,7 +119,7 @@ async def probe_terminal_width() -> int | None:
 def _effective_width(probed: int | None) -> int:
     # Panel border + padding takes 4 chars (│ + space each side + │)
     raw = (probed or 80) - 4
-    return max(56, min(raw, 90))
+    return max(20, min(raw, 90))
 
 
 def _group_segments_by_line(

--- a/src/python/termstatus/tests/test_render.py
+++ b/src/python/termstatus/tests/test_render.py
@@ -27,3 +27,17 @@ class TestRenderLines(unittest.TestCase):
         self.assertTrue("B0" in lines[2])
         self.assertFalse("B10" in lines[2])
         self.assertTrue("C0" in lines[3] and "C10" in lines[3])
+
+    def test_render_lines_narrow_terminal(self):
+        payload = StatusLineStdIn()
+
+        segments = [
+            SegmentGenerationResult(line=0, index=0, segment=Segment(text="Long text that would usually wrap or exceed narrow width")),
+            SegmentGenerationResult(line=0, index=10, segment=Segment(text="More text")),
+        ]
+
+        lines = render_lines(payload, None, segments, terminal_width=40)
+
+        # Output with Rich Panel should have borders (top and bottom) + content = at least 3 lines.
+        self.assertTrue(len(lines) >= 3)
+        self.assertTrue(any(line.strip() for line in lines))

--- a/src/python/termstatus/tests/test_render.py
+++ b/src/python/termstatus/tests/test_render.py
@@ -32,7 +32,9 @@ class TestRenderLines(unittest.TestCase):
         payload = StatusLineStdIn()
 
         segments = [
-            SegmentGenerationResult(line=0, index=0, segment=Segment(text="Long text that would usually wrap or exceed narrow width")),
+            SegmentGenerationResult(
+                line=0, index=0, segment=Segment(text="Long text that would usually wrap or exceed narrow width")
+            ),
             SegmentGenerationResult(line=0, index=10, segment=Segment(text="More text")),
         ]
 


### PR DESCRIPTION
This PR allows the terminal status panel generated by `termstatus` to shrink more gracefully. Previously, the `_effective_width` function hardcoded a minimum floor of 56 columns. On smaller devices, such as phone terminal sessions, panels with a width under 56 would overwrap terribly. The minimum has been lowered to 20 columns, ensuring better responsiveness. Added tests for a narrow setup in `test_render.py`.

---
*PR created automatically by Jules for task [6275222169581275448](https://jules.google.com/task/6275222169581275448) started by @mkobit*