### PR TITLE
feat(ai): onboard wshobson/agents, bump skill pins

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -112,3 +112,50 @@ sha256 = "cc7e99ab1f744f2a97960d1a1953e0bdf951e7f64a1044f89e0180079835ec2d"
 # running real load/stress/penetration tests — only point it at safe targets.
 "testing/testing-api-tester" = "present"
 "testing/testing-performance-benchmarker" = "present"
+
+# Onboarded 2026-07-20: 91-plugin marketplace (agents/skills/commands per
+# plugin). Hook/MCP-bundling plugins (protect-mcp, review-agent-governance,
+# runapi-mcp) and file-conversion (uploads to a third-party SaaS) excluded as
+# a different risk class. Other categories audited clean but left unselected
+# as out of scope.
+[ai.agents.external.wshobson-agents]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+agents_root = "plugins"
+
+[ai.agents.external.wshobson-agents.agents]
+"content-marketing/agents/content-marketer" = "present"
+"content-marketing/agents/search-specialist" = "present"
+"seo-content-creation/agents/seo-content-auditor" = "present"
+"seo-content-creation/agents/seo-content-planner" = "present"
+"seo-content-creation/agents/seo-content-writer" = "present"
+"llm-application-dev/agents/vector-database-engineer" = "present"
+# Rejected 2026-07-20: duplicates existing engineering-ai-engineer pick.
+"llm-application-dev/agents/ai-engineer" = "absent"
+# Rejected 2026-07-20: duplicates existing engineering-prompt-engineer pick.
+"llm-application-dev/agents/prompt-engineer" = "absent"
+"machine-learning-ops/agents/data-scientist" = "present"
+"machine-learning-ops/agents/ml-engineer" = "present"
+"machine-learning-ops/agents/mlops-engineer" = "present"
+"llm-finetuning/agents/llm-finetuning-architect" = "present"
+"llm-finetuning/agents/llm-finetuning-eval-engineer" = "present"
+# Audit caveat 2026-07-20: soft-references an optional dgx-spark-ops plugin
+# and /spark-preflight command not selected here — degrades to a generic
+# fallback, but the reference will point at nothing.
+"llm-finetuning/agents/llm-finetuning-training-engineer" = "present"
+"julia-development/agents/julia-pro" = "present"
+"jvm-languages/agents/csharp-pro" = "present"
+"jvm-languages/agents/java-pro" = "present"
+"jvm-languages/agents/scala-pro" = "present"
+"dotnet-contribution/agents/dotnet-architect" = "present"
+"functional-programming/agents/elixir-pro" = "present"
+"functional-programming/agents/haskell-pro" = "present"
+"systems-programming/agents/c-pro" = "present"
+"systems-programming/agents/cpp-pro" = "present"
+# Rejected 2026-07-20: generic keyword-list style, weaker than c-pro/cpp-pro siblings.
+"systems-programming/agents/golang-pro" = "absent"
+# Rejected 2026-07-20: same generic-list issue as golang-pro.
+"systems-programming/agents/rust-pro" = "absent"
+"shell-scripting/agents/bash-pro" = "present"
+"shell-scripting/agents/posix-shell-pro" = "present"

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -42,6 +42,7 @@ sha256 = "d2c15e07a4637bffc7df15daa062eeb569c9adf6d6ad6ec08dec4ce6539b3910"
 
 [ai.skills.external.superpowers.skills]
 brainstorming = "present"
+dispatching-parallel-agents = "present"
 executing-plans = "present"
 finishing-a-development-branch = "present"
 receiving-code-review = "present"
@@ -50,14 +51,15 @@ subagent-driven-development = "present"
 systematic-debugging = "present"
 test-driven-development = "present"
 using-git-worktrees = "present"
+using-superpowers = "present"
 verification-before-completion = "present"
 writing-plans = "present"
 writing-skills = "present"
 
 [ai.skills.external.anthropics-skills]
 repo = "anthropics/skills"
-ref = "57546260929473d4e0d1c1bb75297be2fdfa1949" # 2026-06-09
-sha256 = "7a3e7ac65a8057d56c3ed78292b69d1a0b48cb3adfe3e77ec5019621c42e940e"
+ref = "fa0fa64bdc967915dc8399e803be67759e1e62b8" # 2026-07-20
+sha256 = "3fa5cb4472fc79626be4ebc3bf997b1ef57e413b8801a7ccac874860b287317f"
 
 [ai.skills.external.anthropics-skills.skills]
 skill-creator = "claude" # authoring tooling is only useful inside Claude Code
@@ -67,9 +69,88 @@ webapp-testing = "absent"
 # its skills-src content is bundled into the modern-web-guidance skill's guides here).
 [ai.skills.external.modern-web-guidance]
 repo = "GoogleChrome/modern-web-guidance"
-ref = "5733cdd9f89b0f19119e855532f8b8ac7997ecb6" # 2026-06-08
-sha256 = "3d2793fd566307a2e95387266f3c36fe251f727a62883257bda15e36f2aacead"
+ref = "79aae1e0bed948e48fd78b58538c5ee1e6463da9" # 2026-07-20
+sha256 = "915d220920d7715d8338ab97381522f74dc29d78849405df82223ac4afc20c7e"
 
 [ai.skills.external.modern-web-guidance.skills]
 chrome-extensions = "present"
 modern-web-guidance = "present"
+
+# Onboarded 2026-07-20: skills from wshobson/agents (see agents.toml
+# wshobson-agents source comment for scope/exclusions). One source per plugin
+# since skills_root is per-source.
+[ai.skills.external.wshobson-llm-application-dev]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/llm-application-dev/skills"
+
+[ai.skills.external.wshobson-llm-application-dev.skills]
+embedding-strategies = "present"
+hybrid-search-implementation = "present"
+langchain-architecture = "present"
+llm-evaluation = "present"
+prompt-engineering-patterns = "present"
+rag-implementation = "present"
+similarity-search-patterns = "present"
+vector-index-tuning = "present"
+
+[ai.skills.external.wshobson-llm-finetuning]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/llm-finetuning/skills"
+
+[ai.skills.external.wshobson-llm-finetuning.skills]
+checkpoint-promotion = "present"
+dataset-curation = "present"
+eval-harness-first = "present"
+finetuning-method-selection = "present"
+grpo-rlvr-training = "present"
+lora-qlora-recipes = "present"
+preference-optimization = "present"
+quantized-export = "present"
+trace-to-training-data = "present"
+vision-sft = "present"
+
+[ai.skills.external.wshobson-machine-learning-ops]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/machine-learning-ops/skills"
+
+[ai.skills.external.wshobson-machine-learning-ops.skills]
+ml-pipeline-workflow = "present"
+# Rejected 2026-07-20: pulls unaudited third-party content via `npx skills add` at agent-invocation time.
+recsys-pipeline-architect = "absent"
+
+[ai.skills.external.wshobson-dotnet-contribution]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/dotnet-contribution/skills"
+
+[ai.skills.external.wshobson-dotnet-contribution.skills]
+dotnet-backend-patterns = "present"
+
+[ai.skills.external.wshobson-systems-programming]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/systems-programming/skills"
+
+[ai.skills.external.wshobson-systems-programming.skills]
+go-concurrency-patterns = "present"
+memory-safety-patterns = "present"
+rust-async-patterns = "present"
+
+[ai.skills.external.wshobson-shell-scripting]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/shell-scripting/skills"
+
+[ai.skills.external.wshobson-shell-scripting.skills]
+bash-defensive-patterns = "present"
+bats-testing-patterns = "present"
+shellcheck-configuration = "present"


### PR DESCRIPTION
## Summary
- Onboards 23 agents + 21 skills from `wshobson/agents` (pinned `c4b82b0`), scoped to actual usage (software, writing/blogging, research) after a full prompt-injection/quality audit across all candidate categories; hook- and MCP-bundling plugins (`protect-mcp`, `review-agent-governance`, `runapi-mcp`, `file-conversion`) excluded as a different risk class.
- Bumps `anthropics/skills` and `GoogleChrome/modern-web-guidance` pins to latest HEAD.
- Adds two previously-unselected `superpowers` skills: `using-superpowers`, `dispatching-parallel-agents`.
- 4 candidates explicitly rejected inline: `ai-engineer`/`prompt-engineer` (duplicate existing agency-agents picks), `golang-pro`/`rust-pro` (generic-quality flag vs. sibling agents).

## Test plan
- [x] `python3 -c "import tomllib; ..."` — both TOML files parse
- [x] `chezmoi execute-template -f .chezmoiexternals/ai-agents.toml.tmpl` — renders clean, no duplicate-target errors
- [x] `chezmoi execute-template -f .chezmoiexternals/ai-skills.toml.tmpl` — renders clean
- [x] Verified sha256 pins against the exact `codeload.github.com/.../tar.gz/<ref>` URL chezmoi fetches at apply time (not the API tarball endpoint, which serves different bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)