### PR TITLE
build(deps): update chezmoi to v2.71.1 and mise to v2026.7.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   CHEZMOI_CACHE_DIR: /tmp/.chezmoi-cache
   CHEZMOI_CONFIG: /tmp/.chezmoi-config.toml
   CHEZMOI_DEST: /tmp/chezmoi-test
-  CHEZMOI_VERSION: v2.71.0
+  CHEZMOI_VERSION: v2.71.1
 
 defaults:
   run:
@@ -40,7 +40,7 @@ jobs:
         with:
           # Pin to match .chezmoidata/bin/mise.toml. Without this, the
           # action falls back to a default that may be yanked from upstream.
-          version: 2026.7.7
+          version: 2026.7.13
       - name: Restore uv cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: jdx/mise-action@v4.2.1
         with:
-          version: 2026.7.7
+          version: 2026.7.13
       - name: Restore uv Python cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
@@ -96,7 +96,7 @@ jobs:
         with:
           # Pin to match .chezmoidata/bin/mise.toml. Without this, the
           # action falls back to a default that may be yanked from upstream.
-          version: 2026.7.7
+          version: 2026.7.13
       - name: Restore uv cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -1,6 +1,6 @@
 # mise version already includes "v" prefix — tag_format = "{version}" (no added v)
 [bin.mise]
-version = "v2026.7.7"
+version = "v2026.7.13"
 
 [bin.mise.github_releases]
 repo            = "jdx/mise"
@@ -18,10 +18,10 @@ linux_amd64  = "linux-x64"
 linux_arm64  = "linux-arm64"
 
 [bin.mise.github_releases.checksums]
-darwin_arm64 = "5b890cccc75fc43a494b83ace21dbd2ee26120ff19ba1994cdcd054b3a15abbd"
-darwin_amd64 = "7b860e6495eea9a264a16dae575ac20d5618ea2fe97905756c661eb02035c5d9"
-linux_amd64  = "429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c"
-linux_arm64  = "1b4ef061d25f0ceb508f11169482f3074e55c1698a1494f666386b2fcfb46b9b"
+darwin_arm64 = "80dad4a76db564540be56ebd19e76165e2425e0b45f6f7aca6ac2d5efa3a6161"
+darwin_amd64 = "62563fe6e4799c6e499db4a328632f63499ee864581c923a7bb45bd90e8827bd"
+linux_amd64  = "2dfb74b2e09d1f73a4cfa0c4db0332418e39d35940b48f501b3b4004b59a379c"
+linux_arm64  = "c002f9c3fd8ef7535afb5e20006cbdcc5f7e8144f7210057c241ec7e902743bc"
 
 [mise]
 

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -18,10 +18,10 @@ linux_amd64  = "linux-x64"
 linux_arm64  = "linux-arm64"
 
 [bin.mise.github_releases.checksums]
-darwin_arm64 = "80dad4a76db564540be56ebd19e76165e2425e0b45f6f7aca6ac2d5efa3a6161"
-darwin_amd64 = "62563fe6e4799c6e499db4a328632f63499ee864581c923a7bb45bd90e8827bd"
-linux_amd64  = "2dfb74b2e09d1f73a4cfa0c4db0332418e39d35940b48f501b3b4004b59a379c"
-linux_arm64  = "c002f9c3fd8ef7535afb5e20006cbdcc5f7e8144f7210057c241ec7e902743bc"
+darwin_arm64 = "ef747f4bd944d7cb4efe1832ec6cd29dfdbc217389122fa37c20d116d90c1eb6"
+darwin_amd64 = "3cd0f468c4c8ba1196d949441cb84eeaebb92b94666ef8caa17602c82421f420"
+linux_amd64  = "47878bc295922c5f7ba4b7054cc372ce6ae730a1f12b0753c1cda2f04376eee2"
+linux_arm64  = "f115d1f911b8eed1bdc9d889d94ff6fdaf892131d573b5678914b2bcf14b2965"
 
 [mise]
 


### PR DESCRIPTION
This PR updates `chezmoi` and `mise` to their respective latest stable versions due to security fixes, overriding the 7-day minimum release age rule.

- `chezmoi` is updated from `v2.71.0` to `v2.71.1` to include a security fix for a path traversal vulnerability.
- `mise` is updated from `2026.7.7` to `2026.7.13` to apply a patch that prevents silent bypasses of signature verification when `gpg` is not found, along with other improvements in version resolution and OCI features.

---
*PR created automatically by Jules for task [15761139419792702392](https://jules.google.com/task/15761139419792702392) started by @mkobit*