### PR TITLE
fix: use dig for git.personal in chezmoi templates

### DIFF
--- a/src/chezmoi/dot_config/ghostty/AGENTS.md
+++ b/src/chezmoi/dot_config/ghostty/AGENTS.md
@@ -15,4 +15,4 @@
   font-family = "DejaVu Sans Mono"
   {{- end }}
   ```
-- **Profiles**: Profile-specific settings (e.g., window titles) are rendered based on `.git.personal.enabled`.
+- **Profiles**: Profile-specific settings (e.g., window titles) are rendered based on `dig "git" "personal" "enabled" false .`.

--- a/src/chezmoi/dot_dotfiles/git/config.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/config.tmpl
@@ -34,7 +34,7 @@
 # Personal configuration — unconditional on the base layer so fresh `git init`
 # repos (no remote yet, any directory) still get user.name/email/signing.
 # Overlays restrict by defining [git.personal.scopes] in chezmoi data.
-{{- if .git.personal.enabled }}
+{{- if dig "git" "personal" "enabled" false . }}
 {{-   $scopes := dig "git" "personal" "scopes" (dict) . }}
 {{-   if $scopes }}
 {{-     range $name, $path := $scopes }}

--- a/src/chezmoi/dot_dotfiles/git/snippets/personal.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/personal.gitconfig.tmpl
@@ -1,18 +1,18 @@
-{{- with .git.personal }}
-{{- if .enabled }}
-{{- if not (and .name .email) }}
+{{- $personal := dig "git" "personal" (dict) . }}
+{{- if dig "enabled" false $personal }}
+{{- if not (and $personal.name $personal.email) }}
 {{- fail "git.personal.enabled is true but name or email is empty" }}
 {{- end }}
 
 [user]
-  name = {{ .name | quote }}
-  email = {{ .email | quote }}
-{{- if .signing_key }}
-  signingkey = {{ .signing_key }}
+  name = {{ $personal.name | quote }}
+  email = {{ $personal.email | quote }}
+{{- if $personal.signing_key }}
+  signingkey = {{ $personal.signing_key }}
 {{- end }}
 
 [commit]
-{{- if .signing_key }}
+{{- if $personal.signing_key }}
   gpgsign = true
 {{- else }}
   gpgsign = false
@@ -20,5 +20,4 @@
 
 [gpg]
   program = gpg
-{{- end }}
 {{- end }}

--- a/src/chezmoi/dot_dotfiles/git/snippets/user.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/user.gitconfig.tmpl
@@ -1,8 +1,8 @@
 [user]
   # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-username
-  name = {{ .git.personal.name | quote }}
+  name = {{ dig "git" "personal" "name" "" . | quote }}
   # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-useremail
-  email = {{ .git.personal.email | quote }}
+  email = {{ dig "git" "personal" "email" "" . | quote }}
   # Documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
-  signingkey = {{ .git.personal.signing_key }}
+  signingkey = {{ dig "git" "personal" "signing_key" "" . }}
 


### PR DESCRIPTION
In `.chezmoi.toml.tmpl`, `[data.git.personal]` is only conditionally defined.
If the underlying `git.toml` does not define `[git.personal]` or it is omitted, evaluating `.git.personal.enabled` will crash chezmoi with:
`map has no entry for key "enabled"` or `"git"`.

This commit replaces direct struct dot-accesses for `.git.personal.*` with `dig` lookups (e.g., `dig "git" "personal" "enabled" false .`), which safely provides a default value instead of failing template execution.

---
*PR created automatically by Jules for task [16010972756921225314](https://jules.google.com/task/16010972756921225314) started by @mkobit*