### PR TITLE
feat(ai-skills): add modern-java-patterns skill

### DIFF
--- a/docs/DESIGN-modern-java-patterns-skill.md
+++ b/docs/DESIGN-modern-java-patterns-skill.md
@@ -1,0 +1,78 @@
+# Modern java patterns skill design
+
+## Problem
+Java training data overrepresents imperative style.
+For/while loops with `continue`/`break`, deeply nested `if` chains, manual `instanceof`-and-cast, hand-rolled thread pools, and index-based collection access all dominate what coding models have seen.
+Modern JDK releases (17 through 25, all LTS) replaced most of these idioms with more concise, safer alternatives.
+Coding agents default to the imperative style anyway, even on codebases that target JDK 21 or 25.
+This skill exists to correct that default by giving agents a concrete map from imperative pattern to modern replacement, gated by the JDK version each replacement actually requires.
+
+## Non-goals
+No Spring Boot or other framework-specific guidance — this skill covers core JDK language and API features only.
+No coverage of JDK versions below 17.
+No recommendation of string templates.
+String templates were previewed in JDK 21 and JDK 22, then withdrawn before reaching general availability, and must not appear in this skill's guidance.
+
+## Scope
+Three LTS milestones only: JDK 17, JDK 21, JDK 25.
+Intermediate non-LTS releases (18 through 20, 22 through 24) are referenced only to note when a feature entered preview or reached general availability, since each LTS release inherits everything finalized in the non-LTS releases before it.
+Non-LTS releases are not adoption targets on their own.
+
+## Skill structure
+```
+src/ai/skills/modern-java-patterns/
+  SKILL.md                                          # short router: symptom -> feature -> min JDK -> reference file
+  references/jdk-milestones.md                      # version-safety table; explicit string-templates exclusion
+  references/streams-and-gatherers.md                # primary: loops/continue/break/nested-if -> Stream pipelines + Gatherers
+  references/pattern-matching-and-records.md         # records, sealed types, pattern matching for instanceof/switch
+  references/virtual-threads-and-structured-concurrency.md
+  references/sequenced-collections.md
+```
+This follows the existing heavy-reference skill pattern already used by upstream skills in this repo (for example the `javascript-typescript` plugin's `modern-javascript-patterns` and `nodejs-backend-patterns` skills, which each ship a `references/` subdirectory alongside a short `SKILL.md`).
+Nested paths deploy automatically: `.chezmoiexternals/ai-authored-skills.toml.tmpl` globs every file under a skill's directory and preserves relative paths, so `references/*.md` needs no template changes.
+
+## SKILL.md content
+Frontmatter `description` starts with "Use when..." and names concrete symptoms: manual `instanceof`/cast chains, null-check ladders, hand-rolled POJOs, manual `ExecutorService`/`Future` management, index-based first/last collection access, and loops accumulating state that a stream pipeline or gatherer could express directly.
+Body is a quick-reference table: symptom, modern feature, minimum stable JDK, which reference file to read.
+Streams-and-gatherers is listed first since it addresses the most common imperative pattern (loops and nested conditionals).
+An explicit boundary line states this skill does not cover Spring or other frameworks, and does not apply to codebases pinned below JDK 17.
+
+## Reference file contents
+
+### jdk-milestones.md
+A table with one row per feature area, columns for JDK 17 / 21 / 25 status (absent, preview, stable).
+Includes an explicit "do not use" row for string templates, with the reason (withdrawn, never GA).
+Exact JEP numbers get verified against openjdk.org/jeps during implementation rather than asserted from memory here.
+
+### streams-and-gatherers.md
+Stream pipeline basics (`map`/`filter`/`reduce`/`collect`, `Stream.toList()`) as the default replacement for imperative loops with `continue`/`break` and nested `if` filtering.
+Gatherers (`java.util.stream.Gatherers`) for the stateful cases plain streams cannot express: windowing (fixed and sliding), fold, scan, and similar custom intermediate operations that today get hand-rolled as loops with mutable accumulators.
+Gatherers reached general availability in JDK 24, which is stable under this skill's JDK 25 LTS milestone.
+One before/after example: a loop with a mutable accumulator and manual windowing logic, rewritten with `Gatherers.windowSliding` or an equivalent.
+
+### pattern-matching-and-records.md
+Records, sealed classes/interfaces, pattern matching for `instanceof`, pattern matching for `switch` including `case null` handling, record patterns.
+One before/after example: an `instanceof`-and-cast chain rewritten as a pattern-matched `switch` expression.
+
+### virtual-threads-and-structured-concurrency.md
+Virtual threads (stable in JDK 21), structured concurrency and scoped values (preview starting JDK 21, stable in JDK 25).
+One before/after example: manual `ExecutorService` plus `Future` plus `try`/`finally` shutdown, rewritten with `StructuredTaskScope`.
+
+### sequenced-collections.md
+`SequencedCollection`, `SequencedSet`, `SequencedMap`; `getFirst()`/`getLast()`/`reversed()`.
+One before/after example: index-based first/last element access rewritten using the sequenced-collection methods.
+
+## Deployment
+Add one entry to `src/chezmoi/.chezmoidata/ai/skills.toml` under `[ai.skills.authored]`:
+```toml
+modern-java-patterns = "present"
+```
+`"present"` deploys to every tool's skill directory (Claude, antigravity, cursor, codex), matching the existing authored skills.
+No changes needed to `.chezmoiexternals/ai-authored-skills.toml.tmpl` or any `.chezmoiremove.tmpl` file.
+Preview with `chezmoi diff`, apply with `chezmoi apply`.
+
+## Testing approach
+This is a recognition/pattern skill, not a discipline-enforcing rule skill, so the full adversarial pressure-scenario RED-GREEN-REFACTOR loop from the writing-skills process does not apply.
+Test as application scenarios instead: give a subagent an imperative Java snippet with no skill loaded and record the baseline (does it reach for the old idiom?).
+Then repeat with the skill available and verify it recognizes the modern replacement, cites the correct minimum JDK, and does not recommend string templates.
+Cover at least one scenario per reference file: a loop-with-accumulator case for streams-and-gatherers, an `instanceof`-chain case for pattern-matching-and-records, a manual-executor case for virtual-threads-and-structured-concurrency, and an index-based-access case for sequenced-collections.

--- a/docs/DESIGN-modern-java-patterns-skill.md
+++ b/docs/DESIGN-modern-java-patterns-skill.md
@@ -3,15 +3,16 @@
 ## Problem
 Java training data overrepresents imperative style.
 For/while loops with `continue`/`break`, deeply nested `if` chains, manual `instanceof`-and-cast, hand-rolled thread pools, and index-based collection access all dominate what coding models have seen.
-Modern JDK releases (17 through 25, all LTS) replaced most of these idioms with more concise, safer alternatives.
+Modern JDK releases, spanning the three LTS milestones 17/21/25, replaced most of these idioms with more concise, safer alternatives.
 Coding agents default to the imperative style anyway, even on codebases that target JDK 21 or 25.
 This skill exists to correct that default by giving agents a concrete map from imperative pattern to modern replacement, gated by the JDK version each replacement actually requires.
 
 ## Non-goals
-No Spring Boot or other framework-specific guidance — this skill covers core JDK language and API features only.
+No Spring Boot or other application framework guidance — this skill covers core JDK language/API features plus a small set of widely-used, non-framework immutability libraries (Guava, AutoValue), not full frameworks.
 No coverage of JDK versions below 17.
 No recommendation of string templates.
 String templates were previewed in JDK 21 and JDK 22, then withdrawn before reaching general availability, and must not appear in this skill's guidance.
+No firm recommendation of structured concurrency as if it were stable: it is still in preview as of JDK 25 (fifth preview, JEP 505; not expected to finalize before JDK 27). It stays in scope but is marked preview-only, distinctly from the stable virtual-threads content it sits alongside — see virtual-threads-and-structured-concurrency.md below.
 
 ## Scope
 Three LTS milestones only: JDK 17, JDK 21, JDK 25.
@@ -21,18 +22,20 @@ Non-LTS releases are not adoption targets on their own.
 ## Skill structure
 ```
 src/ai/skills/modern-java-patterns/
-  SKILL.md                                          # short router: symptom -> feature -> min JDK -> reference file
-  references/jdk-milestones.md                      # version-safety table; explicit string-templates exclusion
+  SKILL.md                                           # short router: symptom -> feature -> min JDK -> reference file
+  references/jdk-milestones.md                       # version-safety table; explicit string-templates exclusion
   references/streams-and-gatherers.md                # primary: loops/continue/break/nested-if -> Stream pipelines + Gatherers
   references/pattern-matching-and-records.md         # records, sealed types, pattern matching for instanceof/switch
+  references/immutability-and-value-types.md         # records + Guava Immutable* + AutoValue, favor-when-available
   references/virtual-threads-and-structured-concurrency.md
   references/sequenced-collections.md
 ```
-This follows the existing heavy-reference skill pattern already used by upstream skills in this repo (for example the `javascript-typescript` plugin's `modern-javascript-patterns` and `nodejs-backend-patterns` skills, which each ship a `references/` subdirectory alongside a short `SKILL.md`).
+This follows the existing heavy-reference skill pattern already deployed in this repo's own `skills.toml` — for example `wshobson-llm-finetuning`'s `lora-qlora-recipes` skill (`references/hyperparameters.md`, `references/unsloth-trl-mapping.md`) and `wshobson-llm-application-dev`'s `prompt-engineering-patterns` skill, both `"present"` today, ship a `references/` subdirectory alongside a short `SKILL.md`.
 Nested paths deploy automatically: `.chezmoiexternals/ai-authored-skills.toml.tmpl` globs every file under a skill's directory and preserves relative paths, so `references/*.md` needs no template changes.
+This is the first *authored* skill (as opposed to upstream-sourced) to use a nested `references/` directory — both existing authored skills (`technical-writing`, `write-agent-context`) are flat single files — so the implementer should confirm the nested paths in `chezmoi diff` output rather than assume it's proven by precedent.
 
 ## SKILL.md content
-Frontmatter `description` starts with "Use when..." and names concrete symptoms: manual `instanceof`/cast chains, null-check ladders, hand-rolled POJOs, manual `ExecutorService`/`Future` management, index-based first/last collection access, and loops accumulating state that a stream pipeline or gatherer could express directly.
+Frontmatter `description` follows this repo's own authored-skill convention rather than importing a generic external template: lead with a verb describing what the skill does, with "use when ..." as a trailing clause naming concrete symptoms (matches `write-agent-context`'s and `technical-writing`'s existing phrasing, not the "starts with Use when" template from the `writing-skills` skill). Symptoms named: manual `instanceof`/cast chains, null-check ladders, hand-rolled POJOs and defensive-copy/builder boilerplate, manual `ExecutorService`/`Future` management, index-based first/last collection access, and loops accumulating state that a stream pipeline or gatherer could express directly.
 Body is a quick-reference table: symptom, modern feature, minimum stable JDK, which reference file to read.
 Streams-and-gatherers is listed first since it addresses the most common imperative pattern (loops and nested conditionals).
 An explicit boundary line states this skill does not cover Spring or other frameworks, and does not apply to codebases pinned below JDK 17.
@@ -54,9 +57,19 @@ One before/after example: a loop with a mutable accumulator and manual windowing
 Records, sealed classes/interfaces, pattern matching for `instanceof`, pattern matching for `switch` including `case null` handling, record patterns.
 One before/after example: an `instanceof`-and-cast chain rewritten as a pattern-matched `switch` expression.
 
+### immutability-and-value-types.md
+Records as the default immutable value type (JDK-native, always available, stable since 17).
+When Guava is already a project dependency, favor its `ImmutableList`/`ImmutableMap`/`ImmutableSet` over `Collections.unmodifiableX()` or manual defensive copies.
+When AutoValue is already a project dependency, favor `@AutoValue` for value types that need generated builders or validation beyond what a plain record gives you.
+Both library recommendations are conditional on the library already being present — this file states the JDK-only fallback in the same breath as the library recommendation, never as a separate path to hunt for.
+This favor-when-available framing is scoped to this file only; other reference files stay JDK-only unless a future revision extends it deliberately.
+A small number of before/after examples (not exhaustive per library) given the emphasis on lean examples over coverage.
+
 ### virtual-threads-and-structured-concurrency.md
-Virtual threads (stable in JDK 21), structured concurrency and scoped values (preview starting JDK 21, stable in JDK 25).
-One before/after example: manual `ExecutorService` plus `Future` plus `try`/`finally` shutdown, rewritten with `StructuredTaskScope`.
+Virtual threads: stable since JDK 21, presented as the default concurrency recommendation without caveats.
+Structured concurrency and scoped values: scoped values are stable since JDK 25 (JEP 506); structured concurrency is still preview as of JDK 25 (fifth preview, JEP 505) despite being significantly more battle-tested in design and scope than a feature like string templates ever was.
+Structured concurrency content is visually and textually distinct from the stable virtual-threads content in the same file — marked preview, `--enable-preview`-required, and subject to API changes across previews (its shape has already changed between the JDK 21 and JDK 25 previews) — rather than presented with the same confidence as the stable material.
+One before/after example: manual `ExecutorService` plus `Future` plus `try`/`finally` shutdown, rewritten with virtual threads directly; structured concurrency shown as a preview-flagged extension of that same example, not a separate stable recommendation.
 
 ### sequenced-collections.md
 `SequencedCollection`, `SequencedSet`, `SequencedMap`; `getFirst()`/`getLast()`/`reversed()`.
@@ -75,4 +88,4 @@ Preview with `chezmoi diff`, apply with `chezmoi apply`.
 This is a recognition/pattern skill, not a discipline-enforcing rule skill, so the full adversarial pressure-scenario RED-GREEN-REFACTOR loop from the writing-skills process does not apply.
 Test as application scenarios instead: give a subagent an imperative Java snippet with no skill loaded and record the baseline (does it reach for the old idiom?).
 Then repeat with the skill available and verify it recognizes the modern replacement, cites the correct minimum JDK, and does not recommend string templates.
-Cover at least one scenario per reference file: a loop-with-accumulator case for streams-and-gatherers, an `instanceof`-chain case for pattern-matching-and-records, a manual-executor case for virtual-threads-and-structured-concurrency, and an index-based-access case for sequenced-collections.
+Cover at least one scenario per reference file: a loop-with-accumulator case for streams-and-gatherers, an `instanceof`-chain case for pattern-matching-and-records, a hand-rolled-builder or defensive-copy case for immutability-and-value-types (both with and without Guava/AutoValue on the classpath, to verify the fallback framing actually holds), a manual-executor case for virtual-threads-and-structured-concurrency (verify virtual-threads guidance stays unconditional while structured-concurrency guidance stays marked preview), and an index-based-access case for sequenced-collections.

--- a/src/ai/skills/modern-java-patterns/SKILL.md
+++ b/src/ai/skills/modern-java-patterns/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: modern-java-patterns
+description: Replaces verbose imperative Java — instanceof/cast chains, null-check ladders, hand-rolled POJOs and defensive copies, manual ExecutorService/Future management, index-based collection access, loops with mutable accumulators — with modern JDK 17/21/25 idioms and, when already a dependency, Guava/AutoValue. Use when writing or reviewing Java code targeting JDK 17 or newer; not for Spring or other framework conventions.
+---
+
+# Modern Java patterns
+
+Modern JDK releases, spanning the three LTS milestones 17, 21, and 25, replaced many imperative idioms with more concise, safer alternatives.
+This skill maps common imperative symptoms to their modern replacement, each gated by the minimum JDK version it actually requires.
+
+## Quick reference
+
+| Symptom | Modern feature | Min stable JDK | Reference |
+|---|---|---|---|
+| Loops with `continue`/`break`, nested `if` filtering, manual accumulation | Stream pipelines; Gatherers for stateful/windowed cases | 8 (streams); 25 (Gatherers, GA'd in 24) | [streams-and-gatherers.md](references/streams-and-gatherers.md) |
+| `instanceof`-and-cast chains, type-switch ladders | Sealed types + pattern matching for `instanceof`/`switch`, record patterns | 17 (`instanceof`); 21 (`switch`, record patterns) | [pattern-matching-and-records.md](references/pattern-matching-and-records.md) |
+| Hand-rolled POJOs, defensive copies, manual builders | Records; Guava `Immutable*`/`@AutoValue` when already a dependency | 17 | [immutability-and-value-types.md](references/immutability-and-value-types.md) |
+| Manual `ExecutorService`/`Future`/shutdown management | Virtual threads (stable); structured concurrency (preview) | 21 (virtual threads); still preview at 25 (structured concurrency) | [virtual-threads-and-structured-concurrency.md](references/virtual-threads-and-structured-concurrency.md) |
+| Index-based first/last element access, manual reversal | `SequencedCollection`/`SequencedMap` | 21 | [sequenced-collections.md](references/sequenced-collections.md) |
+
+See [jdk-milestones.md](references/jdk-milestones.md) for the full version-safety table, including features this skill explicitly excludes.
+
+## Boundaries
+
+Not for Spring Boot or other application frameworks — core JDK and the two named libraries (Guava, AutoValue) only.
+Not for codebases pinned below JDK 17.
+Never recommend string templates: previewed in JDK 21/22, withdrawn, never reached general availability.

--- a/src/ai/skills/modern-java-patterns/references/immutability-and-value-types.md
+++ b/src/ai/skills/modern-java-patterns/references/immutability-and-value-types.md
@@ -1,0 +1,50 @@
+# Immutability and value types
+
+Replace hand-rolled POJOs, manual defensive copies, and hand-rolled builders with immutable value types.
+Records are the default: JDK-native, finalized in JDK 16, stable at every JDK version this skill covers (17 and later).
+Guava and AutoValue are recommended only when already a project dependency — each note below states the JDK-only fallback in the same breath, so the guidance holds even when the library is absent.
+This favor-when-available framing is scoped to this file only.
+
+## Before/after: defensive copies
+
+Imperative, with a manual defensive copy on the way in and out:
+
+```java
+final class Config {
+    private final List<String> tags;
+    Config(List<String> tags) {
+        this.tags = new ArrayList<>(tags);
+    }
+    List<String> getTags() {
+        return Collections.unmodifiableList(tags);
+    }
+}
+```
+
+Modern, JDK 17+ (a record's canonical constructor normalizes the field once):
+
+```java
+record Config(List<String> tags) {
+    Config {
+        tags = List.copyOf(tags);
+    }
+}
+```
+
+## If Guava is already a dependency
+
+Prefer `ImmutableList.copyOf(tags)` (or `ImmutableMap`/`ImmutableSet`) over `List.copyOf(tags)` in the example above.
+If Guava is not a dependency, `List.copyOf()` (JDK 10+) is the no-dependency equivalent — do not add Guava solely for this.
+
+## If AutoValue is already a dependency
+
+Prefer `@AutoValue` over a hand-rolled builder for a value type that needs a generated builder (many optional fields) or shared validation across multiple construction paths.
+If AutoValue is not a dependency, use a record's canonical constructor for simple validation, or a plain nested builder class when many optional fields are unavoidable — do not add AutoValue solely for this.
+
+## Quick reference
+
+| Imperative shape | Replacement | Condition |
+|---|---|---|
+| Hand-rolled POJO with manual `equals`/`hashCode`/`toString` | Record | JDK 17+, always |
+| Manual defensive copy in and out | `List.copyOf()` / `ImmutableList.copyOf()` | JDK-only, or Guava if present |
+| Hand-rolled builder for many optional fields | `@AutoValue` builder | Only if AutoValue already a dependency |

--- a/src/ai/skills/modern-java-patterns/references/jdk-milestones.md
+++ b/src/ai/skills/modern-java-patterns/references/jdk-milestones.md
@@ -1,0 +1,33 @@
+# JDK version-safety table
+
+One row per feature area.
+Status is one of: not available, preview (requires `--enable-preview`, API not guaranteed stable), stable.
+
+| Feature | JDK 17 | JDK 21 | JDK 25 |
+|---|---|---|---|
+| Records (JEP 395) | Stable | Stable | Stable |
+| Sealed classes/interfaces (JEP 409) | Stable | Stable | Stable |
+| Pattern matching for `instanceof` (JEP 394) | Stable | Stable | Stable |
+| Pattern matching for `switch`, record patterns (JEP 441, JEP 440) | Not available | Stable | Stable |
+| Sequenced collections (JEP 431) | Not available | Stable | Stable |
+| Virtual threads (JEP 444) | Not available | Stable | Stable |
+| Stream Gatherers (JEP 485, GA'd in JDK 24) | Not available | Not available | Stable |
+| Scoped values (JEP 506) | Not available | Preview | Stable |
+| Structured concurrency (JEP 505, fifth preview) | Not available | Preview | Preview |
+| String templates (JEP 430, JEP 459) | Not available | Preview | Withdrawn |
+
+## Do not use: string templates
+
+String templates were previewed in JDK 21 (JEP 430) and JDK 22 (JEP 459).
+A third preview was planned for JDK 23 and then withdrawn before shipping.
+The feature never reached general availability and has not returned.
+Do not recommend string templates anywhere in this skill.
+Use `String.format`, `StringBuilder`, or text blocks instead.
+
+## Preview caution: structured concurrency
+
+Structured concurrency is still preview as of JDK 25 (JEP 505, its fifth preview).
+OpenJDK does not expect it to finalize before roughly JDK 27.
+Its API shape has already changed across previews — the JDK 21 preview's `ShutdownOnFailure`/`ShutdownOnSuccess` subclasses were replaced by `Joiner`-based construction in JEP 505.
+Any code sample using `StructuredTaskScope` must be marked preview and must not be presented with the same confidence as stable features like virtual threads.
+See `virtual-threads-and-structured-concurrency.md` for how this distinction is drawn in practice.

--- a/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
+++ b/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
@@ -41,6 +41,6 @@ String describe(Shape shape) {
 
 | Imperative shape | Replacement | Min JDK |
 |---|---|---|
-| `if (x instanceof T) { T t = (T) x; ... }` | `if (x instanceof T t) { ... }` | 16 |
+| `if (x instanceof T) { T t = (T) x; ... }` | `if (x instanceof T t) { ... }` | 17 |
 | `if (x == null) return ...;` inside a switch-like chain | `case null ->` in a pattern-matched `switch` | 21 |
 | Type-switch ladder over a closed set of subtypes | Sealed interface/class + pattern-matched `switch` | 21 (17 for sealed alone) |

--- a/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
+++ b/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
@@ -1,7 +1,7 @@
 # Pattern matching and records
 
 Replace `instanceof`-and-cast chains and type-switch ladders with sealed types and pattern matching.
-Records and pattern matching for `instanceof` have been stable since JDK 17.
+Records and pattern matching for `instanceof` were finalized in JDK 16, stable at every JDK version this skill covers (17 and later).
 Pattern matching for `switch` and record patterns have been stable since JDK 21, including `case null` handling that replaces a leading defensive null check.
 
 ## Before/after: instanceof-and-cast chain
@@ -41,6 +41,6 @@ String describe(Shape shape) {
 
 | Imperative shape | Replacement | Min JDK |
 |---|---|---|
-| `if (x instanceof T) { T t = (T) x; ... }` | `if (x instanceof T t) { ... }` | 17 |
+| `if (x instanceof T) { T t = (T) x; ... }` | `if (x instanceof T t) { ... }` | 16 |
 | `if (x == null) return ...;` inside a switch-like chain | `case null ->` in a pattern-matched `switch` | 21 |
 | Type-switch ladder over a closed set of subtypes | Sealed interface/class + pattern-matched `switch` | 21 (17 for sealed alone) |

--- a/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
+++ b/src/ai/skills/modern-java-patterns/references/pattern-matching-and-records.md
@@ -1,0 +1,46 @@
+# Pattern matching and records
+
+Replace `instanceof`-and-cast chains and type-switch ladders with sealed types and pattern matching.
+Records and pattern matching for `instanceof` have been stable since JDK 17.
+Pattern matching for `switch` and record patterns have been stable since JDK 21, including `case null` handling that replaces a leading defensive null check.
+
+## Before/after: instanceof-and-cast chain
+
+Imperative:
+
+```java
+String describe(Object shape) {
+    if (shape instanceof Circle) {
+        Circle c = (Circle) shape;
+        return "Circle radius=" + c.radius();
+    } else if (shape instanceof Rectangle) {
+        Rectangle r = (Rectangle) shape;
+        return "Rectangle " + r.width() + "x" + r.height();
+    } else {
+        return "Unknown shape";
+    }
+}
+```
+
+Modern, JDK 21+ (sealed types make the switch exhaustive, so there is no reachable "unknown shape" case):
+
+```java
+sealed interface Shape permits Circle, Rectangle {}
+record Circle(double radius) implements Shape {}
+record Rectangle(double width, double height) implements Shape {}
+
+String describe(Shape shape) {
+    return switch (shape) {
+        case Circle c -> "Circle radius=" + c.radius();
+        case Rectangle r -> "Rectangle " + r.width() + "x" + r.height();
+    };
+}
+```
+
+## Quick reference
+
+| Imperative shape | Replacement | Min JDK |
+|---|---|---|
+| `if (x instanceof T) { T t = (T) x; ... }` | `if (x instanceof T t) { ... }` | 17 |
+| `if (x == null) return ...;` inside a switch-like chain | `case null ->` in a pattern-matched `switch` | 21 |
+| Type-switch ladder over a closed set of subtypes | Sealed interface/class + pattern-matched `switch` | 21 (17 for sealed alone) |

--- a/src/ai/skills/modern-java-patterns/references/sequenced-collections.md
+++ b/src/ai/skills/modern-java-patterns/references/sequenced-collections.md
@@ -1,0 +1,33 @@
+# Sequenced collections
+
+Replace index-based first/last element access and manual reversal with the sequenced-collection methods.
+`SequencedCollection`, `SequencedSet`, and `SequencedMap` have been stable since JDK 21.
+
+## Before/after: first/last access and reversal
+
+Imperative:
+
+```java
+String first = list.isEmpty() ? null : list.get(0);
+String last = list.isEmpty() ? null : list.get(list.size() - 1);
+List<String> reversed = new ArrayList<>(list);
+Collections.reverse(reversed);
+```
+
+Modern, JDK 21+:
+
+```java
+String first = list.isEmpty() ? null : list.getFirst();
+String last = list.isEmpty() ? null : list.getLast();
+List<String> reversed = list.reversed();
+```
+
+`reversed()` returns a view backed by the original collection, not a copy.
+Mutating the view mutates the original, and vice versa — this is a correctness difference from `Collections.reverse`, not just a syntax change.
+
+## Quick reference
+
+| Imperative shape | Replacement | Min JDK |
+|---|---|---|
+| `list.get(0)` / `list.get(size - 1)` | `list.getFirst()` / `list.getLast()` | 21 |
+| Manual `Collections.reverse` into a copy | `list.reversed()` (a view, not a copy) | 21 |

--- a/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
+++ b/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
@@ -1,7 +1,7 @@
 # Streams and gatherers
 
 Replace imperative loops — `continue`/`break`, nested `if` filtering, manual accumulation into a mutable list — with a stream pipeline.
-Stream basics (`map`/`filter`/`reduce`/`collect`, `Stream.toList()`) have been stable since JDK 8 and apply at every milestone in this skill's scope.
+Stream basics (`map`/`filter`/`reduce`/`collect`) have been stable since JDK 8; `Stream.toList()` is a later convenience, stable since JDK 16. Both apply at every milestone in this skill's scope.
 For stateful operations a plain stream cannot express — windowing, fold, scan — use a Gatherer.
 Gatherers (`java.util.stream.Gatherers`) reached general availability in JDK 24 (JEP 485), which is stable under this skill's JDK 25 LTS milestone.
 
@@ -33,6 +33,6 @@ List<Double> movingAverages = readings.stream()
 
 | Imperative shape | Stream/Gatherer replacement | Min JDK |
 |---|---|---|
-| Nested `if` filtering into a mutable list | `.filter(...).map(...).toList()` | 8 |
+| Nested `if` filtering into a mutable list | `.filter(...).map(...).toList()` | 16 (`.filter`/`.map` are JDK 8; `.toList()` is JDK 16) |
 | Manual sliding/fixed window accumulation | `Gatherers.windowSliding` / `Gatherers.windowFixed` | 24 (stable at 25) |
 | Manual running-total accumulation | `Gatherers.fold` | 24 (stable at 25) |

--- a/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
+++ b/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
@@ -1,0 +1,38 @@
+# Streams and gatherers
+
+Replace imperative loops — `continue`/`break`, nested `if` filtering, manual accumulation into a mutable list — with a stream pipeline.
+Stream basics (`map`/`filter`/`reduce`/`collect`, `Stream.toList()`) have been stable since JDK 8 and apply at every milestone in this skill's scope.
+For stateful operations a plain stream cannot express — windowing, fold, scan — use a Gatherer.
+Gatherers (`java.util.stream.Gatherers`) reached general availability in JDK 24 (JEP 485), which is stable under this skill's JDK 25 LTS milestone.
+
+## Before/after: manual windowing
+
+Imperative, with a hand-rolled accumulator and nested loop:
+
+```java
+List<Double> movingAverages = new ArrayList<>();
+for (int i = 0; i <= readings.size() - windowSize; i++) {
+    double sum = 0;
+    for (int j = i; j < i + windowSize; j++) {
+        sum += readings.get(j);
+    }
+    movingAverages.add(sum / windowSize);
+}
+```
+
+Modern, JDK 25 (Gatherers stable; needs JDK 24+):
+
+```java
+List<Double> movingAverages = readings.stream()
+    .gather(Gatherers.windowSliding(windowSize))
+    .map(window -> window.stream().mapToDouble(Double::doubleValue).average().orElseThrow())
+    .toList();
+```
+
+## Quick reference
+
+| Imperative shape | Stream/Gatherer replacement | Min JDK |
+|---|---|---|
+| Nested `if` filtering into a mutable list | `.filter(...).map(...).toList()` | 8 |
+| Manual sliding/fixed window accumulation | `Gatherers.windowSliding` / `Gatherers.windowFixed` | 24 (stable at 25) |
+| Manual running-total accumulation | `Gatherers.fold` | 24 (stable at 25) |

--- a/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
+++ b/src/ai/skills/modern-java-patterns/references/streams-and-gatherers.md
@@ -1,7 +1,9 @@
 # Streams and gatherers
 
 Replace imperative loops — `continue`/`break`, nested `if` filtering, manual accumulation into a mutable list — with a stream pipeline.
-Stream basics (`map`/`filter`/`reduce`/`collect`) have been stable since JDK 8; `Stream.toList()` is a later convenience, stable since JDK 16. Both apply at every milestone in this skill's scope.
+Stream basics (`map`/`filter`/`reduce`/`collect`) have been stable since JDK 8.
+`Stream.toList()` is a later convenience, stable since JDK 16.
+Both apply at every milestone in this skill's scope.
 For stateful operations a plain stream cannot express — windowing, fold, scan — use a Gatherer.
 Gatherers (`java.util.stream.Gatherers`) reached general availability in JDK 24 (JEP 485), which is stable under this skill's JDK 25 LTS milestone.
 

--- a/src/ai/skills/modern-java-patterns/references/virtual-threads-and-structured-concurrency.md
+++ b/src/ai/skills/modern-java-patterns/references/virtual-threads-and-structured-concurrency.md
@@ -1,0 +1,66 @@
+# Virtual threads and structured concurrency
+
+Replace manual `ExecutorService`/`Future`/shutdown management with virtual threads.
+Virtual threads have been stable since JDK 21 — present them as the default concurrency recommendation without caveats.
+Structured concurrency is still preview as of JDK 25 (JEP 505, fifth preview; not expected to finalize before roughly JDK 27), despite being far more battle-tested in design and scope than a withdrawn feature like string templates ever was.
+Every structured-concurrency code sample below is explicitly marked PREVIEW and kept visually separate from the stable virtual-threads material — do not present it with the same confidence.
+
+## Before/after: manual executor management
+
+Imperative:
+
+```java
+ExecutorService executor = Executors.newFixedThreadPool(10);
+try {
+    List<Future<String>> futures = new ArrayList<>();
+    for (Request request : requests) {
+        futures.add(executor.submit(() -> handle(request)));
+    }
+    List<String> results = new ArrayList<>();
+    for (Future<String> future : futures) {
+        results.add(future.get());
+    }
+    return results;
+} finally {
+    executor.shutdown();
+}
+```
+
+Modern, JDK 21+ (virtual threads, stable, no preview flag):
+
+```java
+try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    List<Future<String>> futures = requests.stream()
+        .map(request -> executor.submit(() -> handle(request)))
+        .toList();
+    List<String> results = new ArrayList<>();
+    for (Future<String> future : futures) {
+        results.add(future.get());
+    }
+    return results;
+}
+```
+
+### PREVIEW — structured concurrency (JDK 21–25, requires `--enable-preview`)
+
+This is not a stable recommendation.
+It is shown so the shape is recognizable, not so it gets applied by default.
+The API differs from the JDK 21 preview: JEP 505 replaced the `ShutdownOnFailure`/`ShutdownOnSuccess` subclasses with `Joiner`-based construction, so JDK 21 preview syntax does not carry over unchanged to JDK 25.
+
+```java
+// PREVIEW: requires --enable-preview; API shape not final, JEP 505 as of JDK 25
+try (var scope = StructuredTaskScope.open(Joiner.<String>awaitAll())) {
+    List<Subtask<String>> subtasks = requests.stream()
+        .map(request -> scope.fork(() -> handle(request)))
+        .toList();
+    scope.join();
+    return subtasks.stream().map(Subtask::get).toList();
+}
+```
+
+## Quick reference
+
+| Imperative shape | Replacement | Status | Min JDK |
+|---|---|---|---|
+| Manual `ExecutorService` sizing/pooling | `Executors.newVirtualThreadPerTaskExecutor()` | Stable | 21 |
+| Manual `Future` fan-out/fan-in with shared shutdown/error handling | `StructuredTaskScope` | Preview, `--enable-preview` required | 21 (shape changed by 25) |

--- a/src/ai/skills/modern-java-patterns/references/virtual-threads-and-structured-concurrency.md
+++ b/src/ai/skills/modern-java-patterns/references/virtual-threads-and-structured-concurrency.md
@@ -63,4 +63,4 @@ try (var scope = StructuredTaskScope.open(Joiner.<String>awaitAll())) {
 | Imperative shape | Replacement | Status | Min JDK |
 |---|---|---|---|
 | Manual `ExecutorService` sizing/pooling | `Executors.newVirtualThreadPerTaskExecutor()` | Stable | 21 |
-| Manual `Future` fan-out/fan-in with shared shutdown/error handling | `StructuredTaskScope` | Preview, `--enable-preview` required | 21 (shape changed by 25) |
+| Manual `Future` fan-out/fan-in with shared shutdown/error handling | `StructuredTaskScope` | PREVIEW, `--enable-preview` required | 21 (shape changed by 25) |

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -24,6 +24,7 @@ url_format = "https://codeload.github.com/{repo}/tar.gz/{ref}"
 # deployed via file:// externals (see .chezmoiexternals/ai-authored-skills.toml.tmpl).
 [ai.skills.authored]
 example_skill = "absent"
+modern-java-patterns = "present"
 pr-reviewer = "absent" # source deleted 2026-06-11; replaced by superpowers requesting/receiving-code-review
 technical-writing = "present"
 typescript-expert = "absent" # source deleted 2026-06-11; find a publicly maintained replacement


### PR DESCRIPTION
## Summary
- Adds a new authored skill, `modern-java-patterns` (`src/ai/skills/modern-java-patterns/`): a `SKILL.md` router plus six `references/*.md` files teaching agents to replace verbose imperative Java (loops, instanceof/cast chains, hand-rolled POJOs, manual executor management, index-based collection access) with modern JDK 17/21/25 idioms — streams/Gatherers, pattern matching/records, immutability (records + Guava/AutoValue when already a dependency), virtual threads/structured concurrency, and sequenced collections.
- Deploys it via the existing generic authored-skill mechanism: one line under `[ai.skills.authored]` in `src/chezmoi/.chezmoidata/ai/skills.toml`.
- Design spec at `docs/DESIGN-modern-java-patterns-skill.md`, itself already through an adversarial review before implementation.

## Process notes
- Built task-by-task via subagent-driven development; several per-task reviews caught and fixed real factual JDK-version errors before they shipped (e.g. `Stream.toList()` is JDK 16 not JDK 8; records/pattern-matching-for-`instanceof` finalized JDK 16 not 17) — all independently verified against OpenJDK/Oracle sources, not just asserted.
- String templates are explicitly excluded (previewed JDK 21/22, withdrawn, never GA). Structured concurrency is kept in scope but marked preview-only (still preview as of JDK 25, JEP 505) and visually distinct from the stable virtual-threads content in the same file.
- Final whole-branch review (opus): verdict "ready to merge." Recommended squash-merge since several commits are pure fixups to content that never shipped anywhere — use the squash-merge option on this PR.

## Test plan
- [x] `uv run pytest tests/integration/test_ai_skills.py -v` — 5/5 passing (validates the skill deploys correctly to all tool skill directories)
- [x] `chezmoi diff` / `chezmoi apply` run live on this machine — skill deployed and verified present under `.claude/skills/`, `.gemini/antigravity-cli/skills/`, `.cursor/skills/`, `.codex/skills/`
- [x] 7 application-scenario validations (subagent given imperative Java snippets, with/without the skill) — all matched expected modern-idiom recognition, correct min-JDK citation, and correctly avoided string templates / correctly flagged structured concurrency as preview
- [ ] Full suite has 4 pre-existing failures unrelated to this change (`jules`/`termbud`/`transcribe`/`statusline` PATH resolution) — not introduced by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)