### PR TITLE
fix(claude): remove inert tool search configuration

### DIFF
--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -37,4 +37,3 @@ command = "statusline claude render"
 [claude_code.settings.env]
 DISABLE_AUTOUPDATER = "true"
 DISABLE_TELEMETRY = "true"
-ENABLE_TOOL_SEARCH = "true"


### PR DESCRIPTION
The "Tool Search Tool" is a feature of the Anthropic Platform API, designed to help custom agents navigate large tool catalogs. It is not currently a supported configuration option or feature within the Claude Code CLI itself.

The `ENABLE_TOOL_SEARCH = "true"` setting in `src/chezmoi/.chezmoidata/claude_code.toml` was inert. This PR removes it to clean up the configuration and avoid confusion.

---
*PR created automatically by Jules for task [13386961732933286920](https://jules.google.com/task/13386961732933286920) started by @mkobit*