### PR TITLE
chore: add .claude/settings.local.json to global gitignore

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -12,3 +12,4 @@ mise.local.toml
 .agy
 __pycache__/
 *.py[cod]
+.claude/settings.local.json


### PR DESCRIPTION
This ensures local Claude Code settings files are explicitly ignored globally, preventing accidental commits across all repositories configured with these dotfiles.

---
*PR created automatically by Jules for task [674291343392155003](https://jules.google.com/task/674291343392155003) started by @mkobit*