### PR TITLE
feat(termstatus): regroup usage metrics, chip-style rows, drop nested…

### DIFF
--- a/src/python/termstatus/termstatus/main.py
+++ b/src/python/termstatus/termstatus/main.py
@@ -24,7 +24,6 @@ from termstatus.segments.chezmoi import detect_chezmoi_root, generate_chezmoi_se
 from termstatus.segments.claude import (
     format_context_usage,
     format_cost,
-    format_lines_impact,
     format_model_info,
     format_session_info,
 )
@@ -285,7 +284,6 @@ def claude_render(  # noqa: C901
             format_obsidian_vault(cwd),
             format_context_usage(payload.context_window),
             format_cost(payload),
-            format_lines_impact(payload),
         ]
         for result_list in internal_results_nested:
             all_segments = all_segments + result_list

--- a/src/python/termstatus/termstatus/main.py
+++ b/src/python/termstatus/termstatus/main.py
@@ -3,31 +3,35 @@ import json
 import logging
 import os
 import shlex
+import subprocess
 import sys
+import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Annotated
 
 import typer
 from pydantic import TypeAdapter, ValidationError
+from rich.console import Console
+from rich.text import Text
 from whenever import Instant
 
 from termstatus.cache import SegmentCache
 from termstatus.layout import Segment, SegmentGenerationResult
-from termstatus.payload import StatusLineStdIn
+from termstatus.payload import CostInfo, ModelInfo, OutputStyle, StatusLineStdIn
 from termstatus.payloads.antigravity import AntigravityPayload
 from termstatus.render import probe_terminal_width, render_lines
 from termstatus.segments.antigravity import format_agent_state, format_vcs_info, format_workspace_info, generate_title
 from termstatus.segments.antigravity import format_context_usage as ag_format_context_usage
 from termstatus.segments.antigravity import format_model_info as ag_format_model_info
-from termstatus.segments.chezmoi import detect_chezmoi_root, generate_chezmoi_segment
+from termstatus.segments.chezmoi import _format_repo, detect_chezmoi_root, generate_chezmoi_segment
 from termstatus.segments.claude import (
     format_context_usage,
     format_cost,
     format_model_info,
     format_session_info,
 )
-from termstatus.segments.git import generate_git_segment
+from termstatus.segments.git import GitInfo, generate_git_segment
 from termstatus.segments.workspace import format_directory, format_obsidian_vault
 
 logging.basicConfig(level=logging.WARNING, stream=sys.stderr, format="%(levelname)s: %(message)s")
@@ -294,6 +298,110 @@ def claude_render(  # noqa: C901
 
     for line in lines:
         print(line)
+
+
+dev_app = typer.Typer()
+cli.add_typer(dev_app, name="dev")
+
+
+def _mock_payload(cost_usd: float = 42.50, duration_ms: int = 3_723_000, used_pct: float = 47.0) -> StatusLineStdIn:
+    return StatusLineStdIn(
+        model=ModelInfo(display_name="Sonnet 5"),
+        cost=CostInfo(total_cost_usd=cost_usd, total_duration_ms=duration_ms),
+        context_window={
+            "total_input_tokens": int(1_000_000 * used_pct / 100),
+            "context_window_size": 1_000_000,
+            "used_percentage": used_pct,
+        },
+        output_style=OutputStyle(name="concise"),
+    )
+
+
+def _mock_git_info(branch: str = "main", **overrides) -> GitInfo:
+    defaults = {
+        "branch": branch,
+        "remote": "https://github.com/example/repo",
+        "dirty": False,
+        "staged": False,
+        "untracked": False,
+        "ahead": 0,
+        "behind": 0,
+        "is_repo": True,
+        "stash_count": 0,
+    }
+    defaults.update(overrides)
+    return GitInfo(**defaults)
+
+
+def _build_scenario(name: str) -> list[SegmentGenerationResult]:
+    payload = _mock_payload()
+    common = [
+        *format_model_info(payload),
+        *format_directory(Path("/Users/example/project")),
+        *format_session_info(payload),
+        *format_cost(payload),
+        *format_context_usage(payload.context_window),
+    ]
+
+    if name == "single-repo":
+        return [*common, *_format_repo("", _mock_git_info(), line=2)]
+
+    if name == "dual-repo":
+        overlay = _mock_git_info("main", ahead=1)
+        base = _mock_git_info("feature/dashboard", dirty=True, staged=True)
+        return [*common, *_format_repo("overlay", overlay, line=2), *_format_repo("base", base, line=3)]
+
+    if name == "long-branch":
+        overlay = _mock_git_info("main")
+        base = _mock_git_info("feature/a-very-long-branch-name-that-needs-truncating", dirty=True)
+        return [*common, *_format_repo("overlay", overlay, line=2), *_format_repo("base", base, line=3)]
+
+    if name == "dirty":
+        info = _mock_git_info("main", dirty=True, staged=True, untracked=True, ahead=3, behind=1, stash_count=2)
+        return [*common, *_format_repo("", info, line=2)]
+
+    raise typer.BadParameter(f"Unknown scenario {name!r}. Choices: single-repo, dual-repo, long-branch, dirty")
+
+
+@dev_app.command("preview")
+def dev_preview(
+    scenario: Annotated[str, typer.Argument(help="single-repo | dual-repo | long-branch | dirty")],
+    width: Annotated[int | None, typer.Option(help="Force a terminal width instead of probing it.")] = None,
+    image: Annotated[
+        bool, typer.Option("--image", help="Also render a PNG (via qlmanage) and print its path.")
+    ] = False,
+) -> None:
+    """Render a canonical mock scenario directly -- no live git calls, no Claude Code
+    session needed. Point of this command: iterating on rendering shouldn't require
+    hand-writing a JSON payload and a subprocess pipeline every time.
+    """
+    segments = _build_scenario(scenario)
+    lines = render_lines(None, None, segments, terminal_width=width)
+    for line in lines:
+        print(line)
+
+    if not image:
+        return
+
+    with Path(os.devnull).open("w") as devnull:
+        console = Console(record=True, color_system="truecolor", width=width or 120, file=devnull)
+        for line in lines:
+            console.print(Text.from_ansi(line, no_wrap=True))
+
+    svg_path = Path(tempfile.gettempdir()) / f"termstatus-preview-{scenario}.svg"
+    console.save_svg(str(svg_path), title=f"preview: {scenario}")
+
+    result = subprocess.run(
+        ["qlmanage", "-t", "-s", "1200", "-o", str(svg_path.parent), str(svg_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    png_path = svg_path.with_suffix(".svg.png")
+    if result.returncode == 0 and png_path.exists():
+        print(f"image: {png_path}")
+    else:
+        print(f"qlmanage failed (macOS QuickLook only): {result.stderr.strip()}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/src/python/termstatus/termstatus/render.py
+++ b/src/python/termstatus/termstatus/render.py
@@ -7,11 +7,12 @@ from collections.abc import Iterable, Sequence
 
 from rich.console import Console, Group
 from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 
 from termstatus.layout import SegmentGenerationResult
 from termstatus.payload import StatusLineStdIn
-from termstatus.segments.constants import CHIP_STYLE, CYAN, DIM, RESET, get_icon
+from termstatus.segments.constants import CYAN, RESET
 from termstatus.segments.git import GitInfo
 
 
@@ -130,45 +131,30 @@ def _group_segments_by_line(
     return {k: sorted(v, key=lambda s: s.index) for k, v in sorted(by_line.items())}
 
 
-_RIGHT_COLUMN_THRESHOLD = 3
+_LEAD_COLUMN = 0
+_BODY_COLUMN = 1
+_BADGE_COLUMN = 2
 
 
-def _build_standard_row(
-    line_segs: Sequence[SegmentGenerationResult],
-    left_sep: str,
-) -> tuple[Text, Text]:
-    left = [s for s in line_segs if (s.column or 0) < _RIGHT_COLUMN_THRESHOLD]
-    right = [s for s in line_segs if (s.column or 0) >= _RIGHT_COLUMN_THRESHOLD]
-    left_text = left_sep.join(s.segment.text for s in left) if left else ""
-    right_text = "  ".join(s.segment.text for s in right) if right else ""
+def _build_row_cells(line_segs: Sequence[SegmentGenerationResult]) -> tuple[Text, Text, Text]:
+    lead = [s for s in line_segs if (s.column or 0) == _LEAD_COLUMN]
+    body = [s for s in line_segs if (s.column or 0) == _BODY_COLUMN]
+    trailing = [s for s in line_segs if (s.column or 0) >= _BADGE_COLUMN]
+    lead_text = " ".join(s.segment.text for s in lead)
+    body_text = "   ".join(s.segment.text for s in body)
+    trailing_text = "  ".join(s.segment.text for s in trailing)
+    # Everything from badge onward (bracket tags, trailing git icons, a token
+    # ratio, ...) shares ONE cell rather than each getting its own aligned
+    # column. A column that only one or two rows ever populate has nothing to
+    # align against, so Rich pushes it out to an isolated, disconnected
+    # position — confirmed twice now (trailing git icons, then the token
+    # ratio). One shared "whatever comes after body" cell avoids that by
+    # construction: it always sits immediately after ITS OWN row's body.
     return (
-        Text.from_ansi(left_text, no_wrap=True) if left_text else Text(""),
-        Text.from_ansi(right_text, no_wrap=True) if right_text else Text(""),
+        Text.from_ansi(lead_text, no_wrap=True) if lead_text else Text(""),
+        Text.from_ansi(body_text, no_wrap=True) if body_text else Text(""),
+        Text.from_ansi(trailing_text, no_wrap=True) if trailing_text else Text(""),
     )
-
-
-_ROW_GAP = 2  # spaces between left and right content on a line
-
-
-def _pad_row(left: Text, right: Text, target_width: int) -> Text:
-    """Pads (and truncates if needed) one row to target_width, chip-styled as a whole."""
-    has_right = bool(right.plain)
-    right_span = right.cell_len + _ROW_GAP if has_right else 0
-    left_budget = max(target_width - right_span, 0)
-    if left.cell_len > left_budget:
-        left.truncate(left_budget, overflow="ellipsis")
-
-    gap = max(target_width - left.cell_len - right_span, 0)
-    row = Text()
-    row.append(" ")
-    row.append(left)
-    row.append(" " * gap)
-    if has_right:
-        row.append(" " * _ROW_GAP)
-        row.append(right)
-    row.append(" ")
-    row.stylize(CHIP_STYLE)
-    return row
 
 
 def render_lines(
@@ -178,25 +164,26 @@ def render_lines(
     *,
     terminal_width: int | None = None,
 ) -> list[str]:
-    """Renders segments as a panel of uniform-width, chip-styled lines."""
-    left_sep = f" {DIM}{get_icon('dot')}{RESET} "
-
+    """Renders segments as one shared table: lead/body columns size to the
+    widest content across every row, so every row's cells start at the same
+    position. Everything trailing (badges, status icons, secondary values)
+    shares one cell per row instead of each being its own aligned column, so
+    it always sits right next to that row's own content.
+    """
     segments_list = list(segments)
     if not segments_list:
         return []
 
     effective_width = _effective_width(terminal_width)
     lines_map = _group_segments_by_line(segments_list)
+    rows = [_build_row_cells(line_segs) for line_segs in lines_map.values()]
 
-    rows = [_build_standard_row(line_segs, left_sep) for line_segs in lines_map.values()]
-
-    # Every row pads to the same shared width instead of hugging only its own
-    # content, so chips form one consistent block instead of a jagged staircase.
-    available_width = max(effective_width - 2, 1)
-    natural_widths = (left.cell_len + (right.cell_len + _ROW_GAP if right.plain else 0) for left, right in rows)
-    target_width = min(max(natural_widths, default=0), available_width)
-
-    blocks = [_pad_row(left, right, target_width) for left, right in rows]
+    table = Table(show_header=False, show_edge=False, box=None, padding=(0, 1))
+    table.add_column("lead", justify="left", no_wrap=True)
+    table.add_column("body", justify="left", no_wrap=True, max_width=effective_width, overflow="ellipsis")
+    table.add_column("trailing", justify="left", no_wrap=True)
+    for lead, body, trailing in rows:
+        table.add_row(lead, body, trailing)
 
     console = Console(
         width=effective_width,
@@ -208,9 +195,9 @@ def render_lines(
     if payload is not None and payload.session_name:
         session_text = Text.from_ansi(f"{CYAN}#{payload.session_name}{RESET}", no_wrap=True)
         session_text.overflow = "ellipsis"
-        renderable = Group(session_text, *blocks)
+        renderable = Group(session_text, table)
     else:
-        renderable = Group(*blocks)
+        renderable = table
 
     with console.capture() as capture:
         console.print(Panel(renderable, border_style="dim", expand=False))

--- a/src/python/termstatus/termstatus/render.py
+++ b/src/python/termstatus/termstatus/render.py
@@ -12,7 +12,7 @@ from rich.text import Text
 
 from termstatus.layout import SegmentGenerationResult
 from termstatus.payload import StatusLineStdIn
-from termstatus.segments.constants import CYAN, DIM, RESET, get_icon
+from termstatus.segments.constants import CHIP_STYLE, CYAN, DIM, RESET, get_icon
 from termstatus.segments.git import GitInfo
 
 
@@ -132,47 +132,6 @@ def _group_segments_by_line(
 
 
 _RIGHT_COLUMN_THRESHOLD = 3
-_GIT_GENERATORS = frozenset({"internal.git", "internal.chezmoi"})
-
-
-def _is_git_section(line_segs: Sequence[SegmentGenerationResult]) -> bool:
-    return all(s.generator in _GIT_GENERATORS for s in line_segs) and any((s.column or 0) == 1 for s in line_segs)
-
-
-def _build_git_subtable(
-    lines: Sequence[Sequence[SegmentGenerationResult]],
-) -> Table:
-    table = Table(
-        show_header=False,
-        show_edge=False,
-        box=None,
-        padding=(0, 1),
-        expand=True,
-    )
-    table.add_column("label", justify="left", no_wrap=True, min_width=7)
-    table.add_column("branch", justify="left", no_wrap=True, ratio=1)
-    table.add_column("status", justify="left", no_wrap=True)
-    table.add_column("right", justify="right", no_wrap=True)
-
-    for line_segs in lines:
-        col0 = [s for s in line_segs if (s.column or 0) == 0]
-        col1 = [s for s in line_segs if (s.column or 0) == 1]
-        col2 = [s for s in line_segs if (s.column or 0) == 2]
-        col_right = [s for s in line_segs if (s.column or 0) >= _RIGHT_COLUMN_THRESHOLD]
-
-        label_text = " ".join(s.segment.text for s in col0) if col0 else ""
-        branch_text = " ".join(s.segment.text for s in col1) if col1 else ""
-        status_text = " ".join(s.segment.text for s in col2) if col2 else ""
-        right_text = " ".join(s.segment.text for s in col_right) if col_right else ""
-
-        table.add_row(
-            Text.from_ansi(label_text, no_wrap=True) if label_text else Text(""),
-            Text.from_ansi(branch_text, no_wrap=True) if branch_text else Text(""),
-            Text.from_ansi(status_text, no_wrap=True) if status_text else Text(""),
-            Text.from_ansi(right_text, no_wrap=True) if right_text else Text(""),
-        )
-
-    return table
 
 
 def _build_standard_row(
@@ -196,7 +155,7 @@ def render_lines(
     *,
     terminal_width: int | None = None,
 ) -> list[str]:
-    """Renders segments as a panel with subtables for aligned git sections."""
+    """Renders segments as a panel, one chip-styled full-width block per line."""
     left_sep = f" {DIM}{get_icon('dot')}{RESET} "
 
     segments_list = list(segments)
@@ -206,34 +165,23 @@ def render_lines(
     effective_width = _effective_width(terminal_width)
     lines_map = _group_segments_by_line(segments_list)
 
-    outer = Table(
-        show_header=False,
-        show_edge=False,
-        box=None,
-        padding=(0, 1),
-        expand=True,
-    )
-    outer.add_column("left", justify="left", ratio=1, overflow="ellipsis", no_wrap=True)
-    outer.add_column("right", justify="right", no_wrap=True)
-
-    git_line_buffer: list[Sequence[SegmentGenerationResult]] = []
-
-    def flush_git_buffer() -> None:
-        if not git_line_buffer:
-            return
-        subtable = _build_git_subtable(git_line_buffer)
-        outer.add_row(subtable, Text(""))
-        git_line_buffer.clear()
-
+    # Each line becomes its own full-width chip block: its right-aligned column
+    # never shares (and gets shrunk by) another line's right column, and label
+    # padding/truncation happens as plain text upstream instead of via nested
+    # Rich Table columns, so chip backgrounds hug content instead of stretching.
+    blocks: list[Table] = []
     for line_segs in lines_map.values():
-        if _is_git_section(line_segs):
-            git_line_buffer.append(line_segs)
-        else:
-            flush_git_buffer()
-            left_cell, right_cell = _build_standard_row(line_segs, left_sep)
-            outer.add_row(left_cell, right_cell)
+        table = Table(show_header=False, show_edge=False, box=None, padding=(0, 1), expand=True)
+        table.add_column("left", justify="left", ratio=1, overflow="ellipsis", no_wrap=True)
+        table.add_column("right", justify="right", no_wrap=True)
 
-    flush_git_buffer()
+        left_cell, right_cell = _build_standard_row(line_segs, left_sep)
+        if left_cell.plain:
+            left_cell.stylize(CHIP_STYLE)
+        if right_cell.plain:
+            right_cell.stylize(CHIP_STYLE)
+        table.add_row(left_cell, right_cell)
+        blocks.append(table)
 
     console = Console(
         width=effective_width,
@@ -245,9 +193,9 @@ def render_lines(
     if payload is not None and payload.session_name:
         session_text = Text.from_ansi(f"{CYAN}#{payload.session_name}{RESET}", no_wrap=True)
         session_text.overflow = "ellipsis"
-        renderable = Group(session_text, outer)
+        renderable = Group(session_text, *blocks)
     else:
-        renderable = outer
+        renderable = Group(*blocks)
 
     with console.capture() as capture:
         console.print(Panel(renderable, border_style="dim", expand=True))

--- a/src/python/termstatus/termstatus/render.py
+++ b/src/python/termstatus/termstatus/render.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Sequence
 
 from rich.console import Console, Group
 from rich.panel import Panel
-from rich.table import Table
 from rich.text import Text
 
 from termstatus.layout import SegmentGenerationResult
@@ -148,6 +147,30 @@ def _build_standard_row(
     )
 
 
+_ROW_GAP = 2  # spaces between left and right content on a line
+
+
+def _pad_row(left: Text, right: Text, target_width: int) -> Text:
+    """Pads (and truncates if needed) one row to target_width, chip-styled as a whole."""
+    has_right = bool(right.plain)
+    right_span = right.cell_len + _ROW_GAP if has_right else 0
+    left_budget = max(target_width - right_span, 0)
+    if left.cell_len > left_budget:
+        left.truncate(left_budget, overflow="ellipsis")
+
+    gap = max(target_width - left.cell_len - right_span, 0)
+    row = Text()
+    row.append(" ")
+    row.append(left)
+    row.append(" " * gap)
+    if has_right:
+        row.append(" " * _ROW_GAP)
+        row.append(right)
+    row.append(" ")
+    row.stylize(CHIP_STYLE)
+    return row
+
+
 def render_lines(
     payload: StatusLineStdIn | None,
     git_info: GitInfo | None,
@@ -155,7 +178,7 @@ def render_lines(
     *,
     terminal_width: int | None = None,
 ) -> list[str]:
-    """Renders segments as a panel, one chip-styled full-width block per line."""
+    """Renders segments as a panel of uniform-width, chip-styled lines."""
     left_sep = f" {DIM}{get_icon('dot')}{RESET} "
 
     segments_list = list(segments)
@@ -165,23 +188,15 @@ def render_lines(
     effective_width = _effective_width(terminal_width)
     lines_map = _group_segments_by_line(segments_list)
 
-    # Each line becomes its own full-width chip block: its right-aligned column
-    # never shares (and gets shrunk by) another line's right column, and label
-    # padding/truncation happens as plain text upstream instead of via nested
-    # Rich Table columns, so chip backgrounds hug content instead of stretching.
-    blocks: list[Table] = []
-    for line_segs in lines_map.values():
-        table = Table(show_header=False, show_edge=False, box=None, padding=(0, 1), expand=True)
-        table.add_column("left", justify="left", ratio=1, overflow="ellipsis", no_wrap=True)
-        table.add_column("right", justify="right", no_wrap=True)
+    rows = [_build_standard_row(line_segs, left_sep) for line_segs in lines_map.values()]
 
-        left_cell, right_cell = _build_standard_row(line_segs, left_sep)
-        if left_cell.plain:
-            left_cell.stylize(CHIP_STYLE)
-        if right_cell.plain:
-            right_cell.stylize(CHIP_STYLE)
-        table.add_row(left_cell, right_cell)
-        blocks.append(table)
+    # Every row pads to the same shared width instead of hugging only its own
+    # content, so chips form one consistent block instead of a jagged staircase.
+    available_width = max(effective_width - 2, 1)
+    natural_widths = (left.cell_len + (right.cell_len + _ROW_GAP if right.plain else 0) for left, right in rows)
+    target_width = min(max(natural_widths, default=0), available_width)
+
+    blocks = [_pad_row(left, right, target_width) for left, right in rows]
 
     console = Console(
         width=effective_width,
@@ -198,6 +213,6 @@ def render_lines(
         renderable = Group(*blocks)
 
     with console.capture() as capture:
-        console.print(Panel(renderable, border_style="dim", expand=True))
+        console.print(Panel(renderable, border_style="dim", expand=False))
 
     return [line.rstrip() for line in capture.get().splitlines() if line.strip()]

--- a/src/python/termstatus/termstatus/segments/antigravity.py
+++ b/src/python/termstatus/termstatus/segments/antigravity.py
@@ -23,6 +23,7 @@ def format_agent_state(payload: AntigravityPayload) -> list[SegmentGenerationRes
         SegmentGenerationResult(
             line=3,
             index=10,
+            column=1,
             generator="internal.antigravity.agent_state",
             segment=Segment(text=f"{color}[{state}]{RESET}"),
         )
@@ -37,6 +38,7 @@ def format_model_info(payload: AntigravityPayload) -> list[SegmentGenerationResu
         SegmentGenerationResult(
             line=3,
             index=20,
+            column=1,
             generator="internal.antigravity.model_info",
             segment=Segment(text=f"{GREEN}{payload.model.display_name}{RESET}"),
         )
@@ -53,6 +55,7 @@ def format_workspace_info(payload: AntigravityPayload) -> list[SegmentGeneration
         SegmentGenerationResult(
             line=3,
             index=30,
+            column=1,
             generator="internal.antigravity.workspace",
             segment=Segment(text=f"{BLUE}{basename}{RESET}"),
         )
@@ -69,6 +72,7 @@ def format_vcs_info(payload: AntigravityPayload) -> list[SegmentGenerationResult
         SegmentGenerationResult(
             line=3,
             index=40,
+            column=1,
             generator="internal.antigravity.vcs",
             segment=Segment(text=f"{YELLOW}{branch}{dirty_marker}{RESET}"),
         )
@@ -84,6 +88,7 @@ def format_context_usage(payload: AntigravityPayload) -> list[SegmentGenerationR
         SegmentGenerationResult(
             line=3,
             index=50,
+            column=1,
             generator="internal.antigravity.context_usage",
             segment=Segment(text=f"{CYAN}{percent:.1f}% context{RESET}"),
         )

--- a/src/python/termstatus/termstatus/segments/chezmoi.py
+++ b/src/python/termstatus/termstatus/segments/chezmoi.py
@@ -60,7 +60,6 @@ async def _fetch_repo_info(repo_path: Path) -> GitInfo | None:
     )
 
 
-_LABEL_WIDTH = 7
 _MAX_BRANCH_LEN = 24
 
 
@@ -83,8 +82,8 @@ def _format_repo(
     info: GitInfo,
     line: int,
 ) -> Sequence[SegmentGenerationResult]:
-    # Label padded and branch truncated as plain text before any ANSI wrapping, so
-    # rows line up via simple string alignment instead of a shared Rich Table column.
+    # label/body/right map to render.py's shared lead/body/right table columns —
+    # cross-row alignment is that table's job now, not this function's.
     branch_url = _build_branch_url(info.remote, info.branch) if info.remote else None
     branch_label = _truncate(info.branch, _MAX_BRANCH_LEN)
     branch_display = f"\033]8;;{branch_url}\033\\{branch_label}\033]8;;\033\\" if branch_url else branch_label
@@ -98,11 +97,9 @@ def _format_repo(
     if not filled:
         filled = [f"{GREEN}{get_icon('clean')}{RESET}"]
 
-    left_text = (
-        f"{DIM}{label.ljust(_LABEL_WIDTH)}{RESET}  "
-        f"{MAGENTA}{get_icon('branch')} {branch_display}{RESET}  "
-        f"[{''.join(filled)}]"
-    )
+    label_prefix = f"{DIM}{label}{RESET}  " if label else ""
+    body_text = f"{label_prefix}{MAGENTA}{branch_display}{RESET}"
+    badge_text = f"[{''.join(filled)}]"
 
     right_parts = [
         f"{GREEN}↑{info.ahead}{RESET}" if info.ahead > 0 else None,
@@ -130,7 +127,23 @@ def _format_repo(
             line=line,
             index=0,
             column=0,
-            segment=Segment(text=left_text),
+            segment=Segment(text=get_icon("branch")),
+            generator="internal.chezmoi",
+            cache_duration=TimeDelta(seconds=5),
+        ),
+        SegmentGenerationResult(
+            line=line,
+            index=0,
+            column=1,
+            segment=Segment(text=body_text),
+            generator="internal.chezmoi",
+            cache_duration=TimeDelta(seconds=5),
+        ),
+        SegmentGenerationResult(
+            line=line,
+            index=0,
+            column=2,
+            segment=Segment(text=badge_text),
             generator="internal.chezmoi",
             cache_duration=TimeDelta(seconds=5),
         ),
@@ -152,17 +165,6 @@ def _format_repo(
     return results
 
 
-def _chezmoi_dir_indicator() -> SegmentGenerationResult:
-    return SegmentGenerationResult(
-        line=1,
-        index=0,
-        column=0,
-        segment=Segment(text=f"{MAGENTA}{get_icon('chezmoi')} chezmoi{RESET}"),
-        generator="internal.chezmoi",
-        cache_duration=TimeDelta(seconds=5),
-    )
-
-
 async def generate_chezmoi_segment(cwd: Path, chezmoi_root: Path) -> Sequence[SegmentGenerationResult]:
     base_path = chezmoi_root / _BASE_RELATIVE_PATH
     has_base = (base_path / ".git").exists()
@@ -175,15 +177,11 @@ async def generate_chezmoi_segment(cwd: Path, chezmoi_root: Path) -> Sequence[Se
         if overlay_info is None and base_info is None:
             return []
         return [
-            _chezmoi_dir_indicator(),
             *(_format_repo("overlay", overlay_info, line=2) if overlay_info else []),
             *(_format_repo("base", base_info, line=3) if base_info else []),
         ]
 
     repo_info = await _fetch_repo_info(chezmoi_root)
     if repo_info is None:
-        return [_chezmoi_dir_indicator()]
-    return [
-        _chezmoi_dir_indicator(),
-        *_format_repo("source", repo_info, line=2),
-    ]
+        return []
+    return [*_format_repo("", repo_info, line=2)]

--- a/src/python/termstatus/termstatus/segments/chezmoi.py
+++ b/src/python/termstatus/termstatus/segments/chezmoi.py
@@ -60,6 +60,16 @@ async def _fetch_repo_info(repo_path: Path) -> GitInfo | None:
     )
 
 
+_LABEL_WIDTH = 7
+_MAX_BRANCH_LEN = 24
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
 def _build_branch_url(remote: str, branch: str) -> str:
     if branch == "HEAD":
         return remote
@@ -73,8 +83,11 @@ def _format_repo(
     info: GitInfo,
     line: int,
 ) -> Sequence[SegmentGenerationResult]:
+    # Label padded and branch truncated as plain text before any ANSI wrapping, so
+    # rows line up via simple string alignment instead of a shared Rich Table column.
     branch_url = _build_branch_url(info.remote, info.branch) if info.remote else None
-    branch_display = f"\033]8;;{branch_url}\033\\{info.branch}\033]8;;\033\\" if branch_url else info.branch
+    branch_label = _truncate(info.branch, _MAX_BRANCH_LEN)
+    branch_display = f"\033]8;;{branch_url}\033\\{branch_label}\033]8;;\033\\" if branch_url else branch_label
 
     status_parts = [
         f"{RED}{get_icon('dirty')}{RESET}" if info.dirty else None,
@@ -85,9 +98,11 @@ def _format_repo(
     if not filled:
         filled = [f"{GREEN}{get_icon('clean')}{RESET}"]
 
-    label_text = f"{DIM}{label}{RESET}"
-    branch_text = f"{MAGENTA}{get_icon('branch')} {branch_display}{RESET}"
-    status_text = f"[{''.join(filled)}]"
+    left_text = (
+        f"{DIM}{label.ljust(_LABEL_WIDTH)}{RESET}  "
+        f"{MAGENTA}{get_icon('branch')} {branch_display}{RESET}  "
+        f"[{''.join(filled)}]"
+    )
 
     right_parts = [
         f"{GREEN}↑{info.ahead}{RESET}" if info.ahead > 0 else None,
@@ -115,23 +130,7 @@ def _format_repo(
             line=line,
             index=0,
             column=0,
-            segment=Segment(text=label_text),
-            generator="internal.chezmoi",
-            cache_duration=TimeDelta(seconds=5),
-        ),
-        SegmentGenerationResult(
-            line=line,
-            index=5,
-            column=1,
-            segment=Segment(text=branch_text),
-            generator="internal.chezmoi",
-            cache_duration=TimeDelta(seconds=5),
-        ),
-        SegmentGenerationResult(
-            line=line,
-            index=6,
-            column=2,
-            segment=Segment(text=status_text),
+            segment=Segment(text=left_text),
             generator="internal.chezmoi",
             cache_duration=TimeDelta(seconds=5),
         ),
@@ -143,7 +142,7 @@ def _format_repo(
             SegmentGenerationResult(
                 line=line,
                 index=10,
-                column=3,
+                column=4,
                 segment=Segment(text=" ".join(right_filled)),
                 generator="internal.chezmoi",
                 cache_duration=TimeDelta(seconds=5),

--- a/src/python/termstatus/termstatus/segments/claude.py
+++ b/src/python/termstatus/termstatus/segments/claude.py
@@ -75,7 +75,7 @@ def format_context_usage(cw: ContextWindowInfo) -> list[SegmentGenerationResult]
     return [
         SegmentGenerationResult(
             line=_CONTEXT_LINE,
-            index=0,
+            index=30,
             column=0,
             generator="internal.claude",
             segment=Segment(text="  ".join(parts)),
@@ -116,9 +116,9 @@ def format_session_info(payload: StatusLineStdIn) -> list[SegmentGenerationResul
     timer = f"{hours:02d}:{minutes:02d}:{seconds:02d}" if hours > 0 else f"{minutes:02d}:{seconds:02d}"
     return [
         SegmentGenerationResult(
-            line=0,
-            index=40,
-            column=4,
+            line=_CONTEXT_LINE,
+            index=10,
+            column=0,
             generator="internal.claude",
             segment=Segment(text=f"{DIM}{get_icon('timer')} {timer}{RESET}"),
         )
@@ -130,9 +130,9 @@ def format_cost(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
         return []
     return [
         SegmentGenerationResult(
-            line=0,
-            index=30,
-            column=3,
+            line=_CONTEXT_LINE,
+            index=0,
+            column=0,
             generator="internal.claude",
             segment=Segment(text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"),
         )
@@ -153,9 +153,9 @@ def format_lines_impact(payload: StatusLineStdIn) -> list[SegmentGenerationResul
 
     return [
         SegmentGenerationResult(
-            line=1,
-            index=50,
-            column=4,
+            line=_CONTEXT_LINE,
+            index=20,
+            column=0,
             generator="internal.claude",
             segment=Segment(text=" ".join(p for p in parts if p)),
         )

--- a/src/python/termstatus/termstatus/segments/claude.py
+++ b/src/python/termstatus/termstatus/segments/claude.py
@@ -7,7 +7,6 @@ from termstatus.segments.constants import (
     BLUE,
     BOLD,
     BRIGHT_GREEN,
-    BRIGHT_RED,
     DIM,
     GREEN,
     MAGENTA,
@@ -135,28 +134,5 @@ def format_cost(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
             column=0,
             generator="internal.claude",
             segment=Segment(text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"),
-        )
-    ]
-
-
-def format_lines_impact(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
-    added = payload.cost.total_lines_added or 0
-    removed = payload.cost.total_lines_removed or 0
-
-    if added == 0 and removed == 0:
-        return []
-
-    parts = [
-        f"{BRIGHT_GREEN}+{added}{RESET}" if added > 0 else None,
-        f"{BRIGHT_RED}-{removed}{RESET}" if removed > 0 else None,
-    ]
-
-    return [
-        SegmentGenerationResult(
-            line=_CONTEXT_LINE,
-            index=20,
-            column=0,
-            generator="internal.claude",
-            segment=Segment(text=" ".join(p for p in parts if p)),
         )
     ]

--- a/src/python/termstatus/termstatus/segments/claude.py
+++ b/src/python/termstatus/termstatus/segments/claude.py
@@ -17,6 +17,7 @@ from termstatus.segments.constants import (
     get_icon,
 )
 
+_USAGE_LINE = 9
 _CONTEXT_LINE = 10
 
 _BAR_WIDTH = 12
@@ -69,37 +70,63 @@ def format_context_usage(cw: ContextWindowInfo) -> list[SegmentGenerationResult]
         else ""
     )
 
-    parts = [p for p in (bar, pct_text, token_text) if p]
-
-    return [
+    results = [
+        SegmentGenerationResult(
+            line=_CONTEXT_LINE, index=0, column=0, generator="internal.claude", segment=Segment(text=get_icon("tokens"))
+        ),
         SegmentGenerationResult(
             line=_CONTEXT_LINE,
             index=30,
-            column=0,
+            column=1,
             generator="internal.claude",
-            segment=Segment(text="  ".join(parts)),
-        )
+            segment=Segment(text=f"{bar}  {pct_text}"),
+        ),
     ]
+    if token_text:
+        results = [
+            *results,
+            SegmentGenerationResult(
+                line=_CONTEXT_LINE, index=40, column=3, generator="internal.claude", segment=Segment(text=token_text)
+            ),
+        ]
+    return results
 
 
 def format_model_info(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
     style = payload.output_style
-    model_str = f"{get_icon('robot')} {BLUE}{BOLD}{payload.model.display_name}{RESET}"
-
-    agent_style_parts = [
-        f"{MAGENTA}@{payload.agent.name}{RESET}" if payload.agent.name else None,
-        f"{DIM}[{style.name}]{RESET}" if style and style.name else None,
-    ]
-    agent_text = " ".join(p for p in agent_style_parts if p)
-
     results = [
-        SegmentGenerationResult(line=0, index=0, column=0, generator="internal.claude", segment=Segment(text=model_str))
+        SegmentGenerationResult(
+            line=0, index=0, column=0, generator="internal.claude", segment=Segment(text=get_icon("robot"))
+        ),
+        SegmentGenerationResult(
+            line=0,
+            index=0,
+            column=1,
+            generator="internal.claude",
+            segment=Segment(text=f"{BLUE}{BOLD}{payload.model.display_name}{RESET}"),
+        ),
     ]
-    if agent_text:
+
+    if payload.agent.name:
         results = [
             *results,
             SegmentGenerationResult(
-                line=0, index=10, column=1, generator="internal.claude", segment=Segment(text=agent_text)
+                line=0,
+                index=10,
+                column=1,
+                generator="internal.claude",
+                segment=Segment(text=f"{MAGENTA}@{payload.agent.name}{RESET}"),
+            ),
+        ]
+    if style and style.name:
+        results = [
+            *results,
+            SegmentGenerationResult(
+                line=0,
+                index=0,
+                column=2,
+                generator="internal.claude",
+                segment=Segment(text=f"{DIM}[{style.name}]{RESET}"),
             ),
         ]
     return results
@@ -115,9 +142,9 @@ def format_session_info(payload: StatusLineStdIn) -> list[SegmentGenerationResul
     timer = f"{hours:02d}:{minutes:02d}:{seconds:02d}" if hours > 0 else f"{minutes:02d}:{seconds:02d}"
     return [
         SegmentGenerationResult(
-            line=_CONTEXT_LINE,
+            line=_USAGE_LINE,
             index=10,
-            column=0,
+            column=2,
             generator="internal.claude",
             segment=Segment(text=f"{DIM}{get_icon('timer')} {timer}{RESET}"),
         )
@@ -129,10 +156,13 @@ def format_cost(payload: StatusLineStdIn) -> list[SegmentGenerationResult]:
         return []
     return [
         SegmentGenerationResult(
-            line=_CONTEXT_LINE,
+            line=_USAGE_LINE, index=0, column=0, generator="internal.claude", segment=Segment(text=get_icon("cost"))
+        ),
+        SegmentGenerationResult(
+            line=_USAGE_LINE,
             index=0,
-            column=0,
+            column=1,
             generator="internal.claude",
-            segment=Segment(text=f"{GREEN}{get_icon('cost')} ${payload.cost.total_cost_usd:.2f}{RESET}"),
-        )
+            segment=Segment(text=f"{GREEN}${payload.cost.total_cost_usd:.2f}{RESET}"),
+        ),
     ]

--- a/src/python/termstatus/termstatus/segments/constants.py
+++ b/src/python/termstatus/termstatus/segments/constants.py
@@ -27,8 +27,9 @@ BRIGHT_RED = "\033[91m"
 BRIGHT_GREEN = "\033[92m"
 ORANGE = "\033[38;5;208m"
 
-BG_DIM = "\033[48;5;236m"
-BG_RESET = "\033[49m"
+# Rich style string (not raw ANSI) — applied via Text.stylize() so the chip
+# background hugs rendered content instead of a table cell's full column width.
+CHIP_STYLE = "on grey19"
 
 
 @functools.cache

--- a/src/python/termstatus/termstatus/segments/constants.py
+++ b/src/python/termstatus/termstatus/segments/constants.py
@@ -27,10 +27,6 @@ BRIGHT_RED = "\033[91m"
 BRIGHT_GREEN = "\033[92m"
 ORANGE = "\033[38;5;208m"
 
-# Rich style string (not raw ANSI) — applied via Text.stylize() so the chip
-# background hugs rendered content instead of a table cell's full column width.
-CHIP_STYLE = "on grey19"
-
 
 @functools.cache
 def use_icons() -> bool:

--- a/src/python/termstatus/termstatus/segments/workspace.py
+++ b/src/python/termstatus/termstatus/segments/workspace.py
@@ -26,12 +26,15 @@ def format_directory(cwd: Path) -> list[SegmentGenerationResult]:
     cwd_link = f"\033]8;;file://{cwd}\033\\{display_path}\033]8;;\033\\"
     return [
         SegmentGenerationResult(
+            line=1, index=5, column=0, generator="internal.workspace", segment=Segment(text=get_icon("dir"))
+        ),
+        SegmentGenerationResult(
             line=1,
             index=5,
-            column=0,
+            column=1,
             generator="internal.workspace",
-            segment=Segment(text=f"{BLUE}{get_icon('dir')} {cwd_link}{RESET}"),
-        )
+            segment=Segment(text=f"{BLUE}{cwd_link}{RESET}"),
+        ),
     ]
 
 

--- a/src/python/termstatus/tests/test_segments_chezmoi.py
+++ b/src/python/termstatus/tests/test_segments_chezmoi.py
@@ -61,14 +61,12 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("ovl", info, line=2)
-        assert len(results) == 4
+        assert len(results) == 2
         assert results[0].line == 2
         assert results[0].column == 0
         assert "ovl" in results[0].segment.text
-        assert results[1].column == 1
-        assert "main" in results[1].segment.text
-        assert results[2].column == 2
-        assert results[3].column == 3
+        assert "main" in results[0].segment.text
+        assert results[1].column == 4
 
     def test_dirty_repo_with_ahead_behind(self):
         info = GitInfo(
@@ -83,16 +81,14 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("base", info, line=3)
-        assert len(results) == 4
+        assert len(results) == 2
         assert results[0].line == 3
         assert results[0].column == 0
         assert "base" in results[0].segment.text
-        assert results[1].column == 1
-        assert "feature" in results[1].segment.text
-        assert results[2].column == 2
-        assert results[3].column == 3
-        assert "↑2" in results[3].segment.text
-        assert "↓1" in results[3].segment.text
+        assert "feature" in results[0].segment.text
+        assert results[1].column == 4
+        assert "↑2" in results[1].segment.text
+        assert "↓1" in results[1].segment.text
 
     def test_clean_no_remote_no_right_segment(self):
         info = GitInfo(
@@ -107,10 +103,42 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("ovl", info, line=2)
-        assert len(results) == 3
+        assert len(results) == 1
         assert results[0].column == 0
-        assert results[1].column == 1
-        assert results[2].column == 2
+
+    def test_label_is_padded_for_alignment(self):
+        info = GitInfo(
+            branch="main",
+            remote=None,
+            dirty=False,
+            staged=False,
+            untracked=False,
+            ahead=0,
+            behind=0,
+            is_repo=True,
+            stash_count=0,
+        )
+        overlay = _format_repo("overlay", info, line=2)
+        base = _format_repo("base", info, line=3)
+        overlay_prefix_len = overlay[0].segment.text.index("main")
+        base_prefix_len = base[0].segment.text.index("main")
+        assert overlay_prefix_len == base_prefix_len
+
+    def test_long_branch_name_truncated(self):
+        info = GitInfo(
+            branch="feature/a-very-long-branch-name-that-should-be-truncated",
+            remote=None,
+            dirty=False,
+            staged=False,
+            untracked=False,
+            ahead=0,
+            behind=0,
+            is_repo=True,
+            stash_count=0,
+        )
+        results = _format_repo("ovl", info, line=2)
+        assert "…" in results[0].segment.text
+        assert "feature/a-very-long-branch-name-that-should-be-truncated" not in results[0].segment.text
 
 
 @pytest.mark.asyncio

--- a/src/python/termstatus/tests/test_segments_chezmoi.py
+++ b/src/python/termstatus/tests/test_segments_chezmoi.py
@@ -61,12 +61,15 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("ovl", info, line=2)
-        assert len(results) == 2
+        assert len(results) == 4
         assert results[0].line == 2
         assert results[0].column == 0
-        assert "ovl" in results[0].segment.text
-        assert "main" in results[0].segment.text
-        assert results[1].column == 4
+        assert results[1].column == 1
+        assert "ovl" in results[1].segment.text
+        assert "main" in results[1].segment.text
+        assert results[2].column == 2
+        assert results[2].segment.text.startswith("[") and results[2].segment.text.endswith("]")
+        assert results[3].column == 4
 
     def test_dirty_repo_with_ahead_behind(self):
         info = GitInfo(
@@ -81,14 +84,16 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("base", info, line=3)
-        assert len(results) == 2
+        assert len(results) == 4
         assert results[0].line == 3
         assert results[0].column == 0
-        assert "base" in results[0].segment.text
-        assert "feature" in results[0].segment.text
-        assert results[1].column == 4
-        assert "↑2" in results[1].segment.text
-        assert "↓1" in results[1].segment.text
+        assert results[1].column == 1
+        assert "base" in results[1].segment.text
+        assert "feature" in results[1].segment.text
+        assert results[2].column == 2
+        assert results[3].column == 4
+        assert "↑2" in results[3].segment.text
+        assert "↓1" in results[3].segment.text
 
     def test_clean_no_remote_no_right_segment(self):
         info = GitInfo(
@@ -103,10 +108,12 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("ovl", info, line=2)
-        assert len(results) == 1
+        assert len(results) == 3
         assert results[0].column == 0
+        assert results[1].column == 1
+        assert results[2].column == 2
 
-    def test_label_is_padded_for_alignment(self):
+    def test_lead_is_branch_icon_not_label(self):
         info = GitInfo(
             branch="main",
             remote=None,
@@ -118,11 +125,11 @@ class TestFormatRepo:
             is_repo=True,
             stash_count=0,
         )
-        overlay = _format_repo("overlay", info, line=2)
-        base = _format_repo("base", info, line=3)
-        overlay_prefix_len = overlay[0].segment.text.index("main")
-        base_prefix_len = base[0].segment.text.index("main")
-        assert overlay_prefix_len == base_prefix_len
+        with_label = _format_repo("overlay", info, line=2)
+        without_label = _format_repo("", info, line=2)
+        assert with_label[0].segment.text == without_label[0].segment.text
+        assert "overlay" not in with_label[0].segment.text
+        assert "overlay" in with_label[1].segment.text
 
     def test_long_branch_name_truncated(self):
         info = GitInfo(
@@ -137,8 +144,9 @@ class TestFormatRepo:
             stash_count=0,
         )
         results = _format_repo("ovl", info, line=2)
-        assert "…" in results[0].segment.text
-        assert "feature/a-very-long-branch-name-that-should-be-truncated" not in results[0].segment.text
+        body_text = results[1].segment.text
+        assert "…" in body_text
+        assert "feature/a-very-long-branch-name-that-should-be-truncated" not in body_text
 
 
 @pytest.mark.asyncio

--- a/src/python/termstatus/tests/test_segments_claude.py
+++ b/src/python/termstatus/tests/test_segments_claude.py
@@ -150,11 +150,11 @@ class TestFormatCost(unittest.TestCase):
         res = format_cost(payload)
         self.assertEqual(res, [])
 
-    def test_placed_on_context_line(self) -> None:
+    def test_placed_on_usage_line(self) -> None:
         payload = StatusLineStdIn(cost=CostInfo(total_cost_usd=0.5))
         res = format_cost(payload)
         assert res is not None
-        self.assertEqual(res[0].line if res else None, 10)
+        self.assertEqual(res[0].line if res else None, 9)
 
 
 if __name__ == "__main__":

--- a/src/python/termstatus/tests/test_segments_claude.py
+++ b/src/python/termstatus/tests/test_segments_claude.py
@@ -150,11 +150,11 @@ class TestFormatCost(unittest.TestCase):
         res = format_cost(payload)
         self.assertEqual(res, [])
 
-    def test_placed_on_line_0(self) -> None:
+    def test_placed_on_context_line(self) -> None:
         payload = StatusLineStdIn(cost=CostInfo(total_cost_usd=0.5))
         res = format_cost(payload)
         assert res is not None
-        self.assertEqual(res[0].line if res else None, 0)
+        self.assertEqual(res[0].line if res else None, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… git table

Move cost/session-timer/lines-changed onto the context-usage line so all session activity metrics live in one row instead of split across two unrelated ones. Render every line as its own chip-styled block (Text.stylize with the previously-unused CHIP_STYLE constant) instead of sharing a table across rows with mismatched right-column widths.

Git overlay/base rows no longer need a nested 5-column Rich Table (label/ branch/status/spacer/right with ratio and max_width tricks) to align -- _format_repo now left-pads the label and truncates long branch names as plain text before any ANSI wrapping, so rows line up via simple string alignment. This also means the chip styling applies for free to the antigravity render path, which shares the same render_lines().


Committed-By-Agent: claude