### PR TITLE
feat(wsl): cap WSL2 maxCrashDumpCount to prevent disk exhaustion

### DIFF
--- a/src/chezmoi/.chezmoidata/wsl.toml
+++ b/src/chezmoi/.chezmoidata/wsl.toml
@@ -4,6 +4,7 @@
 memory = "16GB"
 swap = "2GB"
 processors = 4
+maxCrashDumpCount = 3
 # Shares localhost between WSL and Windows so Windows-hosted services
 # (Ollama at 127.0.0.1:11434, dev servers, etc.) are reachable from inside
 # WSL without juggling the NAT gateway IP. Default WSL2 mode is "nat".

--- a/src/chezmoi/.chezmoitemplates/wsl/wslconfig
+++ b/src/chezmoi/.chezmoitemplates/wsl/wslconfig
@@ -6,6 +6,7 @@ memory={{ .wsl.wsl2.memory }}
 swap={{ .wsl.wsl2.swap }}
 processors={{ .wsl.wsl2.processors }}
 networkingMode={{ .wsl.wsl2.networkingMode }}
+maxCrashDumpCount={{ .wsl.wsl2.maxCrashDumpCount }}
 
 [experimental]
 autoMemoryReclaim={{ .wsl.experimental.autoMemoryReclaim }}


### PR DESCRIPTION
Updates `.wslconfig` generation to include `maxCrashDumpCount=3` in the `[wsl2]` section. This bounds the number of retained WSL2 crash dumps (e.g., from Electron/renderer processes) to 3, mitigating the risk of host C: drive exhaustion during persistent crash-loop scenarios.

---
*PR created automatically by Jules for task [10228478054954523579](https://jules.google.com/task/10228478054954523579) started by @mkobit*