### PR TITLE
Fix statusline command for antigravity-cli

### DIFF
--- a/src/chezmoi/dot_gemini/antigravity-cli/settings.json.tmpl
+++ b/src/chezmoi/dot_gemini/antigravity-cli/settings.json.tmpl
@@ -36,12 +36,12 @@
         )
         "statusLine" (dict
           "type" "command"
-          "command" (printf "%s/.local/bin/dotfiles/termstatus antigravity render" .chezmoi.destDir)
+          "command" (printf "%s/.local/bin/dotfiles/statusline antigravity render" .chezmoi.destDir)
           "enabled" true
         )
         "title" (dict
           "type" "command"
-          "command" (printf "%s/.local/bin/dotfiles/termstatus antigravity title" .chezmoi.destDir)
+          "command" (printf "%s/.local/bin/dotfiles/statusline antigravity title" .chezmoi.destDir)
           "enabled" true
         )
 -}}


### PR DESCRIPTION
The local Python workspace package termstatus generates an executable named statusline, as defined by its pyproject.toml ([project.scripts]). This commit updates the settings.json.tmpl for antigravity-cli to execute statusline rather than termstatus.

---
*PR created automatically by Jules for task [11465474296501660904](https://jules.google.com/task/11465474296501660904) started by @mkobit*