### PR TITLE
fix(windows-terminal): fix shift+enter for real on WSL (ESC+CR, not CSI-u)

### DIFF
--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -59,12 +59,22 @@ if (!\$settings.actions) {
 }
 
 \$targetActionId = 'User.sendInput.shiftEnter'
-# Built via [char]27 rather than a backslash-escape literal: this whole
-# command is embedded in a bash double-quoted heredoc, which silently
-# drops one level of backslash escaping before powershell.exe ever sees
-# it. That is the root cause behind the shift+enter fixes in #586, #616,
-# and #686 never actually sticking.
-\$shiftEnterInput = [char]27 + '[13;2u'
+# Built via [char]27 + [char]13 rather than a backslash- or backtick-escape
+# literal: this whole command is embedded in a bash double-quoted heredoc,
+# which silently drops one level of backslash escaping (and would treat a
+# literal backtick as command substitution) before powershell.exe ever sees
+# it. That is the root cause behind the shift+enter fixes in #586, #616, and
+# #686 never actually sticking -- every prior attempt sent literal escaped
+# text, never a real escape byte.
+#
+# ESC+CR, not the CSI-u form (ESC [ 13 ; 2 u): Windows Terminal does not
+# distinguish Shift+Enter from Enter at the raw pty level under WSL (both
+# send a bare CR by default), and once the CSI-u form was actually sent
+# correctly, Claude Code treated it as a plain Enter (submit) rather than a
+# newline. ESC+CR (the classic meta+enter convention) is what Claude Code
+# under WSL actually recognizes as insert-newline; confirmed empirically
+# 2026-07-03.
+\$shiftEnterInput = [char]27 + [char]13
 \$existingAction = \$null
 foreach (\$action in \$settings.actions) {
     if (\$action.id -eq \$targetActionId) {

--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 # Font face: {{ .windows_terminal.font_face }}, size: {{ .windows_terminal.font_size }}
-# Version: 3
 
 main() {
     local WIN_LOCALAPPDATA
@@ -60,19 +59,30 @@ if (!\$settings.actions) {
 }
 
 \$targetActionId = 'User.sendInput.shiftEnter'
-\$actionExists = \$false
+# Built via [char]27 rather than a backslash-escape literal: this whole
+# command is embedded in a bash double-quoted heredoc, which silently
+# drops one level of backslash escaping before powershell.exe ever sees
+# it. That is the root cause behind the shift+enter fixes in #586, #616,
+# and #686 never actually sticking.
+\$shiftEnterInput = [char]27 + '[13;2u'
+\$existingAction = \$null
 foreach (\$action in \$settings.actions) {
     if (\$action.id -eq \$targetActionId) {
-        \$actionExists = \$true
+        \$existingAction = \$action
         break
     }
 }
 
-if (!\$actionExists) {
+if (\$existingAction) {
+    if (\$existingAction.command.input -ne \$shiftEnterInput) {
+        \$existingAction.command.input = \$shiftEnterInput
+        \$modified = \$true
+    }
+} else {
     \$newAction = [PSCustomObject]@{
         command = [PSCustomObject]@{
             action = 'sendInput'
-            input = '\u001b[13;2u'
+            input = \$shiftEnterInput
         }
         id = \$targetActionId
         keys = 'shift+enter'
@@ -88,9 +98,6 @@ if (!\$actionExists) {
 
 if (\$modified) {
     \$json = \$settings | ConvertTo-Json -Depth 20
-    # ConvertTo-Json will escape our backslash, creating '\\u001b' in the file.
-    # We replace it back to a single backslash so WT parses it as an escape character.
-    \$json = \$json.Replace('\\u001b', '\u001b')
     [System.IO.File]::WriteAllText(\$settingsPath, \$json, [System.Text.UTF8Encoding]::new(\$false))
     Write-Host \"Successfully updated Windows Terminal settings at \$settingsPath\"
 } else {


### PR DESCRIPTION
## Summary
- The Windows Terminal shift+enter fixup runs inside a bash double-quoted heredoc, which silently drops one level of backslash escaping before `powershell.exe` ever sees the command. That made the `Replace()` cleanup call a no-op, so `settings.json` kept double-escaped literal text instead of a real ESC byte -- **every attempt across #586, #616, and #686 sent literal escaped text, never an actual escape sequence.**
- Fixed by building the input from PowerShell `[char]` codes (`[char]27`, `[char]13`) instead of string literals, sidestepping the backslash/backtick round-trip entirely.
- Also fixed: the script only wrote the action when missing entirely, so an existing (broken) entry from a prior run would never self-correct. Now it updates `input` in place when it doesn't match.
- Dropped the unused `# Version: N` comment -- not a repo-wide convention and unnecessary since `run_onchange_` already reruns on any change to rendered content.
- **Once a real escape byte was actually being sent for the first time**, live testing on the WSL + Windows Terminal setup showed:
  - Windows Terminal does not distinguish Shift+Enter from Enter at the raw pty level under WSL -- both send a bare `CR` by default, confirmed via raw byte capture. The custom keybinding is required, not redundant with terminal-native handling.
  - The CSI-u form (`ESC [ 13 ; 2 u`), once actually delivered correctly, was treated by Claude Code as a plain Enter (submit), not a newline.
  - `ESC+CR` (the classic meta+enter convention) is what Claude Code under WSL actually recognizes as insert-newline. Confirmed working live.

## Test plan
- [x] Extracted the rendered PowerShell logic and ran it against a scratch copy of the real `settings.json` -- confirmed correct byte-level output for both the CSI-u and ESC+CR variants.
- [x] Ran it a second time -- confirmed idempotent.
- [x] `shellcheck` clean on the rendered bash script; `bash -n` syntax check passes.
- [x] Applied via `chezmoi apply` on the live machine.
- [x] Confirmed in a live Claude Code session inside WSL + Windows Terminal: Shift+Enter now inserts a newline instead of submitting or typing literal escape text.
