### PR TITLE
fix(browser-sync): remove blank lines before prompts, fix Cmd+Option …

### DIFF
--- a/src/python/browser_sync/browser_sync/_terminal.py
+++ b/src/python/browser_sync/browser_sync/_terminal.py
@@ -57,7 +57,7 @@ def getkey() -> str:
 
 def prompt_enter(message: str) -> None:
     """Wait for Enter; exit cleanly on Ctrl+C."""
-    print(f"\n\033[0;36m[?]\033[0m    {message}", end="", flush=True)
+    print(f"\033[0;36m[?]\033[0m    {message}", end="", flush=True)
     while True:
         ch = getkey()
         if ch in ("\r", "\n"):
@@ -71,7 +71,7 @@ def prompt_enter(message: str) -> None:
 
 def prompt_done_or_recopy(copy_fn: Callable[[], None]) -> None:
     """Wait for Enter (done) or 'r' (recopy the clipboard payload)."""
-    print("\n\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
+    print("\033[0;36m[?]\033[0m    Press Enter when done, or 'r' to recopy ", end="", flush=True)
     while True:
         ch = getkey()
         if ch in ("\r", "\n"):
@@ -90,7 +90,7 @@ def prompt_done_or_recopy(copy_fn: Callable[[], None]) -> None:
 
 def prompt_prune_or_skip(copy_fn: Callable[[], None]) -> None:
     """Wait for 'p' (copy prune script then confirm) or Enter (skip removals)."""
-    print("\n\033[0;33m[!]\033[0m    Press 'p' to copy PRUNE script, or Enter to skip removals ", end="", flush=True)
+    print("\033[0;33m[!]\033[0m    Press 'p' to copy PRUNE script, or Enter to skip removals ", end="", flush=True)
     while True:
         ch = getkey()
         if ch in ("\r", "\n"):

--- a/src/python/browser_sync/browser_sync/shortcuts.py
+++ b/src/python/browser_sync/browser_sync/shortcuts.py
@@ -151,7 +151,7 @@ def run(toml_path: Path, *, prune: bool, confirm: bool, dry_run: bool, no_open: 
         _log.log(_terminal.OK, "copied — adds new entries, previews removals (WOULD-DEL)")
 
         if not no_open:
-            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
+            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Option+J)")
             _browser.open_in_chrome(_CHROME_SETTINGS_URL)
         else:
             _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)
@@ -168,7 +168,7 @@ def run(toml_path: Path, *, prune: bool, confirm: bool, dry_run: bool, no_open: 
         _log.log(_terminal.OK, "sync script copied to clipboard")
 
         if not no_open:
-            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Opt+J)")
+            _log.info("opening chrome://settings/searchEngines — paste into console (Cmd+Option+J)")
             _browser.open_in_chrome(_CHROME_SETTINGS_URL)
         else:
             _log.info("paste clipboard into DevTools console on:\n  %s", _CHROME_SETTINGS_URL)


### PR DESCRIPTION
…label

Drop leading `\n` from all three terminal prompt functions so no empty line appears between the preceding log message and the interactive prompt. Normalize `Cmd+Opt+J` to `Cmd+Option+J` in shortcuts.py to match the `Cmd+Option+I` already used in vimium.py.


Committed-By-Agent: claude