### PR TITLE
fix(codex): short-circuit modify_config reformat when tui setting alr…

### DIFF
--- a/src/chezmoi/dot_codex/modify_config.toml
+++ b/src/chezmoi/dot_codex/modify_config.toml
@@ -4,4 +4,8 @@
 {{-   $config = fromToml .chezmoi.stdin -}}
 {{- end -}}
 {{- $vimModeDefault := dig "codex" "tui" "vim_mode_default" true . -}}
+{{- if eq (dig "tui" "vim_mode_default" nil $config) $vimModeDefault -}}
+{{- .chezmoi.stdin -}}
+{{- else -}}
 {{- $config | setValueAtPath "tui.vim_mode_default" $vimModeDefault | toToml -}}
+{{- end -}}


### PR DESCRIPTION
…eady correct

Codex updates last_updated in ~/.codex/config.toml on every marketplace sync. The modify script always round-tripped through toToml which normalizes TOML indentation, causing chezmoi to see a perpetual diff on every apply.

Now passes stdin unchanged when tui.vim_mode_default is already the right value — only reformats when actually fixing a wrong or missing setting.


Committed-By-Agent: claude