### PR TITLE
fix(ci): scope AppArmor userns exemption to bwrap instead of runner-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,13 +104,26 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      - name: Allow unprivileged user namespaces (bwrap)
+      - name: Load scoped AppArmor profile for bwrap
         if: runner.os == 'Linux'
-        # Ubuntu 24.04's AppArmor default blocks unprivileged CLONE_NEWUSER,
-        # which bwrap requires for rootless sandboxing -- without this,
-        # sandboxr's bwrap-backed integration tests fail with "setting up
-        # uid map: Permission denied" / "loopback: Failed RTM_NEWADDR".
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        # Ubuntu 24.04's AppArmor default blocks unprivileged CLONE_NEWUSER
+        # for otherwise-unconfined processes, which bwrap needs for rootless
+        # sandboxing -- without this, sandboxr's bwrap-backed integration
+        # tests fail with "setting up uid map: Permission denied" /
+        # "loopback: Failed RTM_NEWADDR". A profile scoped to /usr/bin/bwrap
+        # that grants it `userns,` exempts only that binary; every other
+        # process on the runner keeps the restriction, unlike flipping
+        # kernel.apparmor_restrict_unprivileged_userns off runner-wide.
+        # Ref: https://discourse.ubuntu.com/t/spec-unprivileged-user-namespace-restrictions-via-apparmor-in-ubuntu-23-10/37626
+        run: |
+          cat <<'PROFILE' | sudo tee /etc/apparmor.d/bwrap >/dev/null
+          abi <abi/4.0>,
+
+          /usr/bin/bwrap flags=(unconfined) {
+            allow userns create,
+          }
+          PROFILE
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap
 
       - name: Cache chezmoi downloads
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9


### PR DESCRIPTION
## Summary
- Ubuntu 24.04's AppArmor default blocks unprivileged `CLONE_NEWUSER` for otherwise-unconfined processes, which `bwrap` needs for rootless sandboxing.
- The previous fix (merged in #695) disabled the restriction runner-wide via `kernel.apparmor_restrict_unprivileged_userns=0`. This replaces it with an AppArmor profile scoped to `/usr/bin/bwrap` that grants only that binary `userns,` — every other process on the runner keeps the restriction.
- Mechanism confirmed against [Ubuntu's own design spec](https://discourse.ubuntu.com/t/spec-unprivileged-user-namespace-restrictions-via-apparmor-in-ubuntu-23-10/37626) and corroborated by two independent real-world reports ([chainguard-dev/melange#1508](https://github.com/chainguard-dev/melange/issues/1508), [anthropic-experimental/sandbox-runtime#74](https://github.com/anthropic-experimental/sandbox-runtime/issues/74)).

## Test plan
- [ ] `integration` CI job (both `bwrap` and `srt` backends) passes on `ubuntu-24.04` with this profile in place instead of the sysctl toggle
- [ ] `sandboxr doctor` output in the CI log shows the same probe results as before (no regression)

Can't validate locally: WSL2's kernel has no AppArmor LSM at all, so a real GH Actions `ubuntu-24.04` run is the only way to exercise this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)