### PR TITLE
fix(wsl): disable WSL2 crash-dump capture at the source

### DIFF
--- a/src/chezmoi/.chezmoidata/wsl.toml
+++ b/src/chezmoi/.chezmoidata/wsl.toml
@@ -4,7 +4,11 @@
 memory = "16GB"
 swap = "2GB"
 processors = 4
-maxCrashDumpCount = 3
+# -1 disables WSL2 crash-dump capture entirely at the source (not just
+# retention count) -- see microsoft/WSL WslCoreVm.cpp/main.cpp, all
+# gated on maxCrashDumpCount >= 0. Prevents repeat multi-hundred-GB
+# dumps from orphaned WSL processes filling the Windows C: drive.
+maxCrashDumpCount = -1
 # Shares localhost between WSL and Windows so Windows-hosted services
 # (Ollama at 127.0.0.1:11434, dev servers, etc.) are reachable from inside
 # WSL without juggling the NAT gateway IP. Default WSL2 mode is "nat".

--- a/src/chezmoi/.chezmoitemplates/wsl/wslconfig
+++ b/src/chezmoi/.chezmoitemplates/wsl/wslconfig
@@ -6,6 +6,10 @@ memory={{ .wsl.wsl2.memory }}
 swap={{ .wsl.wsl2.swap }}
 processors={{ .wsl.wsl2.processors }}
 networkingMode={{ .wsl.wsl2.networkingMode }}
+# -1 disables WSL2 crash-dump capture entirely at the source (not just
+# retention count) -- see microsoft/WSL WslCoreVm.cpp/main.cpp, all
+# gated on maxCrashDumpCount >= 0. Prevents repeat multi-hundred-GB
+# dumps from orphaned WSL processes filling the Windows C: drive.
 maxCrashDumpCount={{ .wsl.wsl2.maxCrashDumpCount }}
 
 [experimental]


### PR DESCRIPTION
## Summary
- `maxCrashDumpCount=-1` (was `3`) in `.chezmoidata/wsl.toml` and the rendered `.wslconfig` template comment — stops the WSL2 guest from ever registering the `core_pattern` pipe crash-dump handler, instead of just capping the retained-file count.
- Root cause traced through [microsoft/WSL](https://github.com/microsoft/WSL) source: `WslCoreVm.cpp:340`, `WslCoreVm.cpp:1704`, `main.cpp:4032` all gate on `maxCrashDumpCount >= 0`. A negative value disables capture at the root.
- Motivated by repeated orphaned Electron/Obsidian crash-loops (bases-chartkit repo) dumping multi-hundred-GB to `C:\Users\<user>\AppData\Local\Temp\wsl-crashes\`, worst case 1TB+.

## Test plan
- [ ] After merge + `chezmoi apply`, run `wsl --shutdown` from PowerShell (not inside WSL) and relaunch.
- [ ] `cat /proc/sys/kernel/core_pattern` inside WSL shows kernel default (`core`), not `|/wsl-capture-crash %t %E %p %s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)