### PR TITLE
fix(scripts): guard uninstall block against missing package_name

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_after_08_install-local-bin-tools.sh.tmpl
@@ -20,7 +20,10 @@ fi
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
   "$MISE" exec --cd "{{ $root }}" -- uv tool install --force --editable "{{ $root }}/{{ $tool.source_dir }}"
 {{- else if eq $method "uninstall" }}
+{{- $pkg := index $tool "package_name" -}}
+{{- if $pkg }}
 UV_TOOL_BIN_DIR="{{ $.chezmoi.destDir }}/.local/bin/dotfiles" \
-  "$MISE" exec --cd "{{ $root }}" -- uv tool uninstall {{ index $tool "package_name" }} 2>/dev/null || true
+  "$MISE" exec --cd "{{ $root }}" -- uv tool uninstall {{ $pkg }} 2>/dev/null || true
+{{- end }}
 {{- end }}
 {{ end -}}


### PR DESCRIPTION
`{{ index $tool "package_name" }}` renders `<no value>` when the key is absent, producing invalid shell syntax at the `2>/dev/null` redirect. Skip the uninstall entirely when no package_name is configured.


Committed-By-Agent: claude