### PR TITLE
feat(chezmoi): prompt once for Stitch API key, export via zsh secrets fragment

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -169,3 +169,16 @@ installation_method = "dotfiles.script"
 
 [data.npmrc]
 installation_method = "chezmoi"
+
+# Secrets — prompted once at chezmoi init, exported to the shell (see
+# .chezmoitemplates/shell/secrets.sh via zsh.config_fragments."15-secrets" in
+# .chezmoidata/zsh.toml), never written into any git-tracked file. Blank
+# answer = not exported, harmless no-op. Skipped entirely in CI —
+# promptStringOnce has long-standing upstream bugs falling back to its
+# default under --promptString/non-interactive use, so CI never calls it.
+{{- $stitchApiKey := "" -}}
+{{- if not (env "CI") -}}
+{{-   $stitchApiKey = promptStringOnce . "stitch_api_key" "Stitch API key, exported as $STITCH_API_KEY for use in any project's .mcp.json (blank to skip — stitch.withgoogle.com → Settings → API key)" "" -}}
+{{- end }}
+[data.secrets]
+stitch_api_key = {{ $stitchApiKey | quote }}

--- a/src/chezmoi/.chezmoidata/zsh.toml
+++ b/src/chezmoi/.chezmoidata/zsh.toml
@@ -4,3 +4,6 @@ prompt = "starship"
 
 [zsh.config_fragments."10-personal"]
 template = "shell/personal-zshrc.sh"
+
+[zsh.config_fragments."15-secrets"]
+template = "shell/secrets.sh"

--- a/src/chezmoi/.chezmoitemplates/shell/secrets.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/secrets.sh
@@ -1,0 +1,4 @@
+{{- $stitchApiKey := dig "secrets" "stitch_api_key" "" . -}}
+{{- if ne $stitchApiKey "" }}
+export STITCH_API_KEY={{ $stitchApiKey | quote }}
+{{- end }}

--- a/src/chezmoi/AGENTS.md
+++ b/src/chezmoi/AGENTS.md
@@ -14,6 +14,7 @@ This directory contains the Chezmoi source state for dotfiles management.
 
 - **AI agent sandbox** (`sandboxr`, see [src/python/sandboxr/AGENTS.md](../python/sandboxr/AGENTS.md)): autonomous agent CLI runs are wrapped by `sandboxr` reading `.chezmoidata/ai/sandbox.toml`, rendered to `~/.config/ai-policy/sandbox.toml` plus per-tool fragments under `dot_config/ai-policy/`.
 - **Command approval policy** (see below): global command-approval allowlist for attended (HITL) agent sessions, rendered into each tool's native permission syntax.
+- **Secrets** (`[data.secrets]` in `.chezmoi.toml.tmpl`, prompted once via `promptStringOnce`, skipped under `env "CI"`): exported to the shell via a `zsh.config_fragments` entry (`.chezmoidata/zsh.toml` → `.chezmoitemplates/shell/secrets.sh`), never written to a git-tracked file. Blank answer = not exported. Add more secrets here rather than inventing a per-tool prompt/deploy mechanism — e.g. a project's `.mcp.json` can reference `${STITCH_API_KEY}` directly with no chezmoi involvement beyond this export.
 
 ## Command approval policy
 


### PR DESCRIPTION
## Summary
- Adds a reusable `[data.secrets]` pattern: `promptStringOnce` in `.chezmoi.toml.tmpl` captures a Stitch API key once at `chezmoi init`, skipped under `env "CI"` to avoid long-standing upstream `promptStringOnce`/`--promptString` non-interactive bugs.
- Exports it as `$STITCH_API_KEY` via a new `zsh.config_fragments."15-secrets"` entry (`.chezmoitemplates/shell/secrets.sh`), reusing the existing fragment-injection mechanism already used for `10-personal`. Never written to any git-tracked file.
- Lets any project's `.mcp.json` reference `${STITCH_API_KEY}` (e.g. for Google Stitch's MCP server) with no per-tool plugin/deployment machinery — that config stays manual, per-project.
- One-line doc addition to `src/chezmoi/AGENTS.md`.

## Test plan
- [x] `CI=1 chezmoi execute-template --init` renders `stitch_api_key = ""` with no prompt attempted, exit 0
- [x] `chezmoi init --promptString "...=<value>"` round-trips the value into `[data.secrets]`
- [x] `.chezmoitemplates/shell/secrets.sh` renders the export line only when the secret is set, empty otherwise
- [x] Rendered `modify_dot_zshrc.tmpl`, executed against a fake existing `.zshrc`, preserves prior content and appends both fragments correctly
- [x] Full `chezmoi apply --dry-run` against a scratch destination shows the export landing in `.zshrc`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)