### PR TITLE
Disable OpenSpec CLI telemetry

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/telemetry.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/telemetry.sh
@@ -1,4 +1,5 @@
 # Opt out of GitHub CLI telemetry and other tracking
 # https://cli.github.com/telemetry#how-to-opt-out
-export DO_NOT_TRACK=true
+export DO_NOT_TRACK=1
 export GH_TELEMETRY=false
+export OPENSPEC_TELEMETRY=0


### PR DESCRIPTION
Disable OpenSpec CLI telemetry in every interactive shell (bash, zsh) managed by this dotfiles repo by updating the shared `telemetry.sh` template. OpenSpec requires strict string equality for `OPENSPEC_TELEMETRY=0` or `DO_NOT_TRACK=1`.

---
*PR created automatically by Jules for task [5734682445903443011](https://jules.google.com/task/5734682445903443011) started by @mkobit*