### PR TITLE
fix(skill-filter): use typing.Callable for Python < 3.9 compatibility

### DIFF
--- a/src/python/skill_filter/skill_filter/main.py
+++ b/src/python/skill_filter/skill_filter/main.py
@@ -40,8 +40,8 @@ import os
 import posixpath
 import sys
 import tarfile
-from collections.abc import Callable, Iterable, Sequence
-from typing import BinaryIO, NamedTuple, Optional
+from collections.abc import Iterable, Sequence
+from typing import BinaryIO, Callable, NamedTuple, Optional
 
 
 class Selection(NamedTuple):


### PR DESCRIPTION
collections.abc.Callable is not subscriptable at runtime before Python 3.9. The Transform = Callable[[str, bytes], bytes] line is a runtime assignment, so from __future__ import annotations does not defer it. Moves Callable to typing where it is subscriptable on all Python 3.x versions.


Committed-By-Agent: claude