### PR TITLE
fix(sandboxr): close unrestricted-egress gap on the default autonomous profile

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/sandbox.toml
+++ b/src/chezmoi/.chezmoidata/ai/sandbox.toml
@@ -17,12 +17,18 @@ default_profile = "autonomous"
 
 [ai.sandbox.profiles.autonomous]
 enabled = true
-# "auto" = bwrap on linux, sandbox-exec on darwin.
-backend = "auto"
+# srt (not "auto"): unrestricted ("shared") egress let an autonomous, hours-
+# long unsupervised run exfiltrate anything through the harness's own
+# session credential -- domain-allowlisted egress is required for the
+# default profile, not just the purpose-built srt-claude one. Domain list
+# is Claude Code's, copied from the already-verified srt-claude profile
+# below -- this profile is Claude-Code-specific until a second harness is
+# actually run through sandboxr and gets its own verified list.
+backend = "srt"
 # Project worktree mounted read-write.
 project_write = true
-# Network shared with host so the agent can reach model APIs and ollama.
-network = "shared"
+network = "allowlist"
+allowed_domains = ["api.anthropic.com", "statsig.anthropic.com", "sentry.io"]
 # No agent socket forwarding by default; enable ad-hoc with --ssh-agent.
 ssh_agent = false
 gpg_agent = false

--- a/tests/integration/test_sandboxr.py
+++ b/tests/integration/test_sandboxr.py
@@ -24,7 +24,9 @@ def test_sandboxr_on_path(host):
 def test_doctor_bwrap_profile_passes(host):
     if not _tool_available(host, "bwrap"):
         pytest.skip("bwrap not installed on this runner")
-    result = host.run("sandboxr doctor --profile autonomous")
+    # readonly, not autonomous: autonomous moved to the srt backend
+    # (domain-allowlisted egress) so it no longer exercises bwrap.
+    result = host.run("sandboxr doctor --profile readonly")
     assert result.rc == 0, f"doctor failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
     assert "sandboxr doctor: all probes passed" in result.stdout
     assert "FAIL:" not in result.stdout


### PR DESCRIPTION
## Summary
- `autonomous` (the default sandboxr profile) moves from bwrap with `network="shared"` (unrestricted egress) to srt with `network="allowlist"`, using the same domain list already live-verified for `srt-claude` (`api.anthropic.com`, `statsig.anthropic.com`, `sentry.io`).
- Closes a real gap: an hours-long unsupervised autonomous run could previously exfiltrate anything through the harness's own session credential, since egress was unrestricted.
- Repoints the CI bwrap-coverage test (`test_doctor_bwrap_profile_passes`) from `autonomous` to `readonly`, since `autonomous` no longer exercises the bwrap backend.
- Scoped intentionally minimal: no new harness-manifest abstraction, no schema changes — just the profile data + the CI test fix it requires. A broader first-principles design spec was explored this session but is not part of this change.

## Test plan
- [x] `sandboxr doctor` (default `autonomous` profile) — all 12 probes pass live, including allowed-domain-reachable / denied-domain-blocked
- [x] `sandboxr doctor --profile readonly` — still passes live under bwrap
- [x] `uv run pytest src/python/sandboxr` — 136 passed
- [x] `uv run ruff check` on changed files — clean
- [ ] CI integration job (bwrap + srt live probes on ubuntu-24.04 runner)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>