### PR TITLE
fix(sandboxr): apply srt startup-race workaround to shell command

### DIFF
--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -98,7 +98,10 @@ def shell(
         _require_bwrap()
     spec = _sandbox_spec(active, cwd, tty=tty)
     args = _apply_timeout(
-        [*backend.build_args(spec, os.environ, default_mask_paths(os.getuid())), shell_cmd],
+        [
+            *backend.build_args(spec, os.environ, default_mask_paths(os.getuid())),
+            *backend.wrap_command([shell_cmd]),
+        ],
         active.timeout_seconds,
     )
     if show_command:

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -204,6 +204,34 @@ def test_shell_show_command_no_tty_adds_new_session():
     assert "--new-session" in result.output
 
 
+def test_shell_srt_backend_show_command_applies_startup_race_workaround(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda name, **kwargs: f"/usr/bin/{name}" if name in ("node", "mise") else None,
+    )
+    install_dir = tmp_path / "mise-installs" / "npm-anthropic-ai-sandbox-runtime" / "0.0.63"
+    cli_js = install_dir / srt_backend.CLI_JS_RELATIVE_TO_INSTALL
+    cli_js.parent.mkdir(parents=True)
+    cli_js.write_text("")
+
+    def _run(args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, stdout=f"{install_dir}\n", stderr="")
+
+    monkeypatch.setattr(srt_backend.subprocess, "run", _run)
+    result = runner.invoke(
+        app,
+        ["shell", "--profile", "srt-allowlist", "--show-command"],
+    )
+    assert result.exit_code == 0
+    # same startup-race workaround as `run`: srt drops positional args after
+    # `bash -c`, so the shell command must be embedded in the wrapper script.
+    assert "sleep 0.2; exec /bin/bash" in result.output
+
+
 # ── profiles subcommand ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `sandboxr shell` built its argv as `backend.build_args() + shell_cmd`, never calling `backend.wrap_command()` — unlike `run`/`doctor`, which both correctly do `[*build_args(...), *wrap_command(cmd)]`.
- For the `srt` backend this meant `shell` had no protection against the known startup-race bug (srt's internal proxy bridges aren't ready for ~150-200ms after launch — the first request can fail instantly without a grace sleep). `run` and `doctor` already work around this; `shell` didn't.
- Fixed by mirroring `run.py`'s pattern: `*backend.wrap_command([shell_cmd])`.

## Test plan
- [x] Added `test_shell_srt_backend_show_command_applies_startup_race_workaround`, confirmed it fails against the pre-fix code (asserted `sleep 0.2; exec ...` is embedded in the wrapped command), then confirmed it passes after the fix.
- [x] Full suite (141 tests), ruff, ty all clean.
- [x] CI green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>