### PR TITLE
feat(ai): support flat single-skill repos, onboard socrates skill

### DIFF
--- a/src/ai/README.md
+++ b/src/ai/README.md
@@ -24,6 +24,7 @@ brainstorming = "present"
 
 Each source downloads from an archive host (`host`, default `"github"`) declared under `[ai.skills.hosts.<name>]` with a `url_format` substituting `{repo}` and `{ref}`.
 Overlays can repoint a host at a proxy, add internal hosts (for example GitHub Enterprise), or set `url` on a source for a one-off published archive.
+A flat, single-skill repo (`SKILL.md` at the archive root, no `skills_root/<name>/` subdirectory) sets `skill_file = "SKILL.md"` instead of relying on `skills_root`; the `[.skills]` entry's key still names the installed skill directory.
 
 To compute the pin for a new ref:
 

--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -32,7 +32,10 @@ write-agent-context = "present"
 
 # External sources: [ai.skills.external.<name>] with repo, ref (commit SHA), sha256 (downloaded archive).
 # Optional: host (archive host key, default "github"), skills_root (default "skills"),
-# url (full archive URL for one-off published artifacts, bypasses host construction).
+# url (full archive URL for one-off published artifacts, bypasses host construction),
+# skill_file (for a flat, single-skill repo with SKILL.md at the archive root
+# instead of a skills_root/<name>/ subdirectory — selects that bare file directly;
+# the [.skills] entry's key still names the installed skill directory).
 # Each [.skills] entry maps an upstream skill directory name to a state:
 #   "present" (all tools), "absent" (pruned everywhere), or a single tool name
 #   ("claude", "antigravity", "cursor") to deploy only to that tool.
@@ -172,3 +175,17 @@ skills_root = "plugins/developer-essentials/skills"
 
 [ai.skills.external.wshobson-developer-essentials.skills]
 bazel-build-optimization = "present"
+
+# Onboarded 2026-07-29: socrates audited (security: approve, no caveat —
+# plain-markdown teaching prompt, no scripts, no external fetches, no content
+# beyond the documented Socratic-questioning behavior). Flat single-file repo
+# (SKILL.md at archive root, no skills/ subdirectory); uses skill_file instead
+# of skills_root.
+[ai.skills.external.socrates]
+repo = "bevibing/socrates-skill"
+ref = "becb2e51fe7ed063f5f3304cccf8da03aacef6cf" # 2026-04-02
+sha256 = "f18b663b78f346a06a1705c99adbf84b46f2a76b2d9c6d1fc49dec220f9f66f0"
+skill_file = "SKILL.md"
+
+[ai.skills.external.socrates.skills]
+socrates = "present"

--- a/src/chezmoi/.chezmoiexternals/ai-skills.toml.tmpl
+++ b/src/chezmoi/.chezmoiexternals/ai-skills.toml.tmpl
@@ -3,6 +3,9 @@
   catalog in .chezmoidata/ai/skills.toml. Each external downloads the pinned
   upstream archive (verified against sha256, cached once per URL) and pipes it
   through skill_filter to re-root a single skill directory at the target.
+  A source with "skill_file" set (flat, single-skill repo with SKILL.md at
+  the archive root instead of a skills_root/<name>/ subdirectory) selects
+  that bare file directly rather than a subtree.
   The filter runs via system python3 and must stay stdlib-only because uv and
   mise are not installed until after apply. Target directories are fixed by
   each tool's skill discovery and are hardcoded here; overlays deselect skills
@@ -29,7 +32,11 @@
 {{-         end -}}
 {{-         $url = $host.url_format | replace "{repo}" $source.repo | replace "{ref}" $source.ref -}}
 {{-       end -}}
-{{-       $path := printf "%s/%s" (dig "skills_root" "skills" $source) $skillName -}}
+{{-       $skillFile := dig "skill_file" "" $source -}}
+{{-       $selectArg := $skillFile -}}
+{{-       if not $skillFile -}}
+{{-         $selectArg = printf "%s/%s:." (dig "skills_root" "skills" $source) $skillName -}}
+{{-       end -}}
 {{-       range $toolName, $skillsDir := $tools -}}
 {{-         if or (eq $state "present") (eq $state $toolName) -}}
 {{-           $entry := dict
@@ -40,7 +47,7 @@
                 "format" "tar"
                 "filter" (dict
                   "command" $python
-                  "args" (list "-S" $script "--cache-key" $source.sha256 "--select" (printf "%s:." $path)))
+                  "args" (list "-S" $script "--cache-key" $source.sha256 "--select" $selectArg))
 -}}
 {{-           $_ := set $config (printf "%s/%s" $skillsDir $skillName) $entry -}}
 {{-         end -}}


### PR DESCRIPTION
Adds skill_file to the external-skill catalog schema for repos that ship SKILL.md at the archive root instead of a skills_root/<name>/ subdirectory. Onboards bevibing/socrates-skill (161 stars, MIT), a Socratic-method teaching skill that guides learning through questions instead of direct answers.

Committed-By-Agent: claude