### PR TITLE
Add session-reset guideline to shared AI agent guidelines

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/guidelines.toml
+++ b/src/chezmoi/.chezmoidata/ai/guidelines.toml
@@ -23,3 +23,9 @@ content = """
 content = """
 ## Tools
 - `fd` over `find`; `rg` over `grep`."""
+
+[[ai.guidelines.sections]]
+content = """
+## Session resets
+- At a clear stopping point before starting unrelated work, ask whether to reset the session and restart.
+- Give the continuation prompt in a fenced code block (tagged `markdown` or `md`) so it can be copied in one action."""


### PR DESCRIPTION
## Summary
- Adds a "Session resets" section to `.chezmoidata/ai/guidelines.toml`, shared across `dot_claude/CLAUDE.md.tmpl` and `dot_codex/AGENTS.md.tmpl`.
- Advises agents to propose a session reset with a copyable continuation prompt at clear stopping points, to reduce token spend and quality degradation in long-running conversations.
- Kept tool-agnostic (no hardcoded `/clear`) since this file renders verbatim into multiple tools' context files with no per-tool conditional.

## Test plan
- [x] `chezmoi execute-template < src/chezmoi/dot_claude/CLAUDE.md.tmpl` renders the new section correctly
- [x] `chezmoi execute-template < src/chezmoi/dot_codex/AGENTS.md.tmpl` renders the new section correctly
- [ ] CI green
- [ ] `chezmoi apply` after merge