### PR TITLE
fix(ai): prune conductor commands and add codex skill removal coverage

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -3,7 +3,7 @@
 # Skills are deployed as static files by chezmoi externals (see .chezmoiexternals/ai-skills.toml.tmpl).
 # Each upstream is pinned to an exact commit and archive checksum.
 # The archive is piped through src/python/skill_filter at apply time to extract one skill per external.
-# Skills marked "absent" are pruned via the .chezmoiremove.tmpl files in dot_claude/, dot_gemini/, and dot_cursor/;
+# Skills marked "absent" are pruned via the .chezmoiremove.tmpl files in dot_claude/, dot_gemini/, dot_cursor/, and dot_codex/;
 # keep the key when deselecting a skill — deleting it outright orphans any installed copy.
 #
 # Every present skill installs to every tool's skill directory; the target

--- a/src/chezmoi/dot_claude/commands/.chezmoiremove
+++ b/src/chezmoi/dot_claude/commands/.chezmoiremove
@@ -1,0 +1,5 @@
+# Manually-installed Conductor commands (28 Mar 2026), predating this repo's
+# skill/agent catalog. Never brought under chezmoi management; superseded by
+# the superpowers-derived skills (writing-plans, executing-plans,
+# subagent-driven-development, etc).
+conductor

--- a/src/chezmoi/dot_codex/.chezmoiremove.tmpl
+++ b/src/chezmoi/dot_codex/.chezmoiremove.tmpl
@@ -1,0 +1,18 @@
+{{- /*
+  Prunes catalog skills (.chezmoidata/ai/skills.toml) that do not target
+  ~/.codex/skills: state "absent", or a tool-name state for another tool.
+  Only known catalog keys are removed; deleting a catalog key outright
+  orphans any installed copy.
+*/ -}}
+{{- range $sourceName, $source := .ai.skills.external -}}
+{{-   range $skillName, $state := dig "skills" (dict) $source -}}
+{{-     if not (or (eq $state "present") (eq $state "codex")) }}
+skills/{{ $skillName }}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
+{{- range $skillName, $state := dig "authored" (dict) .ai.skills -}}
+{{-   if not (or (eq $state "present") (eq $state "codex")) }}
+skills/{{ $skillName }}
+{{-   end -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- Removes stray Conductor commands (`~/.claude/commands/conductor/`, installed 28 Mar, predates this repo's skill/agent catalog) via a directory-scoped `.chezmoiremove`, matching the existing `dot_local/bin/`, `dot_dotfiles/zsh/`, and `dot_local/share/ai/` pattern.
- Closes a pruning gap: `dot_codex/` never had a `.chezmoiremove.tmpl` like `dot_claude/`, `dot_gemini/`, and `dot_cursor/` do, so deselected skills (`webapp-testing`, marked `absent`) never got pruned from `~/.codex/skills`.

## Test plan
- [x] `chezmoi diff` confirmed only `.claude/commands/conductor` and `.codex/skills/webapp-testing` are targeted for removal
- [x] `chezmoi apply` run locally; both paths confirmed gone