### PR TITLE
fix(chezmoi): guard secrets fragment source against missing file

### DIFF
--- a/src/chezmoi/.chezmoitemplates/shell/secrets.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/secrets.sh
@@ -1,1 +1,1 @@
-source {{ .chezmoi.destDir }}/.config/shell/secrets.sh
+[ -f {{ .chezmoi.destDir }}/.config/shell/secrets.sh ] && source {{ .chezmoi.destDir }}/.config/shell/secrets.sh

--- a/src/chezmoi/.chezmoitemplates/shell/secrets.sh
+++ b/src/chezmoi/.chezmoitemplates/shell/secrets.sh
@@ -1,1 +1,3 @@
-[ -f {{ .chezmoi.destDir }}/.config/shell/secrets.sh ] && source {{ .chezmoi.destDir }}/.config/shell/secrets.sh
+if [ -f {{ .chezmoi.destDir }}/.config/shell/secrets.sh ]; then
+  source {{ .chezmoi.destDir }}/.config/shell/secrets.sh
+fi


### PR DESCRIPTION
## Summary
- #739 (just merged) moved the Stitch secret export into `dot_config/shell/private_secrets.sh.tmpl`, sourced unconditionally from `.zshrc`/`.bashrc`.
- Broke main: chezmoi doesn't create a target when its template renders to an empty string, which is always true in CI (`promptStringOnce` skipped, `stitch_api_key = ""`). The unguarded `source .../secrets.sh` then failed shell startup with "no such file or directory" — this is what's currently failing on `main`'s integration tests.
- Fix: guard the fragment with `[ -f ... ] && source ...`.

## Test plan
- [x] Reproduced the CI failure locally: `chezmoi init`/`apply` against a scratch destination with `CI=true` (empty secret) — confirmed `.config/shell/secrets.sh` is never created, and `zsh -i -c 'exit'` failed with the same "no such file or directory" error before this fix.
- [x] Re-ran the same repro with the guard in place — no errors, clean exit.
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)