### PR TITLE
feat(ai): expand security/design agent coverage, bump agency-agents and superpowers

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -26,8 +26,8 @@
 
 [ai.agents.external.agency-agents]
 repo = "msitarzewski/agency-agents"
-ref = "a077c9ac0be381ec15e7dcbb690f641d6091a5db" # 2026-06-07
-sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
+ref = "86a6695d4cee1c9720e2be4fd8ae007f9b6d96ae" # 2026-07-15
+sha256 = "cc7e99ab1f744f2a97960d1a1953e0bdf951e7f64a1044f89e0180079835ec2d"
 
 [ai.agents.external.agency-agents.agents]
 "engineering/engineering-backend-architect" = "present"
@@ -36,6 +36,34 @@ sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
 "engineering/engineering-prompt-engineer" = "present"
 "engineering/engineering-software-architect" = "present"
 "engineering/engineering-sre" = "present"
+# Audit caveat 2026-07-15: step 1 assumes an ai/memory-bank/ requirements doc
+# from the author's own pipeline — gather requirements normally if absent.
+"engineering/engineering-ai-engineer" = "present"
+"engineering/engineering-api-platform-engineer" = "present"
+"engineering/engineering-code-reviewer" = "present"
+# Audit caveat 2026-07-15: recommends scheduling live failover/restore drills
+# and production game-days — confirm target environment and blast-radius
+# controls first.
+"engineering/engineering-database-reliability-engineer" = "present"
+"engineering/engineering-developer-tooling-engineer" = "present"
+# Audit caveat 2026-07-15: workflow implies applying Terraform and kubectl
+# mutations directly with no dry-run/approval gate — require plan review and
+# non-prod confirmation first.
+"engineering/engineering-devops-automator" = "present"
+"engineering/engineering-git-workflow-master" = "present"
+"engineering/engineering-i18n-engineer" = "present"
+"engineering/engineering-identity-access-engineer" = "present"
+# Audit caveat 2026-07-15: "delete this and see what breaks" technique
+# assumes reliable test coverage — deprecate instead in low-coverage repos.
+"engineering/engineering-minimal-change-engineer" = "present"
+# Audit caveat 2026-07-15: numeric thresholds (chain length, fan-out, eval
+# counts) are opinionated defaults for production-scale pipelines — treat as
+# heuristics for prototypes.
+"engineering/engineering-multi-agent-systems-architect" = "present"
+# Audit caveat 2026-07-15: hardcoded numeric success metrics assume
+# analytics/support-ticket infra this agent won't have access to — ignore them.
+"engineering/engineering-technical-writer" = "present"
+"engineering/engineering-webassembly-engineer" = "present"
 "product/product-feedback-synthesizer" = "present"
 "product/product-manager" = "present"
 "product/product-sprint-prioritizer" = "present"
@@ -46,6 +74,40 @@ sha256 = "dbe0b0aadd2b12a5cceb5a0f613c272e74da6ddc4acc66344dfece16ea172d5b"
 # Rejected 2026-06-12: prompt embeds the author's own project layout (runs
 # ./qa-playwright-capture.sh, writes ai/memory-bank/ paths); adapt or replace.
 "project-management/project-manager-senior" = "absent"
+"design/design-ui-designer" = "present"
+"design/design-ux-architect" = "present"
+# Audit caveat 2026-07-15: core workflow assumes recruiting and interviewing
+# real human research participants — verify consent/privacy handling before
+# treating its protocols as ready to run.
+"design/design-ux-researcher" = "present"
+# Audit caveat 2026-07-15: directs manual penetration testing/DAST against
+# staging environments — scope to authorized, non-production targets only.
+"security/security-appsec-engineer" = "present"
+# Audit caveat 2026-07-15: workflow generates working exploit/PoC code (SQLi,
+# SSRF, auth-bypass) — confirm target is local/non-production before running.
+"security/security-architect" = "present"
+"security/security-ai-generated-code-auditor" = "present"
+# Audit caveat 2026-07-15: directs live penetration tests/red-team exercises
+# against cloud environments — require explicit written authorization and a
+# non-prod scoped target.
+"security/security-cloud-security-architect" = "present"
+"security/security-compliance-auditor" = "present"
+# Audit caveat 2026-07-15: forensic scripts run as root/admin and collect
+# credentials, logs, and process state — only run against systems you're
+# authorized to investigate.
+"security/security-incident-responder" = "present"
+# Audit caveat 2026-07-15: directs real offensive techniques (credential
+# exfiltration, AD compromise, physical/social engineering) — verify written
+# authorization before executing against any real target.
+"security/security-penetration-tester" = "present"
+# Audit caveat 2026-07-15: leak-response runbook rotates/revokes real
+# provider credentials and rewrites git history — confirm target account/repo
+# and team coordination first.
+"security/security-secrets-credential-engineer" = "present"
+# Rejected 2026-07-15: prompt is built around a fictional internal doc
+# (security/17-security-pattern.md, cited ~30 times) and assumes IdP-backed
+# role sync as ground truth; would need authoring before use.
+"security/security-senior-secops" = "absent"
 # Audit caveat 2026-06-12: no malicious content, but the prompt eagerly directs
 # running real load/stress/penetration tests — only point it at safe targets.
 "testing/testing-api-tester" = "present"

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -37,8 +37,8 @@ write-agent-context = "present"
 #   ("claude", "antigravity", "cursor") to deploy only to that tool.
 [ai.skills.external.superpowers]
 repo = "obra/superpowers"
-ref = "6fd4507659784c351abbd2bc264c7162cfd386dc" # 2026-05-29
-sha256 = "bae555f742a6f223bca7825f79f0305315944653e8763b7939f19f93f9adda32"
+ref = "d884ae04edebef577e82ff7c4e143debd0bbec99" # 2026-07-02
+sha256 = "d2c15e07a4637bffc7df15daa062eeb569c9adf6d6ad6ec08dec4ce6539b3910"
 
 [ai.skills.external.superpowers.skills]
 brainstorming = "present"


### PR DESCRIPTION
## Summary
- Bumps `agency-agents` to `86a6695` (2026-07-15, verified current upstream HEAD) and adds 25 curated security/design/engineering agents after a per-agent audit (dedicated subagent per candidate, checking prompt-injection risk and embedded author-specific assumptions).
- Caveat-worthy agents (live pentest/DAST, credential rotation, production DR drills, infra mutations, etc.) get audit-caveat comments mirroring the existing `testing-api-tester` precedent. `security-senior-secops` is rejected — its prompt is structurally built around a fictional internal doc (`security/17-security-pattern.md`, cited ~10+ times) rather than a scoped, fixable caveat.
- Bumps `superpowers` to `d884ae0` (2026-07-02, verified current) after diffing every changed skill. Highest-risk changes (three new shell scripts in `subagent-driven-development/scripts/`, the restructured `SKILL.md`, and the `brainstorming` local server) each got a dedicated subagent review: the new scripts use `set -euo pipefail` with quoted variables and confined output paths, and the server diff is a real hardening pass (adds session auth tokens, WS Origin checks, path-traversal guards, safer PID handling) — no regressions found.

## Scope note
Coverage of the upstream `security`/`design`/`engineering` categories is curated, not exhaustive: 9 of 12 security agents, 3 of 9 design agents, and 19 of 52 engineering agents got an explicit present/absent decision (the rest were triaged out on relevance — e.g. WordPress/Drupal/network-hardware/blockchain-specific agents — without a full audit, consistent with how this file already treats unreviewed candidates as silently omitted rather than explicitly rejected).

## Test plan
- [x] Independently re-verified both archive sha256sums via fresh download (not reused from cache)
- [x] Confirmed both refs are still current upstream HEAD via `git ls-remote`
- [x] `chezmoi diff` / `chezmoi apply` run locally — new agents render correctly across Claude Code, opencode, cursor-as-skills, and antigravity-as-skills targets; diff is clean post-apply
- [x] Verified no previously-selected `present` agents were disturbed (full old-vs-new key diff)
- [x] Adversarial second-pass review (independent subagent, no access to prior reasoning) spot-checked 6 of the audited files against source and confirmed the present/absent/caveat calls are accurate and internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)