### PR TITLE
feat(chezmoi): git-core PPA, at/atd, version-gated git hooks

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -70,6 +70,18 @@ installation_method = "github_releases"
 [data.local.bin.betterleaks]
 installation_method = "github_releases"
 
+# Git hooks backend (config vs hookspath) — see dot_dotfiles/git/AGENTS.md.
+{{- $gitHooksBackend := "hookspath" -}}
+{{- if lookPath "git" -}}
+{{-   $gitVersion := output "git" "--version" | trim | trimPrefix "git version " | splitList " " | first -}}
+{{-   if semverCompare ">=2.54.0" $gitVersion -}}
+{{-     $gitHooksBackend = "config" -}}
+{{-   end -}}
+{{- end }}
+
+[data.git_hooks]
+backend = {{ $gitHooksBackend | quote }}
+
 # Git hooks, gated on the betterleaks binary above ("chezmoi" / "none").
 [data.git_hooks.pre_commit]
 installation_method = "chezmoi"
@@ -183,12 +195,14 @@ installation_method = "chezmoi"
 # Secrets — prompted once at chezmoi init, exported to the shell (see
 # .chezmoitemplates/shell/secrets.sh via zsh.config_fragments."15-secrets" in
 # .chezmoidata/zsh.toml), never written into any git-tracked file. Blank
-# answer = not exported, harmless no-op. Skipped entirely in CI —
-# promptStringOnce has long-standing upstream bugs falling back to its
-# default under --promptString/non-interactive use, so CI never calls it.
+# answer = not exported, harmless no-op. Skipped in CI (no TTY, no cached
+# answer on ephemeral runners).
+#
+# promptStringOnce's path arg is a dotted lookup into nested data, not a flat
+# key — must match where the value lands below ("secrets.stitch_api_key").
 {{- $stitchApiKey := "" -}}
 {{- if not (env "CI") -}}
-{{-   $stitchApiKey = promptStringOnce . "stitch_api_key" "Stitch API key, exported as $STITCH_API_KEY for use in any project's .mcp.json (blank to skip — stitch.withgoogle.com → Settings → API key)" "" -}}
+{{-   $stitchApiKey = promptStringOnce . "secrets.stitch_api_key" "Stitch API key, exported as $STITCH_API_KEY for use in any project's .mcp.json (blank to skip — stitch.withgoogle.com → Settings → API key)" "" -}}
 {{- end }}
 [data.secrets]
 stitch_api_key = {{ $stitchApiKey | quote }}

--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -137,6 +137,16 @@ installation_method = {{ if eq .chezmoi.os "linux" }}"apt"{{ else }}"none"{{ end
 [data.packages.socat]
 installation_method = {{ if eq .chezmoi.os "linux" }}"apt"{{ else }}"none"{{ end }}
 
+# git-core PPA (see .chezmoidata/packages/git.toml) tracks current upstream
+# stable; macOS keeps its Xcode/Homebrew git untouched — overlay never sets
+# this, so it stays "none" there.
+[data.packages.git]
+installation_method = {{ if eq .chezmoi.os "linux" }}"apt"{{ else }}"none"{{ end }}
+
+# `at`/`atq`/`atrm` job scheduling — Linux only, no macOS equivalent.
+[data.packages.at]
+installation_method = {{ if eq .chezmoi.os "linux" }}"apt"{{ else }}"none"{{ end }}
+
 # Local Python Tools (via uv) Installation Methods
 [data.local_bin_tools.termstatus]
 installation_method = "dotfiles.uv"

--- a/src/chezmoi/.chezmoidata/packages/at.toml
+++ b/src/chezmoi/.chezmoidata/packages/at.toml
@@ -1,0 +1,6 @@
+[packages.at.package.apt]
+name = "at"
+
+# atd must be enabled + running for `at`/`atq`/`atrm` to actually execute queued jobs.
+[packages.at.systemd]
+service = "atd"

--- a/src/chezmoi/.chezmoidata/packages/git.toml
+++ b/src/chezmoi/.chezmoidata/packages/git.toml
@@ -1,0 +1,6 @@
+# Ubuntu's archive git lags upstream stable by a year or more. git-core PPA
+# is maintained by the Git project's own Debian/Ubuntu packagers and tracks
+# current stable: https://launchpad.net/~git-core/+archive/ubuntu/ppa
+[packages.git.package.apt]
+name = "git"
+ppa  = "ppa:git-core/ppa"

--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
@@ -19,11 +19,41 @@ if ! check_command apt-get; then
     exit 1
 fi
 
+{{- $ppaPkgs := list -}}
+{{- range $aptPkgs -}}
+{{-   $tool := index $.packages . -}}
+{{-   $pkg  := dig "package" "apt" (dict) $tool -}}
+{{-   if dig "ppa" "" $pkg -}}
+{{-     $ppaPkgs = append $ppaPkgs . -}}
+{{-   end -}}
+{{- end -}}
+
+{{- if $ppaPkgs }}
+if ! check_command add-apt-repository; then
+    log_info "Installing software-properties-common for add-apt-repository..."
+    sudo apt-get install -y software-properties-common \
+        || { log_error "Failed to install software-properties-common"; exit 1; }
+fi
+{{- end }}
+
 {{- range $aptPkgs }}
 {{-   $tool := index $.packages . }}
 {{-   $pkg := dig "package" "apt" (dict) $tool }}
 {{-   $name := dig "name" . $pkg }}
+{{-   $ppa := dig "ppa" "" $pkg }}
+{{-   $service := dig "systemd" "service" "" $tool }}
 
+{{- if $ppa }}
+log_info "Adding apt repository {{ $ppa }} for {{ $name }}..."
+sudo add-apt-repository -y --no-update {{ $ppa | quote }} \
+    || { log_error "Failed to add repository {{ $ppa }} for {{ $name }}"; exit 1; }
+sudo apt-get update
+
+log_info "Installing {{ $name }} via apt (from {{ $ppa }})..."
+sudo apt-get install -y {{ $name }} \
+    || { log_error "Failed to install {{ $name }} via apt"; exit 1; }
+log_success "{{ $name }} installed"
+{{- else }}
 if dpkg -l {{ $name }} 2>/dev/null | grep -q "^ii"; then
     log_success "{{ $name }} already installed via apt"
 else
@@ -32,6 +62,18 @@ else
         || { log_error "Failed to install {{ $name }} via apt"; exit 1; }
     log_success "{{ $name }} installed"
 fi
+{{- end }}
+
+{{- if $service }}
+if check_command systemctl; then
+    log_info "Enabling {{ $service }} service..."
+    sudo systemctl enable --now {{ $service }} \
+        || { log_error "Failed to enable {{ $service }} service"; exit 1; }
+    log_success "{{ $service }} enabled and started"
+else
+    log_warn "systemctl not found — skipping {{ $service }} service enable"
+fi
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
@@ -30,7 +30,7 @@ fi
 
 {{- if $ppaPkgs }}
 if ! check_command add-apt-repository; then
-    log_info "Installing software-properties-common for add-apt-repository..."
+    log_info "🔒 Installing software-properties-common for add-apt-repository..."
     sudo apt-get install -y software-properties-common \
         || { log_error "Failed to install software-properties-common"; exit 1; }
 fi
@@ -44,12 +44,12 @@ fi
 {{-   $service := dig "systemd" "service" "" $tool }}
 
 {{- if $ppa }}
-log_info "Adding apt repository {{ $ppa }} for {{ $name }}..."
+log_info "🔒 Adding apt repository {{ $ppa }} for {{ $name }}..."
 sudo add-apt-repository -y --no-update {{ $ppa | quote }} \
     || { log_error "Failed to add repository {{ $ppa }} for {{ $name }}"; exit 1; }
 sudo apt-get update
 
-log_info "Installing {{ $name }} via apt (from {{ $ppa }})..."
+log_info "🔒 Installing {{ $name }} via apt (from {{ $ppa }})..."
 sudo apt-get install -y {{ $name }} \
     || { log_error "Failed to install {{ $name }} via apt"; exit 1; }
 log_success "{{ $name }} installed"
@@ -57,7 +57,7 @@ log_success "{{ $name }} installed"
 if dpkg -l {{ $name }} 2>/dev/null | grep -q "^ii"; then
     log_success "{{ $name }} already installed via apt"
 else
-    log_info "Installing {{ $name }} via apt..."
+    log_info "🔒 Installing {{ $name }} via apt..."
     sudo apt-get install -y {{ $name }} \
         || { log_error "Failed to install {{ $name }} via apt"; exit 1; }
     log_success "{{ $name }} installed"
@@ -66,7 +66,7 @@ fi
 
 {{- if $service }}
 if check_command systemctl; then
-    log_info "Enabling {{ $service }} service..."
+    log_info "🔒 Enabling {{ $service }} service..."
     sudo systemctl enable --now {{ $service }} \
         || { log_error "Failed to enable {{ $service }} service"; exit 1; }
     log_success "{{ $service }} enabled and started"

--- a/src/chezmoi/dot_dotfiles/git/AGENTS.md
+++ b/src/chezmoi/dot_dotfiles/git/AGENTS.md
@@ -1,0 +1,10 @@
+# Git config (this directory)
+
+Pre-commit secret scanning wires through `.git_hooks.backend`, computed in `.chezmoi.toml.tmpl` from the installed git version.
+Git >=2.54 uses native config-based hooks (`[hook "name"]`, event/command keys).
+Older git falls back to `core.hooksPath`.
+
+Both point at the same script, `hooks/pre-commit`.
+Only `snippets/hooks.gitconfig.tmpl` branches between the two backends — the hook script itself doesn't change.
+
+The hook renders empty (chezmoi removes it) unless `git_hooks.pre_commit.installation_method` is `chezmoi` and the `betterleaks` binary is installed.

--- a/src/chezmoi/dot_dotfiles/git/hooks/executable_pre-commit.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/hooks/executable_pre-commit.tmpl
@@ -1,8 +1,6 @@
-{{- /* Deployed to <destDir>/.dotfiles/git/hooks/pre-commit and wired via
-       core.hooksPath (snippets/hooks.gitconfig, mkobit remotes only). Two knobs:
-       the git_hooks.pre_commit BOM enables the hook, and it depends on the
-       betterleaks binary being installed. Renders empty (→ chezmoi removes the
-       file) unless both hold. */ -}}
+{{- /* Wired via snippets/hooks.gitconfig; see dot_dotfiles/git/AGENTS.md.
+       Renders empty unless git_hooks.pre_commit is enabled and betterleaks
+       is installed. */ -}}
 {{- $binOn  := ne (dig "betterleaks" "installation_method" "none" (dig "local" "bin" (dict) .)) "none" -}}
 {{- $hookOn := eq (dig "pre_commit"  "installation_method" "none" (dig "git_hooks" (dict) .)) "chezmoi" -}}
 {{- if and $binOn $hookOn -}}

--- a/src/chezmoi/dot_dotfiles/git/snippets/hooks.gitconfig.tmpl
+++ b/src/chezmoi/dot_dotfiles/git/snippets/hooks.gitconfig.tmpl
@@ -1,13 +1,18 @@
-{{- /* Renders core.hooksPath only when the pre_commit hook is enabled AND the
-       betterleaks binary is installed. Empty otherwise → chezmoi removes the
-       target and the includeIf in config.tmpl points at a missing file (a
-       no-op). */ -}}
+{{- /* Wires pre-commit when enabled + betterleaks is installed; empty
+       otherwise (chezmoi removes the target). See dot_dotfiles/git/AGENTS.md
+       for the backend choice below. */ -}}
 {{- $binOn  := ne (dig "betterleaks" "installation_method" "none" (dig "local" "bin" (dict) .)) "none" -}}
 {{- $hookOn := eq (dig "pre_commit"  "installation_method" "none" (dig "git_hooks" (dict) .)) "chezmoi" -}}
 {{- if and $binOn $hookOn -}}
+{{-   if eq (dig "backend" "hookspath" (dig "git_hooks" (dict) .)) "config" -}}
+[hook "betterleaks-pre-commit"]
+	event = pre-commit
+	command = {{ .chezmoi.destDir }}/.dotfiles/git/hooks/pre-commit
+{{-   else -}}
 [core]
 	# Documentation: https://git-scm.com/docs/githooks
 	# NOTE: core.hooksPath is singular — this supersedes per-repo .git/hooks in
 	# matched (mkobit) repos. Add any other hooks to this dir, not .git/hooks.
 	hooksPath = {{ .chezmoi.destDir }}/.dotfiles/git/hooks
+{{-   end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary
- Adds git-core PPA (`ppa:git-core/ppa`) as an apt-backed BOM package, gated Linux-only — Ubuntu's archive git lags upstream by a year+, this tracks current stable
- Adds `at`/`atq`/`atrm` via a generic `systemd.service` field that enables + starts `atd` after install
- Extends the apt install script to support the `ppa` field: adds the repo and always re-runs `apt-get install` (skipping the usual dpkg-already-installed shortcut), since the package may already be present from the base archive
- Marks sudo-requiring apt script log lines with 🔒
- Version-gates git hooks wiring on the installed git version: git ≥2.54 uses native config-based hooks (`[hook "name"]`), older git falls back to `core.hooksPath` — same pre-commit script either way, only the wiring changes. Documented in new `src/chezmoi/dot_dotfiles/git/AGENTS.md`
- Fixes `promptStringOnce`'s self-cache never hitting for `stitch_api_key`: the path argument was the flat key `"stitch_api_key"`, but the answer is written to `[data.secrets]` (nested). Every `chezmoi init` was silently re-prompting instead of reusing the cached answer

## Test plan
- [x] `chezmoi apply` run locally: git upgraded 2.43.0 → 2.54.0 via PPA, `at`/`atd` installed and active
- [x] `chezmoi execute-template` verified rendering for both git-hooks backends (config + hookspath)
- [x] `shellcheck` clean on all rendered scripts
- [x] `chezmoi init` re-run confirms `stitch_api_key` reuses the cached value (no re-prompt)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)