### PR TITLE
fix: run chezmoi init before apply in env_setup.sh

### DIFF
--- a/.jules/env_setup.sh
+++ b/.jules/env_setup.sh
@@ -25,6 +25,9 @@ else
 fi
 
 CHEZMOI_SOURCE="$(pwd)"
+GOMAXPROCS=1 chezmoi init \
+    --source="${CHEZMOI_SOURCE}" --destination="${HOME}" --no-tty
+
 GOMAXPROCS=1 chezmoi apply \
     --source="${CHEZMOI_SOURCE}" --destination="${HOME}" --no-tty \
     --exclude=remove


### PR DESCRIPTION
Added a step in `env_setup.sh` to run `chezmoi init` before `chezmoi apply` because config file template evaluation only works during init and is required to properly evaluate properties based on OS logic and dotfiles settings.

---
*PR created automatically by Jules for task [18019997492234397209](https://jules.google.com/task/18019997492234397209) started by @mkobit*