### PR TITLE
feat(ai): bump pinned Claude Code version to 2.1.215

### DIFF
--- a/src/chezmoi/.chezmoidata/claude_code.toml
+++ b/src/chezmoi/.chezmoidata/claude_code.toml
@@ -1,5 +1,5 @@
 [claude_code]
-version = "2.1.197"
+version = "2.1.215"
 
 # Deployment config → managed via modify_settings.json → ~/.claude/settings.json
 # These are operator/admin-level settings: permissions, env, tooling behavior.


### PR DESCRIPTION
## Summary
- bumps `claude_code.version` in `.chezmoidata/claude_code.toml` from `2.1.197` to `2.1.215`, latest on npm as of 2026-07-19
- install script (`run_once_install-claude.sh.tmpl`) pulls this version string through `claude.ai/install.sh`; no checksums to update

## Test plan
- [ ] CI green (lint, test, integration)