### PR TITLE
feat: onboard bazel-build-optimization skill from wshobson/agents

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/agents.toml
+++ b/src/chezmoi/.chezmoidata/ai/agents.toml
@@ -159,3 +159,7 @@ agents_root = "plugins"
 "systems-programming/agents/rust-pro" = "absent"
 "shell-scripting/agents/bash-pro" = "present"
 "shell-scripting/agents/posix-shell-pro" = "present"
+# Rejected 2026-07-24: security clean, but framed exclusively around JS/TS
+# tooling (Nx/Turborepo/Lerna) plus Bazel — no uv/poetry/Python-workspace
+# coverage, so not applicable to this repo's src/python uv workspace.
+"developer-essentials/agents/monorepo-architect" = "absent"

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -154,3 +154,20 @@ skills_root = "plugins/shell-scripting/skills"
 bash-defensive-patterns = "present"
 bats-testing-patterns = "present"
 shellcheck-configuration = "present"
+
+# Onboarded 2026-07-24: bazel-build-optimization audited (security: approve,
+# no caveat — read-only Bazel query/build commands, pinned http_archive
+# deps, no secrets or curl|sh). Other skills in this plugin
+# (auth-implementation-patterns, code-review-excellence,
+# debugging-strategies, e2e-testing-patterns, error-handling-patterns,
+# git-advanced-workflows, monorepo-management, nx-workspace-patterns,
+# sql-optimization-patterns, turborepo-caching) not reviewed — revisit
+# before selecting any.
+[ai.skills.external.wshobson-developer-essentials]
+repo = "wshobson/agents"
+ref = "c4b82b0ad771190355eb8e204b1329732a18449a" # 2026-07-18
+sha256 = "ada3f8e177be3b522e63b77f14fac4bc95b0b1e6e73e9342028dba55004a2bb3"
+skills_root = "plugins/developer-essentials/skills"
+
+[ai.skills.external.wshobson-developer-essentials.skills]
+bazel-build-optimization = "present"


### PR DESCRIPTION
## Summary
- `skills.toml`: new `wshobson-developer-essentials` source, `bazel-build-optimization` skill selected. Audited at the pinned ref — read-only Bazel `query`/`build` commands, pinned `http_archive` deps, no secrets or `curl|sh`. Approve, no caveat. Other 10 skills in that plugin left unreviewed (documented in the comment).
- `agents.toml`: recorded `monorepo-architect` (same plugin) as rejected — security clean, but scoped to JS/TS monorepo tooling (Nx/Turborepo/Lerna) plus Bazel with no uv/Python-workspace coverage, so not useful here.

## Test plan
- [ ] CI green
- [ ] `chezmoi diff` reviewed after merge, before `chezmoi apply`