### PR TITLE
feat(sandboxr): add opt-in --timeout to bound sandboxed invocations

### DIFF
--- a/src/python/sandboxr/sandboxr/cli/_common.py
+++ b/src/python/sandboxr/sandboxr/cli/_common.py
@@ -5,6 +5,7 @@ import shutil
 import stat
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 import typer
@@ -35,6 +36,20 @@ def _refuse_if_nested() -> None:
 def _require_bwrap() -> None:
     if shutil.which("bwrap") is None:
         raise _fail("bwrap not found; install via the run_once_install-sandbox-deps chezmoi script")
+
+
+def _apply_timeout(args: Sequence[str], timeout_seconds: float | None) -> list[str]:
+    """Prefix `args` with `timeout --foreground` so a hang exits fast (124), not forever.
+
+    `--foreground` lets signals (Ctrl-C, terminal job control) reach the
+    wrapped process directly, matching execvp's usual signal behavior.
+    """
+    if timeout_seconds is None:
+        return list(args)
+    timeout_bin = shutil.which("timeout")
+    if timeout_bin is None:
+        raise _fail("timeout not found; required for timeout_seconds (provided by coreutils)")
+    return [timeout_bin, "--foreground", str(timeout_seconds), *args]
 
 
 def _require_srt() -> None:

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -8,6 +8,7 @@ import typer
 from sandboxr.backend.bwrap import BwrapBackend, default_mask_paths
 from sandboxr.backend.srt import SrtBackend
 from sandboxr.cli._common import (
+    _apply_timeout,
     _fail,
     _refuse_if_nested,
     _require_bwrap,
@@ -67,9 +68,15 @@ def run(
         list[str] | None,
         typer.Option("--rw", help="Bind path read-write (repeatable)."),
     ] = None,
+    timeout: Annotated[
+        float | None,
+        typer.Option("--timeout", help="Kill the sandboxed invocation after N seconds (exit 124)."),
+    ] = None,
 ) -> None:
     """Run a command in the sandbox: sandboxr run [FLAGS] -- COMMAND [ARGS...]"""
     _refuse_if_nested()
+    if timeout is not None and timeout <= 0:
+        raise _fail("--timeout must be positive")
     command = [arg for arg in ctx.args if arg != "--"]
     if not command:
         raise _fail("no command given; usage: sandboxr run [FLAGS] -- COMMAND [ARGS...]")
@@ -83,6 +90,7 @@ def run(
         gpg_agent=gpg_agent,
         extra_ro=extra_ro or [],
         extra_rw=extra_rw or [],
+        timeout_seconds=timeout,
     )
     if isinstance(backend, BwrapBackend):
         _require_bwrap()
@@ -92,10 +100,13 @@ def run(
     adapted_cmd, tool_env = adapt_command(command, os.environ)
     if tool_env:
         spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **tool_env})
-    args = [
-        *backend.build_args(spec, os.environ, default_mask_paths(os.getuid())),
-        *backend.wrap_command(adapted_cmd),
-    ]
+    args = _apply_timeout(
+        [
+            *backend.build_args(spec, os.environ, default_mask_paths(os.getuid())),
+            *backend.wrap_command(adapted_cmd),
+        ],
+        active.timeout_seconds,
+    )
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -6,6 +6,8 @@ import typer
 
 from sandboxr.backend.bwrap import BwrapBackend, default_mask_paths
 from sandboxr.cli._common import (
+    _apply_timeout,
+    _fail,
     _refuse_if_nested,
     _require_bwrap,
     _resolve,
@@ -57,6 +59,10 @@ def shell(
         list[str] | None,
         typer.Option("--rw", help="Bind path read-write (repeatable)."),
     ] = None,
+    timeout: Annotated[
+        float | None,
+        typer.Option("--timeout", help="Kill the sandboxed invocation after N seconds (exit 124)."),
+    ] = None,
 ) -> None:
     """Drop into a sandboxed interactive shell.
 
@@ -69,6 +75,8 @@ def shell(
       sandboxr shell --ro ~/.npmrc             # expose ~/.npmrc read-only
     """
     _refuse_if_nested()
+    if timeout is not None and timeout <= 0:
+        raise _fail("--timeout must be positive")
     shell_cmd = os.environ.get("SHELL", "/bin/bash")
     cwd = Path.cwd()
     _, active, backend = _resolve(profile, cwd)
@@ -80,11 +88,15 @@ def shell(
         gpg_agent=gpg_agent,
         extra_ro=extra_ro or [],
         extra_rw=extra_rw or [],
+        timeout_seconds=timeout,
     )
     if isinstance(backend, BwrapBackend):
         _require_bwrap()
     spec = _sandbox_spec(active, cwd, tty=tty)
-    args = [*backend.build_args(spec, os.environ, default_mask_paths(os.getuid())), shell_cmd]
+    args = _apply_timeout(
+        [*backend.build_args(spec, os.environ, default_mask_paths(os.getuid())), shell_cmd],
+        active.timeout_seconds,
+    )
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/sandboxr/profile/loader.py
+++ b/src/python/sandboxr/sandboxr/profile/loader.py
@@ -63,6 +63,7 @@ def merge_cli_overrides(
     extra_ro: Sequence[str] = (),
     extra_rw: Sequence[str] = (),
     allowed_domains: Sequence[str] = (),
+    timeout_seconds: float | None = None,
 ) -> Profile:
     """Return a new Profile with CLI flag values applied on top of the base profile.
 
@@ -76,6 +77,7 @@ def merge_cli_overrides(
             "network": network,
             "ssh_agent": ssh_agent,
             "gpg_agent": gpg_agent,
+            "timeout_seconds": timeout_seconds,
         }.items()
         if v is not None
     }

--- a/src/python/sandboxr/sandboxr/profile/schema.py
+++ b/src/python/sandboxr/sandboxr/profile/schema.py
@@ -33,6 +33,10 @@ class Profile(BaseModel):
     # Domain allowlist for network="allowlist" (srt backend only). Required
     # non-empty when network="allowlist"; must be empty otherwise.
     allowed_domains: tuple[str, ...] = Field(default=())
+    # Wall-clock bound on the whole sandboxed invocation (outer bwrap/srt
+    # process included). None = unbounded. Turns a silent hang into a fast,
+    # visible exit-124 instead of leaving it to the caller to notice.
+    timeout_seconds: float | None = Field(default=None, gt=0)
 
     @model_validator(mode="after")
     def _check_allowed_domains(self) -> Profile:

--- a/src/python/sandboxr/tests/cli/test_common.py
+++ b/src/python/sandboxr/tests/cli/test_common.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
-from sandboxr.cli._common import _require_srt
+from sandboxr.cli._common import _apply_timeout, _require_srt
 
 
 def _which(*, node_ok: bool, mise_ok: bool):
@@ -63,3 +63,21 @@ def test_require_srt_passes_when_resolved(tmp_path: Path) -> None:
         patch("sandboxr.backend.srt.subprocess.run", side_effect=_run),
     ):
         _require_srt()
+
+
+def test_apply_timeout_none_returns_args_unchanged() -> None:
+    assert _apply_timeout(["bwrap", "--foo"], None) == ["bwrap", "--foo"]
+
+
+def test_apply_timeout_prefixes_with_foreground_flag() -> None:
+    with patch("shutil.which", return_value="/usr/bin/timeout"):
+        result = _apply_timeout(["bwrap", "--foo"], 300)
+    assert result == ["/usr/bin/timeout", "--foreground", "300", "bwrap", "--foo"]
+
+
+def test_apply_timeout_raises_when_binary_missing() -> None:
+    with (
+        patch("shutil.which", return_value=None),
+        pytest.raises(typer.Exit),
+    ):
+        _apply_timeout(["bwrap", "--foo"], 300)

--- a/src/python/sandboxr/tests/profile/test_loader.py
+++ b/src/python/sandboxr/tests/profile/test_loader.py
@@ -130,3 +130,15 @@ def test_merge_none_values_not_applied(config: SandboxConfig) -> None:
     result = merge_cli_overrides(profile, project_write=None, network=None)
     assert result.project_write == profile.project_write
     assert result.network == profile.network
+
+
+def test_merge_timeout_seconds_override(config: SandboxConfig) -> None:
+    profile = config.profiles["autonomous"]
+    result = merge_cli_overrides(profile, timeout_seconds=300)
+    assert result.timeout_seconds == 300
+
+
+def test_merge_timeout_seconds_none_not_applied(config: SandboxConfig) -> None:
+    profile = config.profiles["autonomous"]
+    result = merge_cli_overrides(profile, timeout_seconds=None)
+    assert result.timeout_seconds == profile.timeout_seconds

--- a/src/python/sandboxr/tests/profile/test_schema.py
+++ b/src/python/sandboxr/tests/profile/test_schema.py
@@ -138,6 +138,22 @@ def test_profile_allowlist_with_domains_is_valid():
     assert p.allowed_domains == ("api.example.com",)
 
 
+def test_profile_timeout_seconds_defaults_none():
+    p = Profile(name="test", backend="auto", project_write=True, network="shared")
+    assert p.timeout_seconds is None
+
+
+def test_profile_timeout_seconds_rejects_non_positive():
+    with pytest.raises(ValidationError, match="timeout_seconds"):
+        Profile(
+            name="test",
+            backend="auto",
+            project_write=True,
+            network="shared",
+            timeout_seconds=0,
+        )
+
+
 @pytest.fixture
 def config(tmp_path):
     return load_config(write_config(tmp_path, BASE_TOML))


### PR DESCRIPTION
## Summary
- A `srt-claude` session hung silently for 78 minutes once last session (confirmed via `ps -eo etimes`), likely `.claude.json` lock contention with other concurrently-running host `claude` sessions (this machine typically has several running), compounded by the sandboxed process being forced onto a slower non-atomic write path inside the sandbox. Not reproduced since (4/4 clean retries with zero code changes).
- Doesn't fix the underlying contention — that would need the isolated `.claude.json` copy design, which turned out to need much more architectural work than expected (srt's settings schema has no writable path-remap primitive, only deny/mask, and mask is hardcoded read-only for secret substitution — confirmed by reading the installed package's type definitions). Deferred to a future session.
- Adds an opt-in `--timeout N` flag (`sandboxr run`/`sandboxr shell`) and a matching `timeout_seconds` profile field, so a future stall exits fast and visibly (exit 124) instead of hanging silently and unbounded. No profile sets a default yet.
- Implementation: prefixes the whole outer bwrap/srt invocation with `timeout --foreground N` (not a hand-rolled process-group/signal-forwarding wrapper) — `--foreground` keeps Ctrl-C/job-control signals reaching the wrapped process directly, matching the existing `os.execvp` signal behavior.

## Test plan
- [x] `uv run pytest src/python/sandboxr` — 136 passed (new tests: schema validation, CLI-override merge, `_apply_timeout` helper)
- [x] `uv run ruff check` / `ruff format --check` / `ty check` — clean
- [x] Live-verified against the real srt-claude profile (not just unit tests): `sandboxr run --profile srt-claude --timeout 2 -- sleep 30` killed at ~2.2s with exit 124; `sandboxr run --profile srt-claude -- echo ok` still exits 0 normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)