### PR TITLE
feat(ai): add bun/bunx eslint/openspec entries to command-policy allowlist

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/bun.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/bun.toml
@@ -1,0 +1,20 @@
+# Fixed, bounded bun subcommands only. Excluded deliberately:
+#   - install/add/remove/update/link/unlink/patch: mutate deps/lockfile and
+#     can run arbitrary postinstall lifecycle scripts from any involved
+#     package (supply-chain execution risk, not just local mutation).
+#   - create: downloads and runs arbitrary template scaffolding.
+#   - publish: npm registry write, same bar as "git push".
+#   - upgrade: mutates the bun binary itself, not project state.
+#   - run, x/bunx bare, repl, exec: unbounded per-project or ad hoc code
+#     (specific bunx targets like eslint/openspec are allowed individually
+#     elsewhere, not bunx as a whole).
+# "bun test" is the one exception that runs arbitrary project test-file
+# code rather than a fixed operation — kept in deliberately, workflow value
+# judged to outweigh the precedent break.
+[ai.command_policy.commands]
+"bun audit" = "allow"
+"bun build" = "allow"
+"bun info" = "allow"
+"bun outdated" = "allow"
+"bun test" = "allow"
+"bun why" = "allow"

--- a/src/chezmoi/.chezmoidata/ai/command_policy/eslint.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/eslint.toml
@@ -1,0 +1,4 @@
+# Read-only linting by default; --fix mutates tracked files but is
+# git-recoverable, same bar as "git add"/"git commit" below.
+[ai.command_policy.commands]
+"bunx eslint" = "allow"

--- a/src/chezmoi/.chezmoidata/ai/command_policy/openspec.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/openspec.toml
@@ -1,0 +1,7 @@
+# OpenSpec CLI: local spec-file read/write under a project's openspec/
+# directory, no remote/network write. Three invocation styles seen in the
+# wild for the same tool, each needs its own literal-prefix entry.
+[ai.command_policy.commands]
+"bunx openspec" = "allow"
+"npx openspec" = "allow"
+"openspec" = "allow"


### PR DESCRIPTION
## Summary
- `eslint.toml`: `bunx eslint` = allow (lint by default, `--fix` is git-recoverable)
- `openspec.toml`: `bunx openspec`/`npx openspec`/`openspec` = allow (three invocation styles for the same tool, schema is prefix-keyed)
- `bun.toml`: `bun build`/`outdated`/`audit`/`why`/`info`/`test` = allow — fixed/read-only operations, except `test` which is a deliberate exception (runs arbitrary project test-file code, kept anyway for TDD workflow convenience)

Deliberately excluded: `bun run`/bare `bunx`/`bun x`/`repl`/`exec` (unbounded arbitrary code), `install`/`add`/`remove`/`update`/`link`/`unlink`/`patch` (postinstall lifecycle scripts = supply-chain execution risk), `create` (downloads+runs template scaffolding), `publish` (npm registry write), `upgrade` (mutates the bun binary itself).

Follow-up from the cross-project `.claude/settings.local.json` survey noted in PR #719.

## Test plan
- [x] `chezmoi data --format json` confirms new keys present in `ai.command_policy.commands`
- [x] `chezmoi diff` shows correct render into both `~/.claude/settings.json` (`Bash(<cmd>:*)`) and Antigravity's `settings.json` (`command(<cmd>)`)