### PR TITLE
feat(browser-sync): split into shortcuts/vimium/bookmarklets subcommands

### DIFF
--- a/src/python/browser_sync/browser_sync/_browser.py
+++ b/src/python/browser_sync/browser_sync/_browser.py
@@ -1,0 +1,22 @@
+"""Browser sync targets and launching."""
+
+import enum
+import subprocess
+
+
+class Browser(enum.Enum):
+    """A browser sync target."""
+
+    CHROME = "chrome"
+    FIREFOX = "firefox"
+
+
+def resolve_targets(*, chrome: bool, firefox: bool) -> tuple[Browser, ...]:
+    """Resolve --chrome/--firefox flags to target browsers; default Chrome."""
+    selected = tuple(browser for browser, enabled in ((Browser.CHROME, chrome), (Browser.FIREFOX, firefox)) if enabled)
+    return selected or (Browser.CHROME,)
+
+
+def open_in_chrome(url: str) -> None:
+    """Open a URL in Google Chrome."""
+    subprocess.run(["open", "-a", "Google Chrome", url], check=True)

--- a/src/python/browser_sync/browser_sync/_clipboard.py
+++ b/src/python/browser_sync/browser_sync/_clipboard.py
@@ -1,0 +1,8 @@
+"""macOS clipboard access via pbcopy."""
+
+import subprocess
+
+
+def copy_to_clipboard(text: str) -> None:
+    """Copy text to the macOS clipboard."""
+    subprocess.run(["pbcopy"], input=text.encode(), check=True)

--- a/src/python/browser_sync/browser_sync/_devtools.py
+++ b/src/python/browser_sync/browser_sync/_devtools.py
@@ -1,0 +1,10 @@
+"""Shared JavaScript injected into the browser DevTools console."""
+
+# Console badge helper shared by the generated DevTools scripts. Inserted into
+# f-string templates via a single `{JS_TAG_HELPER}` field, so its own braces
+# stay literal (the template's other braces are doubled to escape them).
+JS_TAG_HELPER = (
+    "const tag = (color, label, msg) =>\n"
+    "    console.log(`%c${label}%c ${msg}`, "
+    "`background:${color};color:#fff;padding:1px 6px;border-radius:3px;font-weight:600`, '');"
+)

--- a/src/python/browser_sync/browser_sync/_terminal.py
+++ b/src/python/browser_sync/browser_sync/_terminal.py
@@ -1,0 +1,109 @@
+"""Terminal I/O for browser-sync: colored logging and raw-tty prompts."""
+
+import logging
+import sys
+import termios
+import time
+import tty
+import typing
+from collections.abc import Callable
+
+OK = 25
+logging.addLevelName(OK, "OK")
+_log = logging.getLogger(__name__)
+
+
+class _ColorFormatter(logging.Formatter):
+    """Terminal formatter with colored level badges and timestamps."""
+
+    _COLORS: typing.ClassVar[dict[int, str]] = {
+        logging.INFO: "\033[0;34m",
+        OK: "\033[0;32m",
+        logging.WARNING: "\033[0;33m",
+        logging.ERROR: "\033[0;31m",
+    }
+    _LABELS: typing.ClassVar[dict[int, str]] = {
+        logging.INFO: "INFO",
+        OK: "OK  ",
+        logging.WARNING: "WARN",
+        logging.ERROR: "ERR ",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format log record with timestamp and colored badge."""
+        ts = time.strftime("%H:%M:%S")
+        color = self._COLORS.get(record.levelno, "\033[0m")
+        label = self._LABELS.get(record.levelno, record.levelname)
+        return f"\033[2m{ts}\033[0m {color}[{label}]\033[0m {record.getMessage()}"
+
+
+def setup_logging() -> None:
+    """Install the colored formatter on the root logger."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(_ColorFormatter())
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+
+def getkey() -> str:
+    """Read a single keypress from stdin in raw mode."""
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        return sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def prompt_enter(message: str) -> None:
+    """Wait for Enter; exit cleanly on Ctrl+C."""
+    print(f"\n\033[0;36m[?]\033[0m    {message}", end="", flush=True)
+    while True:
+        ch = getkey()
+        if ch in ("\r", "\n"):
+            print()
+            return
+        if ch == "\x03":
+            print()
+            _log.info("skipped")
+            sys.exit(0)
+
+
+def prompt_done_or_recopy(copy_fn: Callable[[], None]) -> None:
+    """Wait for Enter (done) or 'r' (recopy the clipboard payload)."""
+    print("\n\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
+    while True:
+        ch = getkey()
+        if ch in ("\r", "\n"):
+            print()
+            return
+        if ch.lower() == "r":
+            copy_fn()
+            print()
+            _log.log(OK, "recopied to clipboard")
+            print("\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
+        if ch == "\x03":
+            print()
+            _log.info("skipped")
+            sys.exit(0)
+
+
+def prompt_prune_or_skip(copy_fn: Callable[[], None]) -> None:
+    """Wait for 'p' (copy prune script then confirm) or Enter (skip removals)."""
+    print("\n\033[0;33m[!]\033[0m    Press 'p' to copy PRUNE script, or Enter to skip removals ", end="", flush=True)
+    while True:
+        ch = getkey()
+        if ch in ("\r", "\n"):
+            print()
+            _log.info("skipped removals")
+            return
+        if ch.lower() == "p":
+            copy_fn()
+            print()
+            _log.log(OK, "prune script copied — paste into console to remove extras")
+            prompt_done_or_recopy(copy_fn)
+            return
+        if ch == "\x03":
+            print()
+            _log.info("skipped")
+            sys.exit(0)

--- a/src/python/browser_sync/browser_sync/bookmarklets.py
+++ b/src/python/browser_sync/browser_sync/bookmarklets.py
@@ -1,0 +1,242 @@
+"""Sync bookmarklet JS source files into Chrome via the chrome.bookmarks API.
+
+Compares source JS files against Chrome's current Bookmarks file. If they
+differ, generates a console script, copies it to clipboard, and opens
+chrome://bookmarks. Paste into the DevTools console (Cmd+Option+I) to apply.
+"""
+
+import json
+import logging
+import re
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from urllib.parse import unquote
+
+from pydantic import BaseModel
+
+from browser_sync import _browser, _clipboard, _terminal
+
+_CHROME_BOOKMARKS = Path.home() / "Library/Application Support/Google/Chrome/Default/Bookmarks"
+_FOLDER_TITLE = "bookmarklets"
+_log = logging.getLogger(__name__)
+
+
+class _Bookmarklet(BaseModel, frozen=True):
+    """A bookmarklet entry: a display title and its `javascript:` URL."""
+
+    title: str
+    url: str
+
+
+class _Update(_Bookmarklet, frozen=True):
+    """A bookmarklet whose title or URL changed, with its prior title."""
+
+    old_title: str
+
+
+class _Diff(BaseModel, frozen=True):
+    """The create/update/remove sets between desired and current state."""
+
+    create: tuple[_Bookmarklet, ...]
+    update: tuple[_Update, ...]
+    remove: tuple[_Bookmarklet, ...]
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether any create/update/remove operations are pending."""
+        return bool(self.create or self.update or self.remove)
+
+
+def _get_title(js_file: Path, js_source: str) -> str:
+    """Extract title from '// title: ...' directive, or fall back to filename."""
+    match = re.match(r"^//\s*title:\s*(.+)", js_source)
+    if match:
+        return match.group(1).strip()
+    return " ".join(word.capitalize() for word in js_file.stem.split("-"))
+
+
+def _js_to_bookmarklet_url(js_source: str) -> str:
+    """Convert JS source to a javascript: bookmarklet URL."""
+    lines = js_source.strip().splitlines()
+    body = lines[1:] if lines and re.match(r"^//\s*title:", lines[0]) else lines
+    collapsed = re.sub(r"\s*\n\s*", " ", "\n".join(body).strip())
+    return f"javascript:{collapsed}"
+
+
+def _get_desired(dir_path: Path) -> Mapping[str, str]:
+    """Return {title: url} from source JS files, sorted case-insensitively by title."""
+    js_files = sorted(dir_path.glob("*.js"))
+    if not js_files:
+        _log.error("no .js files found in %s", dir_path)
+        sys.exit(1)
+
+    sources = {js_file: js_file.read_text() for js_file in js_files}
+    entries = {_get_title(js_file, source): _js_to_bookmarklet_url(source) for js_file, source in sources.items()}
+    return dict(sorted(entries.items(), key=lambda item: item[0].lower()))
+
+
+def _get_chrome_bookmarklets() -> Mapping[str, str]:
+    """Return {title: url} from Chrome's Bookmarks file for the target folder."""
+    if not _CHROME_BOOKMARKS.exists():
+        return {}
+
+    bookmarks = json.loads(_CHROME_BOOKMARKS.read_text())
+
+    def find_folder(node: dict, name: str) -> dict | None:
+        if node.get("name") == name and node.get("type") == "folder":
+            return node
+        return next((found for child in node.get("children", []) if (found := find_folder(child, name))), None)
+
+    roots = (root for root in bookmarks.get("roots", {}).values() if isinstance(root, dict))
+    folder = next((found for root in roots if (found := find_folder(root, _FOLDER_TITLE))), None)
+    if folder is None:
+        return {}
+    return {child["name"]: unquote(child["url"]) for child in folder.get("children", []) if child.get("type") == "url"}
+
+
+def _slugify(title: str) -> str:
+    """Normalize a title to a comparable slug: lowercase, hyphens, no special chars."""
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def _compute_diff(desired: Mapping[str, str], current: Mapping[str, str]) -> _Diff:
+    """Compare desired vs current using slug matching."""
+    desired_by_slug = {_slugify(t): (t, u) for t, u in desired.items()}
+    current_by_slug = {_slugify(t): (t, u) for t, u in current.items()}
+    return _Diff(
+        create=tuple(
+            _Bookmarklet(title=t, url=u) for slug, (t, u) in desired_by_slug.items() if slug not in current_by_slug
+        ),
+        update=tuple(
+            _Update(title=t, url=u, old_title=current_by_slug[slug][0])
+            for slug, (t, u) in desired_by_slug.items()
+            if slug in current_by_slug and (t, u) != current_by_slug[slug]
+        ),
+        remove=tuple(
+            _Bookmarklet(title=t, url=u) for slug, (t, u) in current_by_slug.items() if slug not in desired_by_slug
+        ),
+    )
+
+
+def _build_sync_script(desired: Mapping[str, str]) -> str:
+    """Build the chrome.bookmarks API console script."""
+    desired_json = json.dumps([{"title": t, "url": u} for t, u in desired.items()], indent=2)
+    return f"""\
+(async () => {{
+  const FOLDER_TITLE = {json.dumps(_FOLDER_TITLE)};
+  const desired = {desired_json};
+
+  const style = {{
+    header: "font-weight:bold;font-size:13px;color:#1a73e8",
+    create: "color:#1e8e3e;font-weight:bold",
+    update: "color:#e8710a;font-weight:bold",
+    remove: "color:#d93025;font-weight:bold",
+    skip:   "color:#80868b",
+    done:   "font-weight:bold;color:#1e8e3e;font-size:12px",
+    noop:   "font-weight:bold;color:#80868b;font-size:12px",
+  }};
+
+  const slugify = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+  const folders = await chrome.bookmarks.search({{ title: FOLDER_TITLE }});
+  const folder = folders.find(f => !f.url);
+  if (!folder) {{
+    console.error(`%c✗ Folder "${{FOLDER_TITLE}}" not found — create it first`, style.remove);
+    return;
+  }}
+
+  const existing = await chrome.bookmarks.getChildren(folder.id);
+  const counts = {{ created: 0, updated: 0, removed: 0, unchanged: 0 }};
+
+  for (const bm of existing) {{
+    const match = desired.find(d => slugify(d.title) === slugify(bm.title));
+    if (!match) {{
+      await chrome.bookmarks.remove(bm.id);
+      console.log(`%c  - ${{bm.title}}`, style.remove);
+      counts.removed++;
+    }}
+  }}
+
+  for (const d of desired) {{
+    const match = existing.find(e => slugify(e.title) === slugify(d.title));
+    if (match) {{
+      const changes = {{}};
+      if (match.title !== d.title) changes.title = d.title;
+      if (decodeURIComponent(match.url) !== d.url) changes.url = d.url;
+      if (Object.keys(changes).length > 0) {{
+        await chrome.bookmarks.update(match.id, changes);
+        console.log(`%c  ↻ ${{d.title}}`, style.update);
+        counts.updated++;
+      }} else {{
+        console.log(`%c  · ${{d.title}}`, style.skip);
+        counts.unchanged++;
+      }}
+    }} else {{
+      await chrome.bookmarks.create({{ parentId: folder.id, title: d.title, url: d.url }});
+      console.log(`%c  + ${{d.title}}`, style.create);
+      counts.created++;
+    }}
+  }}
+
+  const bySlug = {{}};
+  for (const c of await chrome.bookmarks.getChildren(folder.id)) bySlug[slugify(c.title)] = c.id;
+  for (let i = 0; i < desired.length; i++) {{
+    const id = bySlug[slugify(desired[i].title)];
+    if (id !== undefined) await chrome.bookmarks.move(id, {{ index: i }});
+  }}
+
+  const changed = counts.created + counts.updated + counts.removed;
+  if (changed > 0) {{
+    const parts = [];
+    if (counts.created) parts.push(`+${{counts.created}}`);
+    if (counts.updated) parts.push(`↻${{counts.updated}}`);
+    if (counts.removed) parts.push(`-${{counts.removed}}`);
+    console.log(`%c✓ ${{parts.join(" ")}} (${{counts.unchanged}} unchanged)`, style.done);
+  }} else {{
+    console.log("%c· already in sync", style.noop);
+  }}
+}})();"""
+
+
+def _log_diff(diff: _Diff) -> None:
+    """Print the pending create/update/remove operations."""
+    _log.info("changes detected:")
+    for bm in diff.create:
+        _log.info("  \033[32m+\033[0m %s", bm.title)
+    for up in diff.update:
+        label = f"{up.old_title} → {up.title}" if up.old_title != up.title else up.title
+        _log.info("  \033[33m~\033[0m %s", label)
+    for bm in diff.remove:
+        _log.info("  \033[31m-\033[0m %s", bm.title)
+
+
+def run(dir_path: Path, *, dry_run: bool, no_open: bool, force: bool) -> None:
+    """Sync bookmarklet JS files from the given directory into Chrome."""
+    desired = _get_desired(dir_path)
+    diff = _compute_diff(desired, _get_chrome_bookmarklets())
+
+    if not diff.has_changes and not force:
+        _log.log(_terminal.OK, "%d bookmarklets in sync", len(desired))
+        return
+
+    if diff.has_changes:
+        _log_diff(diff)
+
+    script = _build_sync_script(desired)
+    if dry_run:
+        print(script)
+        return
+
+    _terminal.prompt_enter("Press Enter to copy sync script to clipboard (Ctrl+C to skip)...")
+    _clipboard.copy_to_clipboard(script)
+    _log.log(_terminal.OK, "sync script copied to clipboard")
+
+    if not no_open:
+        _log.info("opening chrome://bookmarks — paste into DevTools console (Cmd+Option+I)")
+        _browser.open_in_chrome("chrome://bookmarks")
+    else:
+        _log.info("paste clipboard into DevTools console on chrome://bookmarks (Cmd+Option+I)")
+
+    _terminal.prompt_done_or_recopy(lambda: _clipboard.copy_to_clipboard(script))
+    _log.log(_terminal.OK, "done")

--- a/src/python/browser_sync/browser_sync/main.py
+++ b/src/python/browser_sync/browser_sync/main.py
@@ -1,296 +1,85 @@
-"""Sync Chrome site search shortcuts via DevTools console paste.
+"""browser-sync: sync browser config via DevTools console paste.
 
-Generates JavaScript that uses Chrome's internal SearchEnginesBrowserProxy
-to add/remove shortcuts. Paste into DevTools console on chrome://settings/searchEngines.
+Subcommands:
+  shortcuts <toml>              Chrome site search shortcuts (SearchEnginesBrowserProxy).
+  vimium <toml> <keymappings>   Vimium search engines + key mappings (chrome.storage.sync).
+  bookmarklets <dir>            Bookmarklet JS files to Chrome bookmarks (chrome.bookmarks).
 
-Data source: a TOML file with Vimium search engine entries.
-Every entry becomes a Chrome shortcut: key "sg" -> keyword "@sg".
+Browser targeting: --chrome (default) and/or --firefox (not yet supported).
 """
 
 import argparse
-import json
 import logging
-import subprocess
-import sys
-import termios
-import time
-import tomllib
-import tty
-import typing
-from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from pydantic import BaseModel
+from browser_sync import _browser, _terminal, bookmarklets, shortcuts, vimium
 
-_CHROME_SETTINGS_URL = "chrome://settings/searchEngines"
-_OK = 25
-
-
-class _ColorFormatter(logging.Formatter):
-    """Terminal formatter with colored level badges and timestamps."""
-
-    _COLORS: typing.ClassVar[dict[int, str]] = {
-        logging.INFO: "\033[0;34m",
-        _OK: "\033[0;32m",
-        logging.WARNING: "\033[0;33m",
-        logging.ERROR: "\033[0;31m",
-    }
-    _LABELS: typing.ClassVar[dict[int, str]] = {
-        logging.INFO: "INFO",
-        _OK: "OK  ",
-        logging.WARNING: "WARN",
-        logging.ERROR: "ERR ",
-    }
-
-    def format(self, record: logging.LogRecord) -> str:
-        """Format log record with timestamp and colored badge."""
-        ts = time.strftime("%H:%M:%S")
-        color = self._COLORS.get(record.levelno, "\033[0m")
-        label = self._LABELS.get(record.levelno, record.levelname)
-        return f"\033[2m{ts}\033[0m {color}[{label}]\033[0m {record.getMessage()}"
-
-
-logging.addLevelName(_OK, "OK")
 _log = logging.getLogger(__name__)
 
 
-class _Shortcut(BaseModel, frozen=True):
-    """A browser site search shortcut."""
-
-    keyword: str
-    name: str
-    url: str
+def _add_browser_flags(parser: argparse.ArgumentParser) -> None:
+    """Add the shared --chrome/--firefox target flags to a subparser."""
+    parser.add_argument("--chrome", action="store_true", help="Target Google Chrome (default).")
+    parser.add_argument("--firefox", action="store_true", help="Target Firefox (not yet supported).")
 
 
-def _parse_toml(path: Path) -> Sequence[_Shortcut]:
-    """Parse search-engines.toml into Chrome shortcuts.
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser with one subparser per sync flow."""
+    parser = argparse.ArgumentParser(prog="browser-sync", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
 
-    Each entry's key becomes @key. Angle brackets in names are replaced
-    with parens to avoid crashing Chrome's Polymer renderer.
-    """
-    data = tomllib.loads(path.read_text())
-    return tuple(
-        _Shortcut(
-            keyword="@" + entry["key"],
-            name=(entry.get("description", "") or entry["key"]).replace("<", "(").replace(">", ")"),
-            url=entry["url"],
-        )
-        for group in data.get("engine", {}).values()
-        for entry in group.get("entries", [])
-    )
+    shortcuts_parser = sub.add_parser("shortcuts", help="Sync Chrome site search shortcuts.")
+    shortcuts_parser.add_argument("toml_path", type=Path, help="Path to search-engines.toml")
+    shortcuts_parser.add_argument("--prune", action="store_true", help="Show which shortcuts would be removed.")
+    shortcuts_parser.add_argument("--confirm", action="store_true", help="With --prune, actually execute removals.")
+    shortcuts_parser.add_argument("--dry-run", action="store_true", help="Print script without copying.")
+    shortcuts_parser.add_argument("--no-open", action="store_true", help="Don't open the browser.")
+    _add_browser_flags(shortcuts_parser)
 
+    vimium_parser = sub.add_parser("vimium", help="Sync Vimium search engines and key mappings.")
+    vimium_parser.add_argument("toml_path", type=Path, help="Path to search-engines.toml")
+    vimium_parser.add_argument("keymappings_path", type=Path, help="Path to key-mappings.txt")
+    vimium_parser.add_argument("--dry-run", action="store_true", help="Print script without copying.")
+    vimium_parser.add_argument("--no-open", action="store_true", help="Don't open the browser.")
+    _add_browser_flags(vimium_parser)
 
-def _build_sync_script(shortcuts: Sequence[_Shortcut], *, prune: bool = False, confirm: bool = False) -> str:
-    """Generate JS console script for Chrome search engine sync.
+    bookmarklets_parser = sub.add_parser("bookmarklets", help="Sync bookmarklet JS files to Chrome bookmarks.")
+    bookmarklets_parser.add_argument("dir_path", type=Path, help="Directory of *.js bookmarklet files")
+    bookmarklets_parser.add_argument("--force", action="store_true", help="Run even if source matches Chrome's state.")
+    bookmarklets_parser.add_argument("--dry-run", action="store_true", help="Print script without copying.")
+    bookmarklets_parser.add_argument("--no-open", action="store_true", help="Don't open the browser.")
+    _add_browser_flags(bookmarklets_parser)
 
-    Args:
-        shortcuts: Desired shortcuts to sync.
-        prune: If True, identify entries to remove.
-        confirm: If True (with prune), actually execute removals.
-    """
-    desired_json = json.dumps([s.model_dump() for s in shortcuts], indent=2)
-    prune_js = "true" if prune else "false"
-    confirm_js = "true" if confirm else "false"
-    return f"""\
-(async () => {{
-  const m = await import('chrome://settings/settings.js');
-  const proxy = m.SearchEnginesBrowserProxyImpl.getInstance();
-  const delay = ms => new Promise(r => setTimeout(r, ms));
-  const tag = (color, label, msg) =>
-    console.log(`%c${{label}}%c ${{msg}}`, `background:${{color}};color:#fff;padding:1px 6px;border-radius:3px;font-weight:600`, '');
-
-  const data = await proxy.getCategorizedTemplateUrls();
-  const active = data.activeSiteShortcuts.filter(e => e.canBeRemoved);
-  const currentByKeyword = new Map(active.map(e => [e.keyword, e]));
-  await delay(500);
-
-  const desired = {desired_json};
-  const desiredKeywords = new Set(desired.map(d => d.keyword));
-  const toChrome = url => url.replace(/%s/g, '{{searchTerms}}');
-  const toAdd = desired.filter(d => !currentByKeyword.has(d.keyword));
-  const prune = {prune_js};
-  const confirmRemoval = {confirm_js};
-  // Only prune @-prefixed keywords (managed by us), leave others alone
-  const toRemove = prune ? active.filter(e => e.keyword.startsWith('@') && !desiredKeywords.has(e.keyword)) : [];
-
-  if (!toAdd.length && !toRemove.length) {{
-    tag('#6b7280', 'SYNC', `already converged (${{currentByKeyword.size}} entries)`);
-    return;
-  }}
-
-  let added = 0, removed = 0, errors = [];
-
-  for (const d of toAdd) {{
-    try {{
-      proxy.searchEngineEditStarted(0);
-      proxy.searchEngineEditCompleted(d.name, d.keyword, toChrome(d.url));
-      added++;
-      tag('#3b82f6', '+ADD', d.keyword + ' \\u2192 ' + d.name);
-    }} catch (e) {{
-      errors.push('+' + d.keyword + ': ' + e.message);
-    }}
-    await delay(150);
-  }}
-
-  for (const e of toRemove) {{
-    if (!confirmRemoval) {{
-      tag('#f59e0b', 'WOULD-DEL', e.keyword + ' \\u2192 ' + e.name + ' (id=' + e.id + ')');
-      removed++;
-      continue;
-    }}
-    try {{
-      proxy.removeSearchEngine(e.id);
-      removed++;
-      tag('#f59e0b', '-DEL', e.keyword + ' \\u2192 ' + e.name);
-    }} catch (err) {{
-      errors.push('-' + e.keyword + ': ' + err.message);
-    }}
-    await delay(150);
-  }}
-
-  const parts = [];
-  if (added) parts.push(`+${{added}} added`);
-  if (removed && confirmRemoval) parts.push(`-${{removed}} removed`);
-  if (removed && !confirmRemoval) parts.push(`${{removed}} would be removed (run with --prune --confirm to apply)`);
-  parts.push(`${{currentByKeyword.size - (confirmRemoval ? removed : 0) + added}} total`);
-
-  if (errors.length) {{
-    tag('#ef4444', 'ERROR', parts.join(', ') + '\\n' + errors.join('\\n'));
-  }} else {{
-    tag('#22c55e', 'SYNC', parts.join(', '));
-  }}
-}})();"""
-
-
-def _getkey() -> str:
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        return sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-
-
-def _prompt_enter(message: str) -> None:
-    print(f"\n\033[0;36m[?]\033[0m    {message}", end="", flush=True)
-    while True:
-        ch = _getkey()
-        if ch in ("\r", "\n"):
-            print()
-            return
-        if ch == "\x03":
-            print()
-            _log.info("skipped")
-            sys.exit(0)
-
-
-def _prompt_done_or_recopy(copy_fn: Callable[[], None]) -> None:
-    print("\n\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
-    while True:
-        ch = _getkey()
-        if ch in ("\r", "\n"):
-            print()
-            return
-        if ch.lower() == "r":
-            copy_fn()
-            print()
-            _log.log(_OK, "recopied to clipboard")
-            print("\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
-        if ch == "\x03":
-            print()
-            _log.info("skipped")
-            sys.exit(0)
-
-
-def _prompt_prune_or_skip(copy_fn: Callable[[], None]) -> None:
-    print("\n\033[0;33m[!]\033[0m    Press 'p' to copy PRUNE script, or Enter to skip removals ", end="", flush=True)
-    while True:
-        ch = _getkey()
-        if ch in ("\r", "\n"):
-            print()
-            _log.info("skipped removals")
-            return
-        if ch.lower() == "p":
-            copy_fn()
-            print()
-            _log.log(_OK, "prune script copied — paste into console to remove extras")
-            _prompt_done_or_recopy(copy_fn)
-            return
-        if ch == "\x03":
-            print()
-            _log.info("skipped")
-            sys.exit(0)
-
-
-def _copy_to_clipboard(text: str) -> None:
-    subprocess.run(["pbcopy"], input=text.encode(), check=True)
+    return parser
 
 
 def main() -> None:
-    """Entry point for chrome-sync CLI."""
-    handler = logging.StreamHandler()
-    handler.setFormatter(_ColorFormatter())
-    logging.basicConfig(level=logging.INFO, handlers=[handler])
-
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("toml_path", type=Path, help="Path to search-engines.toml")
-    parser.add_argument("--dry-run", action="store_true", help="Print script without copying.")
-    parser.add_argument("--no-open", action="store_true", help="Don't open Chrome settings page.")
-    parser.add_argument("--prune", action="store_true", help="Show which shortcuts would be removed (dry-run).")
-    parser.add_argument("--confirm", action="store_true", help="With --prune, actually execute removals.")
+    """Entry point for the browser-sync CLI."""
+    _terminal.setup_logging()
+    parser = _build_parser()
     args = parser.parse_args()
 
-    if args.confirm and not args.prune:
+    if args.command == "shortcuts" and args.confirm and not args.prune:
         parser.error("--confirm requires --prune")
 
-    toml_path: Path = args.toml_path
-    if not toml_path.exists():
-        _log.error("TOML not found: %s", toml_path)
-        sys.exit(1)
-
-    shortcuts = _parse_toml(toml_path)
-    _log.info("%d shortcuts from %s", len(shortcuts), toml_path.name)
-
-    if args.dry_run:
-        script = _build_sync_script(shortcuts, prune=args.prune, confirm=args.confirm)
-        print(script)
+    targets = _browser.resolve_targets(chrome=args.chrome, firefox=args.firefox)
+    if _browser.Browser.FIREFOX in targets:
+        _log.warning("firefox sync not yet supported — skipping")
+    if _browser.Browser.CHROME not in targets:
         return
 
-    if args.prune and args.confirm:
-        add_script = _build_sync_script(shortcuts, prune=True, confirm=False)
-        prune_script = _build_sync_script(shortcuts, prune=True, confirm=True)
-
-        _prompt_enter("Press Enter to copy ADD + PREVIEW script (Ctrl+C to skip)...")
-        _copy_to_clipboard(add_script)
-        _log.log(_OK, "copied — adds new entries, previews removals (WOULD-DEL)")
-
-        if not args.no_open:
-            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
-            subprocess.run(["open", "-a", "Google Chrome", _CHROME_SETTINGS_URL], check=True)
-        else:
-            _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)
-
-        _prompt_done_or_recopy(lambda: _copy_to_clipboard(add_script))
-        _log.log(_OK, "adds applied — check WOULD-DEL entries in console")
-        _log.warning("next step removes entries not in TOML")
-        _prompt_prune_or_skip(lambda: _copy_to_clipboard(prune_script))
-    else:
-        script = _build_sync_script(shortcuts, prune=args.prune, confirm=args.confirm)
-
-        _prompt_enter("Press Enter to copy sync script to clipboard (Ctrl+C to skip)...")
-        _copy_to_clipboard(script)
-        _log.log(_OK, "sync script copied to clipboard")
-
-        if not args.no_open:
-            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
-            subprocess.run(["open", "-a", "Google Chrome", _CHROME_SETTINGS_URL], check=True)
-        else:
-            _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)
-
-        _prompt_done_or_recopy(lambda: _copy_to_clipboard(script))
-
-    _log.log(_OK, "done")
+    if args.command == "shortcuts":
+        shortcuts.run(
+            args.toml_path,
+            prune=args.prune,
+            confirm=args.confirm,
+            dry_run=args.dry_run,
+            no_open=args.no_open,
+        )
+    elif args.command == "vimium":
+        vimium.run(args.toml_path, args.keymappings_path, dry_run=args.dry_run, no_open=args.no_open)
+    elif args.command == "bookmarklets":
+        bookmarklets.run(args.dir_path, dry_run=args.dry_run, no_open=args.no_open, force=args.force)
 
 
 if __name__ == "__main__":

--- a/src/python/browser_sync/browser_sync/shortcuts.py
+++ b/src/python/browser_sync/browser_sync/shortcuts.py
@@ -1,0 +1,178 @@
+"""Sync Chrome site search shortcuts via DevTools console paste.
+
+Generates JavaScript that uses Chrome's internal SearchEnginesBrowserProxy
+to add/remove shortcuts. Paste into DevTools console on chrome://settings/searchEngines.
+
+Data source: a TOML file with Vimium search engine entries.
+Every entry becomes a Chrome shortcut: key "sg" -> keyword "@sg".
+"""
+
+import json
+import logging
+import sys
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from browser_sync import _browser, _clipboard, _devtools, _terminal
+
+_CHROME_SETTINGS_URL = "chrome://settings/searchEngines"
+_log = logging.getLogger(__name__)
+
+
+class _Shortcut(BaseModel, frozen=True):
+    """A browser site search shortcut."""
+
+    keyword: str
+    name: str
+    url: str
+
+
+def _parse_toml(path: Path) -> Sequence[_Shortcut]:
+    """Parse search-engines.toml into Chrome shortcuts.
+
+    Each entry's key becomes @key. Angle brackets in names are replaced
+    with parens to avoid crashing Chrome's Polymer renderer.
+    """
+    data = tomllib.loads(path.read_text())
+    return tuple(
+        _Shortcut(
+            keyword="@" + entry["key"],
+            name=(entry.get("description", "") or entry["key"]).replace("<", "(").replace(">", ")"),
+            url=entry["url"],
+        )
+        for group in data.get("engine", {}).values()
+        for entry in group.get("entries", [])
+    )
+
+
+def _build_sync_script(shortcuts: Sequence[_Shortcut], *, prune: bool = False, confirm: bool = False) -> str:
+    """Generate JS console script for Chrome search engine sync.
+
+    Args:
+        shortcuts: Desired shortcuts to sync.
+        prune: If True, identify entries to remove.
+        confirm: If True (with prune), actually execute removals.
+    """
+    desired_json = json.dumps([s.model_dump() for s in shortcuts], indent=2)
+    prune_js = "true" if prune else "false"
+    confirm_js = "true" if confirm else "false"
+    return f"""\
+(async () => {{
+  const m = await import('chrome://settings/settings.js');
+  const proxy = m.SearchEnginesBrowserProxyImpl.getInstance();
+  const delay = ms => new Promise(r => setTimeout(r, ms));
+  {_devtools.JS_TAG_HELPER}
+
+  const data = await proxy.getCategorizedTemplateUrls();
+  const active = data.activeSiteShortcuts.filter(e => e.canBeRemoved);
+  const currentByKeyword = new Map(active.map(e => [e.keyword, e]));
+  await delay(500);
+
+  const desired = {desired_json};
+  const desiredKeywords = new Set(desired.map(d => d.keyword));
+  const toChrome = url => url.replace(/%s/g, '{{searchTerms}}');
+  const toAdd = desired.filter(d => !currentByKeyword.has(d.keyword));
+  const prune = {prune_js};
+  const confirmRemoval = {confirm_js};
+  // Only prune @-prefixed keywords (managed by us), leave others alone
+  const toRemove = prune ? active.filter(e => e.keyword.startsWith('@') && !desiredKeywords.has(e.keyword)) : [];
+
+  if (!toAdd.length && !toRemove.length) {{
+    tag('#6b7280', 'SYNC', `already converged (${{currentByKeyword.size}} entries)`);
+    return;
+  }}
+
+  let added = 0, removed = 0, errors = [];
+
+  for (const d of toAdd) {{
+    try {{
+      proxy.searchEngineEditStarted(0);
+      proxy.searchEngineEditCompleted(d.name, d.keyword, toChrome(d.url));
+      added++;
+      tag('#3b82f6', '+ADD', d.keyword + ' \\u2192 ' + d.name);
+    }} catch (e) {{
+      errors.push('+' + d.keyword + ': ' + e.message);
+    }}
+    await delay(150);
+  }}
+
+  for (const e of toRemove) {{
+    if (!confirmRemoval) {{
+      tag('#f59e0b', 'WOULD-DEL', e.keyword + ' \\u2192 ' + e.name + ' (id=' + e.id + ')');
+      removed++;
+      continue;
+    }}
+    try {{
+      proxy.removeSearchEngine(e.id);
+      removed++;
+      tag('#f59e0b', '-DEL', e.keyword + ' \\u2192 ' + e.name);
+    }} catch (err) {{
+      errors.push('-' + e.keyword + ': ' + err.message);
+    }}
+    await delay(150);
+  }}
+
+  const parts = [];
+  if (added) parts.push(`+${{added}} added`);
+  if (removed && confirmRemoval) parts.push(`-${{removed}} removed`);
+  if (removed && !confirmRemoval) parts.push(`${{removed}} would be removed (run with --prune --confirm to apply)`);
+  parts.push(`${{currentByKeyword.size - (confirmRemoval ? removed : 0) + added}} total`);
+
+  if (errors.length) {{
+    tag('#ef4444', 'ERROR', parts.join(', ') + '\\n' + errors.join('\\n'));
+  }} else {{
+    tag('#22c55e', 'SYNC', parts.join(', '));
+  }}
+}})();"""
+
+
+def run(toml_path: Path, *, prune: bool, confirm: bool, dry_run: bool, no_open: bool) -> None:
+    """Sync Chrome site search shortcuts from the given TOML file."""
+    if not toml_path.exists():
+        _log.error("TOML not found: %s", toml_path)
+        sys.exit(1)
+
+    shortcuts = _parse_toml(toml_path)
+    _log.info("%d shortcuts from %s", len(shortcuts), toml_path.name)
+
+    if dry_run:
+        print(_build_sync_script(shortcuts, prune=prune, confirm=confirm))
+        return
+
+    if prune and confirm:
+        add_script = _build_sync_script(shortcuts, prune=True, confirm=False)
+        prune_script = _build_sync_script(shortcuts, prune=True, confirm=True)
+
+        _terminal.prompt_enter("Press Enter to copy ADD + PREVIEW script (Ctrl+C to skip)...")
+        _clipboard.copy_to_clipboard(add_script)
+        _log.log(_terminal.OK, "copied — adds new entries, previews removals (WOULD-DEL)")
+
+        if not no_open:
+            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
+            _browser.open_in_chrome(_CHROME_SETTINGS_URL)
+        else:
+            _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)
+
+        _terminal.prompt_done_or_recopy(lambda: _clipboard.copy_to_clipboard(add_script))
+        _log.log(_terminal.OK, "adds applied — check WOULD-DEL entries in console")
+        _log.warning("next step removes entries not in TOML")
+        _terminal.prompt_prune_or_skip(lambda: _clipboard.copy_to_clipboard(prune_script))
+    else:
+        script = _build_sync_script(shortcuts, prune=prune, confirm=confirm)
+
+        _terminal.prompt_enter("Press Enter to copy sync script to clipboard (Ctrl+C to skip)...")
+        _clipboard.copy_to_clipboard(script)
+        _log.log(_terminal.OK, "sync script copied to clipboard")
+
+        if not no_open:
+            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
+            _browser.open_in_chrome(_CHROME_SETTINGS_URL)
+        else:
+            _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)
+
+        _terminal.prompt_done_or_recopy(lambda: _clipboard.copy_to_clipboard(script))
+
+    _log.log(_terminal.OK, "done")

--- a/src/python/browser_sync/browser_sync/vimium.py
+++ b/src/python/browser_sync/browser_sync/vimium.py
@@ -1,0 +1,120 @@
+"""Sync Vimium config to Chrome via the chrome.storage.sync API.
+
+Compiles a search-engines TOML file plus a key-mappings text file into
+Vimium's storage format and generates a console script. Paste into the
+DevTools console on the Vimium options page (Cmd+Option+I).
+"""
+
+import json
+import logging
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from browser_sync import _browser, _clipboard, _devtools, _terminal
+
+_VIMIUM_OPTIONS_URL = "chrome-extension://dbepggeogbaibhgnhhndojpepiihcmeb/pages/options.html"
+_log = logging.getLogger(__name__)
+
+
+class _Engine(BaseModel, frozen=True):
+    """A single Vimium search engine entry."""
+
+    key: str
+    url: str
+    description: str = ""
+
+    def to_vimium_line(self) -> str:
+        """Render as a `key: url description` Vimium config line."""
+        suffix = f" {self.description}" if self.description else ""
+        return f"{self.key}: {self.url}{suffix}"
+
+
+class _EngineGroup(BaseModel, frozen=True):
+    """A commented group of Vimium search engine entries."""
+
+    comment: str
+    entries: tuple[_Engine, ...]
+
+    def to_vimium_lines(self) -> Sequence[str]:
+        """Render the group's comment header followed by its entry lines."""
+        return [f"# {self.comment}", *(e.to_vimium_line() for e in self.entries)]
+
+
+def _parse_toml(toml_path: Path) -> Sequence[_EngineGroup]:
+    """Parse search-engines.toml into engine groups."""
+    data = tomllib.loads(toml_path.read_text())
+    return tuple(
+        _EngineGroup(
+            comment=group["comment"],
+            entries=tuple(
+                _Engine(
+                    key=entry["key"],
+                    url=entry["url"],
+                    description=entry.get("description", ""),
+                )
+                for entry in group.get("entries", [])
+            ),
+        )
+        for group in data.get("engine", {}).values()
+    )
+
+
+def _compile_search_engines(groups: Sequence[_EngineGroup]) -> str:
+    """Join engine groups into Vimium's searchEngines text block."""
+    return "\n\n".join("\n".join(g.to_vimium_lines()) for g in groups)
+
+
+def _load_key_mappings(path: Path) -> str:
+    """Read non-comment, non-blank lines from the key-mappings file."""
+    return "\n".join(
+        stripped
+        for line in path.read_text().splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    )
+
+
+def _build_sync_script(search_engines: str, key_mappings: str) -> str:
+    """Generate the chrome.storage.sync console script."""
+    settings_json = json.dumps({"searchEngines": search_engines, "keyMappings": key_mappings}, indent=2)
+    return f"""\
+chrome.storage.sync.set({settings_json}, () => {{
+  {_devtools.JS_TAG_HELPER}
+  if (chrome.runtime.lastError) {{
+    tag('#ef4444', 'ERROR', chrome.runtime.lastError.message);
+  }} else {{
+    tag('#22c55e', 'VIMIUM', 'settings synced — reload options page to verify');
+  }}
+}});"""
+
+
+def run(toml_path: Path, keymappings_path: Path, *, dry_run: bool, no_open: bool) -> None:
+    """Sync Vimium search engines and key mappings from the given files."""
+    groups = _parse_toml(toml_path)
+    search_engines = _compile_search_engines(groups)
+    key_mappings = _load_key_mappings(keymappings_path)
+    script = _build_sync_script(search_engines, key_mappings)
+
+    if dry_run:
+        print("=== Compiled search engines ===")
+        print(search_engines)
+        print("\n=== Key mappings ===")
+        print(key_mappings)
+        print("\n=== Console script ===")
+        print(script)
+        return
+
+    _terminal.prompt_enter("Press Enter to copy sync script to clipboard (Ctrl+C to skip)...")
+    _clipboard.copy_to_clipboard(script)
+    _log.log(_terminal.OK, "Vimium sync script copied to clipboard")
+
+    if not no_open:
+        _log.info("opening Vimium options — paste into DevTools console (Cmd+Option+I)")
+        _browser.open_in_chrome(_VIMIUM_OPTIONS_URL)
+    else:
+        _log.info("paste clipboard into DevTools console on:\n  %s", _VIMIUM_OPTIONS_URL)
+
+    _terminal.prompt_done_or_recopy(lambda: _clipboard.copy_to_clipboard(script))
+    _log.log(_terminal.OK, "done")


### PR DESCRIPTION
absorbs the standalone overlay vimium/bookmarks sync scripts into one CLI.

- `browser-sync shortcuts <toml>` — chrome site search (was the whole tool)
- `browser-sync vimium <toml> <keymappings>` — vimium search engines + key mappings
- `browser-sync bookmarklets <dir>` — bookmarklet js to chrome bookmarks
- `--chrome` (default) / `--firefox` (warn-and-skip stub) target flags
- domain models (`_Shortcut`, `_Engine`, `_Bookmarklet`) stay in their modules; vimium dataclasses → pydantic, functional rewrites drop list.append patterns


Committed-By-Agent: claude