### PR TITLE
fix(claude): use \u001b[13;2u for shift+enter in Windows Terminal, VS Code, and Ghostty

### DIFF
--- a/src/chezmoi/.chezmoidata/vscode.toml
+++ b/src/chezmoi/.chezmoidata/vscode.toml
@@ -5,4 +5,4 @@
 key = "shift+enter"
 command = "workbench.action.terminal.sendSequence"
 when = "terminalFocus"
-args = { text = "\u001b\r" }
+args = { text = "\u001b[13;2u" }

--- a/src/chezmoi/dot_config/ghostty/conf.d/claude-ide-shift-enter.conf
+++ b/src/chezmoi/dot_config/ghostty/conf.d/claude-ide-shift-enter.conf
@@ -1,2 +1,2 @@
 # Workaround for https://github.com/anthropics/claude-code/issues/1282
-keybind = shift+enter=text:\x1b\r
+keybind = shift+enter=text:\x1b[13;2u

--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -72,7 +72,7 @@ if (!\$actionExists) {
     \$newAction = [PSCustomObject]@{
         command = [PSCustomObject]@{
             action = 'sendInput'
-            input = '\u001b\r'
+            input = '\u001b[13;2u'
         }
         id = \$targetActionId
         keys = 'shift+enter'


### PR DESCRIPTION
This PR updates the `shift+enter` sequence across Windows Terminal, VS Code, and Ghostty configurations to explicitly use the CSI u sequence `\u001b[13;2u` instead of the old soft newline sequence (`\u001b\r` / `\x1b\r`). 

This ensures multi-line inputs work correctly in Claude Code, as described in the issue https://github.com/anthropics/claude-code/issues/1282.

---
*PR created automatically by Jules for task [15828788272027646295](https://jules.google.com/task/15828788272027646295) started by @mkobit*