### PR TITLE
trim(agents): rightsize AGENTS.md/rules for progressive disclosure

### DIFF
--- a/.codex/memories/11-write-agent-context.md
+++ b/.codex/memories/11-write-agent-context.md
@@ -4,3 +4,10 @@ Human-written context files must describe only minimal requirements.
 Do not include generic documentation, tutorials, or non-critical context.
 Restrict these files to repository-specific constraints and critical architecture maps.
 Excessive repository context reduces task success rates and increases inference cost.
+The same applies to skills (SKILL.md), not just AGENTS.md/CLAUDE.md/GEMINI.md.
+
+Split long context into a tree of files loaded on demand.
+Reference sub-files instead of inlining everything into one dense file.
+
+Prefer brief, judgment-guided steering over rigid blanket rules for nuanced matters.
+Reserve absolute rules for genuinely critical or safety-relevant invariants.

--- a/.cursor/rules/11-write-agent-context.mdc
+++ b/.cursor/rules/11-write-agent-context.mdc
@@ -1,7 +1,7 @@
 ---
 alwaysApply: false
-description: Minimal context rules for agent configuration files
-globs: AGENTS.md,CLAUDE.md,GEMINI.md,*.mdc
+description: Minimal context rules for agent configuration files and skills
+globs: AGENTS.md,CLAUDE.md,GEMINI.md,SKILL.md,*.mdc
 ---
 
 # Write agent context
@@ -10,3 +10,10 @@ Human-written context files must describe only minimal requirements.
 Do not include generic documentation, tutorials, or non-critical context.
 Restrict these files to repository-specific constraints and critical architecture maps.
 Excessive repository context reduces task success rates and increases inference cost.
+The same applies to skills (SKILL.md), not just AGENTS.md/CLAUDE.md/GEMINI.md.
+
+Split long context into a tree of files loaded on demand.
+Reference sub-files instead of inlining everything into one dense file.
+
+Prefer brief, judgment-guided steering over rigid blanket rules for nuanced matters.
+Reserve absolute rules for genuinely critical or safety-relevant invariants.

--- a/.gemini/memories/11-write-agent-context.md
+++ b/.gemini/memories/11-write-agent-context.md
@@ -4,3 +4,10 @@ Human-written context files must describe only minimal requirements.
 Do not include generic documentation, tutorials, or non-critical context.
 Restrict these files to repository-specific constraints and critical architecture maps.
 Excessive repository context reduces task success rates and increases inference cost.
+The same applies to skills (SKILL.md), not just AGENTS.md/CLAUDE.md/GEMINI.md.
+
+Split long context into a tree of files loaded on demand.
+Reference sub-files instead of inlining everything into one dense file.
+
+Prefer brief, judgment-guided steering over rigid blanket rules for nuanced matters.
+Reserve absolute rules for genuinely critical or safety-relevant invariants.

--- a/.jules/AGENTS.md
+++ b/.jules/AGENTS.md
@@ -1,20 +1,18 @@
 # Jules environment constraints
 
 Jules runs `env_setup.sh` in a fresh Ubuntu VM (`HOME=/home/jules`, `PWD=/app`).
-After the script exits, Jules runs a **post-script env-save hook** that captures the shell environment by running `bash -l -c 'env'` and parsing stdout as `KEY=VALUE` pairs.
+After the script exits, a post-script hook captures the shell environment via `bash -l -c 'env'`, parsing stdout as `KEY=VALUE` pairs.
 
 ## Critical rule: never pollute stdout of non-interactive login shells
 
-`bash -l` is a **non-interactive login shell**.
-It sources `~/.bash_profile` (and via it, any files our `modify_dot_bash_profile` injects) but does NOT set the `i` flag in `$-`.
+`bash -l` sources `~/.bash_profile` (and anything it sources) but does not set the `i` flag in `$-`.
+Any stdout output during that sourcing corrupts the hook's parser and silently breaks every subsequent Jules task.
+Route missing-tool warnings to stderr, or gate them on `[[ $- == *i* ]]`.
 
-**Any output to stdout during `~/.bash_profile` or files it sources will corrupt Jules' env-save hook.**
-The hook's parser sees non-`KEY=VALUE` lines and fails silently, breaking every subsequent Jules task.
+### Real incident (2026-05)
 
-### What went wrong (2026-05)
-
-`modify_dot_bash_profile.tmpl` creates `~/.bash_profile` where Jules never had one.
-The fallback line unconditionally sourced `config.bash` in all login shells:
+`modify_dot_bash_profile.tmpl` created `~/.bash_profile` where Jules had none.
+Its fallback unconditionally sourced `config.bash`, which printed fzf/starship/zoxide "not found" warnings to stdout:
 
 ```bash
 # BAD — runs in bash -l -c 'env', pollutes stdout
@@ -23,11 +21,7 @@ if ! type -t g &>/dev/null && [[ -f "~/.dotfiles/bash/config.bash" ]]; then
 fi
 ```
 
-`config.bash` printed fzf/starship/zoxide "not found" warnings to stdout → hook failed.
-
-### The fix
-
-Guard all `config.bash` sourcing with `[[ $- == *i* ]]`:
+Fixed by gating on interactivity:
 
 ```bash
 # GOOD — only fires in interactive shells
@@ -36,9 +30,5 @@ if [[ $- == *i* ]] && ! type -t g &>/dev/null && [[ -f "~/.dotfiles/bash/config.
 fi
 ```
 
-## General rules for modify_ scripts that touch shell RC files
-
-- **Never** print to stdout unconditionally from `~/.bash_profile`, `~/.bashrc`, or any file they source.
-- Warnings for missing tools must go to **stderr** (`>&2`) or be gated on `[[ $- == *i* ]]`.
-- `modify_dot_bash_profile.tmpl` creates `~/.bash_profile` from scratch — Jules had none. Every line in it runs in `bash -l` contexts.
-- `~/.bashrc` is safe because it guards itself: `case $- in *i*) ;; *) return;; esac`. But `~/.bash_profile` has no such guard.
+`~/.bashrc` self-guards (`case $- in *i*) ;; *) return;; esac`), so it's safe by default.
+`~/.bash_profile` has no such guard — every line in it runs in `bash -l` contexts.

--- a/.rules/11-write-agent-context.md
+++ b/.rules/11-write-agent-context.md
@@ -1,9 +1,10 @@
 ---
-description: Minimal context rules for agent configuration files
+description: Minimal context rules for agent configuration files and skills
 paths:
   - AGENTS.md
   - CLAUDE.md
   - GEMINI.md
+  - SKILL.md
   - '*.mdc'
 ---
 # Write agent context
@@ -12,3 +13,10 @@ Human-written context files must describe only minimal requirements.
 Do not include generic documentation, tutorials, or non-critical context.
 Restrict these files to repository-specific constraints and critical architecture maps.
 Excessive repository context reduces task success rates and increases inference cost.
+The same applies to skills (SKILL.md), not just AGENTS.md/CLAUDE.md/GEMINI.md.
+
+Split long context into a tree of files loaded on demand.
+Reference sub-files instead of inlining everything into one dense file.
+
+Prefer brief, judgment-guided steering over rigid blanket rules for nuanced matters.
+Reserve absolute rules for genuinely critical or safety-relevant invariants.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,12 @@
 # Agent context for dotfiles repository
 
-This is a **personal dotfiles repository** managed by mkobit.
-It is a highly customized environment optimized for specific personal workflows.
-AI agents must prioritize consistency with established architectural patterns, naming conventions, and local configuration styles.
-Avoid imposing standard industry "best practices" if they conflict with the existing idiomatic choices made in this repository.
+This is mkobit's personal dotfiles repository.
+Prioritize consistency with this repo's existing patterns, naming, and config style over generic industry best practices when the two conflict.
 
 ## Git context
 
-This repository uses git worktrees.
-You may be operating in a worktree on a feature branch, not the main checkout.
-**Always run `git status` and `git worktree list` at the start of a session** to confirm which branch and worktree you are in before making any changes.
-Never assume you are on `main` or in the primary checkout directory.
+This repository uses git worktrees — you may be in a worktree on a feature branch, not the main checkout.
+Run `git status` and `git worktree list` before making changes to confirm which one.
 
 ## Repository structure
 
@@ -105,8 +101,7 @@ The overlay wins all file collisions, including `.chezmoi.toml.tmpl` — the ove
 
 When adding features, keep them overlay-friendly:
 
-- `installation_method` decisions belong in `.chezmoi.toml.tmpl`; overlays re-declare them in their own init template.
-- Capability data (catalog entries, structural config) belongs in `.chezmoidata/` — overlays extend by adding keys, not editing base files.
+- Follow the control-plane/capability-catalog split above; overlays extend `.chezmoidata/` by adding keys and re-declare `.chezmoi.toml.tmpl` decisions in their own init template, never editing base files.
 - Use generic key names — describe the concept, not the environment.
 - Use `dig` with a safe default for any key an overlay might omit so absence is a no-op.
 - Loop over maps (`range $k, $v := .feature.items`) for injectable content.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,8 +11,8 @@ rules[4]:
     description: Ventilated prose and concise writing standards for documentation files
     applyTo[5]: *.md,*.mdx,*.adoc,*.rst,*.txt
   - path: @.gemini/memories/11-write-agent-context.md
-    description: Minimal context rules for agent configuration files
-    applyTo[4]: AGENTS.md,CLAUDE.md,GEMINI.md,*.mdc
+    description: Minimal context rules for agent configuration files and skills
+    applyTo[5]: AGENTS.md,CLAUDE.md,GEMINI.md,SKILL.md,*.mdc
 
 # Additional Conventions Beyond the Built-in Functions
 

--- a/src/ai/skills/write-agent-context/SKILL.md
+++ b/src/ai/skills/write-agent-context/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: write-agent-context
-description: Enforces minimal context in agent configuration files like AGENTS.md, CLAUDE.md, GEMINI.md, and *.mdc to improve task success rates and reduce inference costs. Use when writing or modifying agent context files.
+description: Enforces minimal, progressively-disclosed context in agent configuration files like AGENTS.md, CLAUDE.md, GEMINI.md, SKILL.md, and *.mdc to improve task success rates and reduce inference costs. Use when writing or modifying agent context files or skills.
 metadata:
-  purpose: "Provides context regarding the research at https://arxiv.org/abs/2602.11988"
+  purpose: "Provides context regarding the research at https://arxiv.org/abs/2602.11988 and https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models"
 ---
 
 # Write agent context
@@ -18,3 +18,7 @@ Do not include generic documentation, tutorials, or non-critical context.
 Restrict these files to repository-specific constraints and critical architecture maps.
 Ensure all documentation formats are written with one sentence per line to improve diff readability.
 Documentation titles and headers must use sentence case.
+The same restraint applies to skills (`SKILL.md`), not just `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`.
+
+Split long context into a tree of files loaded on demand, and reference sub-files instead of inlining everything into one dense file.
+Prefer brief, judgment-guided steering over rigid blanket rules for nuanced matters; reserve absolute rules for genuinely critical or safety-relevant invariants.

--- a/src/chezmoi/AGENTS.md
+++ b/src/chezmoi/AGENTS.md
@@ -1,14 +1,4 @@
-# Chezmoi Configuration
-
-This directory contains the Chezmoi source state for dotfiles management.
-
-## Directory Structure
-
-- `.chezmoidata/`: TOML data files loaded into the template context.
-- `.chezmoiexternals/`: External dependencies (archives, git repos) managed by Chezmoi.
-- `.chezmoiscripts/`: Scripts executed by `chezmoi apply` (e.g., `run_once_` scripts).
-- `.chezmoitemplates/`: Shared template fragments.
-- `dot_*/`: Files that will be deployed to the user's home directory (e.g., `dot_config` -> `~/.config`).
+# Chezmoi configuration
 
 ## Notable cross-cutting features
 
@@ -39,30 +29,18 @@ Documented here rather than inside `.chezmoidata/ai/command_policy/` itself: che
 - Why `git push`/`reset`/`clean` are excluded: see the rationale comment block in `git.toml`.
   Reflog-recoverability and remote-write/leak risk are the deciding factors, not "is it a local command."
 
-## Script Conventions
+## Script conventions
 
-### Sourcing Shared Libraries
+### Sourcing shared libraries
 
-Scripts in `.chezmoiscripts/` should source shared shell libraries (like `logging.sh`) from `.chezmoitemplates` using the absolute path provided by `{{ .chezmoi.sourceDir }}`.
-
-**Pattern:**
+Scripts in `.chezmoiscripts/` source shared shell libraries (e.g. `logging.sh`) from `.chezmoitemplates/` via `{{ .chezmoi.sourceDir }}`, not `.chezmoi.destDir` — `.chezmoitemplates/` files are never deployed, so only the source path resolves them.
+Use the absolute path, not a relative one (e.g. `../../.chezmoitemplates`) — the script's execution cwd varies.
 
 ```bash
-# Source logging library from chezmoi source
 CHEZMOI_SOURCE_DIR="{{ .chezmoi.sourceDir }}"
 source "${CHEZMOI_SOURCE_DIR}/.chezmoitemplates/shell/logging.sh"
 ```
 
-**Why:**
-- `{{ .chezmoi.sourceDir }}` resolves to the absolute path of the source directory.
-- This allows scripts to use shared utilities without them being deployed to the destination machine.
-- Avoid using relative paths (e.g., `../../.chezmoitemplates`) as the execution context might vary.
+### Referencing the repository root
 
-### Referencing repository root
-
-The `{{ .chezmoi.workingTree }}` attribute evaluates to the absolute path of the git repository root.
-This is useful for referencing project files (like Python source code) that live outside of the chezmoi source directory.
-
-### Referencing destination directory
-
-When referring to the destination home directory in scripts (e.g., for `PATH` manipulation), always use `{{ .chezmoi.destDir }}` instead of `{{ .chezmoi.homeDir }}` or hardcoded paths like `$HOME`.
+`{{ .chezmoi.workingTree }}` evaluates to the git repository root — use it for project files (e.g. Python source) that live outside the chezmoi source directory.

--- a/src/python/AGENTS.md
+++ b/src/python/AGENTS.md
@@ -2,58 +2,31 @@
 
 ## Creating a new tool
 
-1. **Create Python package**: `mkdir -p src/python/my_tool`
-   - `src/python/my_tool/main.py`: Entry point.
-   - `src/python/my_tool/pyproject.toml`:
-     ```toml
-     [project]
-     name = "my-tool"
-     version = "0.0.0"
-     requires-python = ">=3.14"
-     dependencies = ["typer>=0.15.1"]
+A new tool needs three registrations, or it won't build or deploy.
+Copy an existing package (e.g. `sandboxr/`) as a template for the shape.
 
-     [project.scripts]
-     my-tool = "my_tool.main:cli"
+1. `src/python/<name>/` package with `main.py` and a `pyproject.toml` declaring `[project.scripts]`.
+2. Added to `members` under `[tool.uv.workspace]` in the root `pyproject.toml`.
+3. A catalog entry in `src/chezmoi/.chezmoidata/local_bin_tools.toml` (`source_dir`, `package_name`), and an `installation_method = "dotfiles.uv"` entry in `.chezmoi.toml.tmpl` under `[data.local_bin_tools.<name>]`.
+   The catalog entry alone is inert — `chezmoi apply` only installs tools opted in via the second file.
 
-     [build-system]
-     requires = ["hatchling"]
-     build-backend = "hatchling.build"
-     ```
-
-2. **Register in workspace**: Add to `members` in the root `pyproject.toml`:
-   ```toml
-   [tool.uv.workspace]
-   members = [
-       "src/python/my_tool",
-       ...
-   ]
-   ```
-
-3. **Add chezmoi data**: In `src/chezmoi/.chezmoidata/local_bin_tools.toml`:
-   ```toml
-   [local_bin_tools.my_tool]
-   installation_method = "dotfiles.uv"
-   source_dir = "src/python/my_tool"
-   package_name = "my-tool"
-   ```
-
-4. **Deploy**: Run `chezmoi apply`.
-   - The executable name comes from `[project.scripts]`.
-   - The bin path is `{{ .chezmoi.destDir }}/.local/bin/dotfiles/my-tool`.
-   - Installation happens via the `run_onchange` script on apply.
+The executable name comes from `[project.scripts]`.
+It lands at `{{ .chezmoi.destDir }}/.local/bin/dotfiles/<name>` via the `run_onchange` install script.
 
 ## Renaming or retiring a tool
 
 Keep the old catalog key.
-Set a non-uv `installation_method` (e.g. `"uninstall"`) with its `package_name`.
-The script's uninstall branch removes the stale uv tool and bin symlink.
-Only delete the key after all machines have applied.
+Set `installation_method = "uninstall"` with its `package_name` so the `run_onchange` script's uninstall branch removes the stale uv tool and bin symlink.
+Delete the key only after all machines have applied.
 
 ## Module imports
 
-Use the package name directly (not the full workspace path):
-- ✅ `from my_tool.lib import ...`
-- ❌ `from src.python.my_tool.lib import ...`
+Import via the package name (`from my_tool.lib import ...`), not the workspace path (`from src.python.my_tool.lib import ...`).
+
+## Module organization
+
+Don't centralize types or models into `types.py` or `models.py`.
+Namespace them into their owning domain module instead.
 
 ## Quality tools
 
@@ -64,103 +37,13 @@ Use the package name directly (not the full workspace path):
 | `uv run ty check` | Type check |
 | `uv run pytest src/python` | Tests |
 
-## Coding guidelines
+Scope pytest to `src/python`.
+Unscoped, it also collects the top-level `tests/integration/` suite, which asserts against local machine state.
 
-Prefer functional, immutable, and non-imperative code.
-Avoid mutability and reassignment wherever possible.
-Code should be declarative and heavily lean on Python's built-in functional capabilities.
+Use `pytest-asyncio` (`@pytest.mark.asyncio`) for async tests, not `unittest.IsolatedAsyncioTestCase`.
 
-### Test asyncio
-When writing async tests, prefer using `pytest-asyncio` and decorating your test functions with `@pytest.mark.asyncio` rather than using `unittest.IsolatedAsyncioTestCase`.
+## Coding style
 
-### Module separation
-Do not put types or models in central `types.py` or `models.py` files.
-Instead, namespace types and models into their corresponding canonical domain locations.
-
-
-### Avoid `list.append()` and mutation
-
-Do not initialize empty lists and conditionally append or `extend` to them.
-Instead, use list comprehensions, generators, or build a sequence and filter it.
-
-❌ **Bad:**
-```python
-results = []
-if condition_a:
-    results.append("a")
-if condition_b:
-    results.append("b")
-```
-
-✅ **Good:**
-```python
-items = [
-    "a" if condition_a else None,
-    "b" if condition_b else None,
-]
-results = [item for item in items if item is not None]
-
-def get_results() -> Iterator[str]:
-    if condition_a:
-        yield "a"
-    if condition_b:
-        yield "b"
-```
-
-### Use immutable types for parameters
-
-Prefer `typing.Sequence`, `typing.Iterable`, `typing.Mapping`, and other immutable/read-only types over mutable ones like `list`.
-
-❌ **Bad:**
-```python
-def process_data(items: list[str]) -> list[str]:
-    ...
-```
-
-✅ **Good:**
-```python
-from collections.abc import Sequence, Iterable
-
-def process_data(items: Sequence[str]) -> Sequence[str]:
-    ...
-```
-
-### Avoid variable reassignment and string concatenation
-
-Treat variables as `const`.
-Do not reassign a variable once it is defined.
-For strings, avoid using `+=` or iterative concatenation.
-
-❌ **Bad:**
-```python
-message = "Hello"
-if condition:
-    message += ", User"
-else:
-    message += ", Guest"
-```
-
-✅ **Good:**
-```python
-name = "User" if condition else "Guest"
-message = f"Hello, {name}"
-
-parts = ["Hello", ", User" if condition else ", Guest"]
-message = "".join(parts)
-```
-
-### Anti-pattern: imperative list deduplication
-Avoid using mutable sets and `list.append()` inside loops for deduplication.
-**Anti-pattern:**
-```python
-seen = set()
-ordered = []
-for item in reversed(items):
-    if item not in seen:
-        seen.add(item)
-        ordered.append(item)
-```
-**Preferred:**
-```python
-ordered = list(dict.fromkeys(reversed(items)))
-```
+Prefer functional, declarative code: comprehensions and generators over manual accumulation, `Sequence`/`Iterable`/`Mapping` over `list` for read-only parameters.
+Match the surrounding code's idiom rather than forcing this where an imperative form is genuinely clearer.
+See [functional-style.md](functional-style.md) for the patterns and anti-patterns.

--- a/src/python/functional-style.md
+++ b/src/python/functional-style.md
@@ -1,0 +1,68 @@
+# Functional style in src/python
+
+Detail for the "Coding style" preference in [AGENTS.md](AGENTS.md).
+Prefer functional, declarative code over imperative accumulation and mutation — matched against the surrounding code's idiom, not forced where it hurts clarity.
+
+## Building collections
+
+Prefer a comprehension, a generator, or filtering a pre-built sequence over appending inside a loop.
+
+Bad:
+```python
+results = []
+if condition_a:
+    results.append("a")
+if condition_b:
+    results.append("b")
+```
+
+Better:
+```python
+items = ["a" if condition_a else None, "b" if condition_b else None]
+results = [item for item in items if item is not None]
+
+def get_results() -> Iterator[str]:
+    if condition_a:
+        yield "a"
+    if condition_b:
+        yield "b"
+```
+
+Reach for `list.append()` in a loop when the accumulation genuinely depends on prior iterations and a comprehension would obscure that.
+
+## Parameter types
+
+Prefer `Sequence`, `Iterable`, or `Mapping` over `list`/`dict` for parameters the function only reads.
+It documents that the callee won't mutate the argument.
+
+```python
+from collections.abc import Sequence
+
+def process_data(items: Sequence[str]) -> Sequence[str]: ...
+```
+
+## Reassignment and string building
+
+Prefer expressing a value once (ternary, f-string, `"".join(...)`) over reassigning a variable or concatenating a string incrementally.
+
+Bad:
+```python
+message = "Hello"
+if condition:
+    message += ", User"
+else:
+    message += ", Guest"
+```
+
+Better:
+```python
+name = "User" if condition else "Guest"
+message = f"Hello, {name}"
+```
+
+## Deduplication
+
+`dict.fromkeys()` preserves order and reads more directly than a `seen`-set loop:
+```python
+ordered = list(dict.fromkeys(reversed(items)))
+```


### PR DESCRIPTION
apply claude 5-gen context-engineering guidance (less-is-more, steering over prescribing, tree-of-files) across root and nested AGENTS.md/GEMINI.md enrich .rules/11-write-agent-context.md (+ .gemini/.cursor/.codex mirrors) with progressive-disclosure and steering-vs-prescribing guidance, and extend scope to SKILL.md
split src/python/AGENTS.md's functional-style examples into functional-style.md fix a stale destDir duplication in src/chezmoi/AGENTS.md and an inaccurate installation_method file reference in src/python/AGENTS.md, caught along the way


Committed-By-Agent: claude