### PR TITLE
ci(integration): cache bun installs, restore uv cache, fix mise cache key path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   UV_CACHE_DIR: /tmp/.uv-cache
   UV_PYTHON_INSTALL_DIR: /tmp/.uv-python
   MISE_CACHE_DIR: /tmp/.mise-cache
+  BUN_INSTALL_CACHE_DIR: /tmp/.bun-cache
   CHEZMOI_CACHE_DIR: /tmp/.chezmoi-cache
   CHEZMOI_CONFIG: /tmp/.chezmoi-config.toml
   CHEZMOI_DEST: /tmp/chezmoi-test
@@ -159,11 +160,31 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ env.MISE_CACHE_DIR }}
-          key: mise-cache-v1-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('src/chezmoi/.chezmoidata/mise.toml') }}
+          key: mise-cache-v1-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('src/chezmoi/.chezmoidata/bin/mise.toml') }}
           restore-keys: |
             mise-cache-v1-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
             mise-cache-v1-${{ runner.os }}-main-
             mise-cache-v1-${{ runner.os }}-
+
+      - name: Cache bun install cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ env.BUN_INSTALL_CACHE_DIR }}
+          key: bun-cache-v1-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('src/chezmoi/.chezmoidata/bin/mise.toml') }}
+          restore-keys: |
+            bun-cache-v1-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            bun-cache-v1-${{ runner.os }}-main-
+            bun-cache-v1-${{ runner.os }}-
+
+      - name: Restore uv cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ env.UV_CACHE_DIR }}
+          key: uv-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ github.head_ref || github.ref_name }}-
+            uv-${{ runner.os }}-main-
+            uv-${{ runner.os }}-
 
       - name: Install chezmoi
         run: |


### PR DESCRIPTION
## Summary
- adds `BUN_INSTALL_CACHE_DIR` + an `actions/cache` step for it in the `integration` job — mise's npm backend (bun) reinstalls gemini-cli/sandbox-runtime's full dependency tree every run with nothing cached
- fixes `mise-cache-v1`'s cache key: `hashFiles('src/chezmoi/.chezmoidata/mise.toml')` pointed at a path that doesn't exist (real path is `.chezmoidata/bin/mise.toml`), so the hash was always empty and the key never varied with the actual tool catalog
- adds the same "Restore uv cache" step the `lint`/`test` jobs already have to `integration`, the only job missing it

## Not pursued
- apt package caching (bubblewrap/socat/zsh, ~17.6s combined) — bottleneck is dpkg database-scan overhead, not network fetch, so caching wouldn't help
- snap caching (ghostty, ~14.5s) — snapd/squashfs mount overhead, not reliably cacheable via actions/cache

## Test plan
- [ ] CI green (lint, test, integration on both OS)
- [ ] Re-run integration once merged to confirm bun/mise cache hits on the second run