### PR TITLE
Disable largePasteWarning in Windows Terminal settings

### DIFF
--- a/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
+++ b/src/chezmoi/run_onchange_after_windows_terminal_settings.sh.tmpl
@@ -53,6 +53,12 @@ if (\$settings.profiles.defaults.font.size -ne {{ .windows_terminal.font_size }}
     \$modified = \$true
 }
 
+# Update Paste Warning settings
+if (\$null -eq \$settings.largePasteWarning -or \$settings.largePasteWarning -ne \$false) {
+    \$settings | Add-Member -NotePropertyName largePasteWarning -NotePropertyValue \$false -Force
+    \$modified = \$true
+}
+
 # Update Actions for Claude Code (Shift+Enter mapping)
 if (!\$settings.actions) {
     \$settings | Add-Member -NotePropertyName actions -NotePropertyValue @() -Force


### PR DESCRIPTION
Resolves an issue where pasting more than 5kb of text into the terminal in WSL prompts a warning message. This change updates the Windows Terminal configuration template to set largePasteWarning to false.

---
*PR created automatically by Jules for task [4103582458914431750](https://jules.google.com/task/4103582458914431750) started by @mkobit*