### PR TITLE
docs/feat: clarify chezmoi-source editing + unnamed-subagent matching rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,19 @@ Never assume you are on `main` or in the primary checkout directory.
    - If a user asks you to use them, you must provably come to the user with the reasons why before ever making an edit.
    - We install to a target directory, which may not be the user's home during testing/CI.
 
+## Editing Claude Code / AI-tool configuration
+
+When a request in this repo mentions editing Claude settings, `CLAUDE.md`, agent definitions, skills, or other AI-tool config, it means editing the chezmoi source and running `chezmoi apply` — **never** editing the deployed file directly.
+Deployed copies under `~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.cursor/`, etc. (or the equivalent under `.chezmoi.destDir` during testing) are chezmoi-managed targets; direct edits there are silently overwritten on the next `chezmoi apply`.
+This applies to every dotfile-managed target, not just Claude's — the same mistake applies to any tool whose config chezmoi owns.
+
+- Global Claude Code prompt: `src/chezmoi/dot_claude/CLAUDE.md.tmpl` → `~/.claude/CLAUDE.md`.
+- Claude Code settings: `src/chezmoi/dot_claude/modify_settings.json` → `~/.claude/settings.json`.
+- Skills catalog: `src/chezmoi/.chezmoidata/ai/skills.toml`; authored skill sources under `src/ai/skills/`.
+- Agents catalog: `src/chezmoi/.chezmoidata/ai/agents.toml` (pinned upstream selections; no authored agent sources exist yet).
+
+After editing source, preview with `chezmoi diff`, then sync with `chezmoi apply` (optionally scoped to a target path, e.g. `chezmoi apply ~/.claude/CLAUDE.md`).
+
 ## Managed environment constraints
 
 - **`modify_` scripts** are the ONLY safe way to customize externally managed files (like `.gitconfig`, `.zshrc` in corporate environments).

--- a/src/chezmoi/.chezmoidata/ai/guidelines.toml
+++ b/src/chezmoi/.chezmoidata/ai/guidelines.toml
@@ -34,7 +34,8 @@ content = """
 content = """
 ## Delegation
 - Delegate specific units of work to subagents to keep the main thread focused and context lean.
-- Prefer pre-installed named skills and agents (superpowers, agency-agents) over ad-hoc subagent prompts — they carry tested workflows and better instructions."""
+- Prefer pre-installed named skills and agents (superpowers, agency-agents) over ad-hoc subagent prompts — they carry tested workflows and better instructions.
+- Match an unnamed subagent request to the best-fitting agent type; use a generic one only if none fits."""
 
 [[ai.guidelines.sections]]
 content = """


### PR DESCRIPTION
## Summary
- `AGENTS.md`: explicit rule that editing Claude/AI-tool config in this repo means editing chezmoi source + `chezmoi apply`, never the deployed `~/.claude/*` copies.
- `guidelines.toml`: new Delegation bullet — an unnamed subagent request should match to the best-fitting agent type, falling back to a generic one only if none fits. Wording went through an independent correctness review and a house-style review before landing here.

## Test plan
- [ ] CI green
- [ ] `chezmoi diff` reviewed after merge, before `chezmoi apply`