### PR TITLE
fix(chezmoi): skip systemd service enable when already done or no sudo access

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-apt-packages.sh.tmpl
@@ -66,10 +66,17 @@ fi
 
 {{- if $service }}
 if check_command systemctl; then
-    log_info "🔒 Enabling {{ $service }} service..."
-    sudo systemctl enable --now {{ $service }} \
-        || { log_error "Failed to enable {{ $service }} service"; exit 1; }
-    log_success "{{ $service }} enabled and started"
+    if systemctl is-enabled --quiet {{ $service }} 2>/dev/null && systemctl is-active --quiet {{ $service }}; then
+        log_success "{{ $service }} already enabled and running"
+    elif sudo -n true 2>/dev/null || [ -t 0 ]; then
+        log_info "🔒 Enabling {{ $service }} service..."
+        sudo systemctl enable --now {{ $service }} \
+            || { log_error "Failed to enable {{ $service }} service"; exit 1; }
+        log_success "{{ $service }} enabled and started"
+    else
+        log_warn "No TTY and no cached sudo credentials — skipping {{ $service }} enable, will retry next apply"
+        exit 1
+    fi
 else
     log_warn "systemctl not found — skipping {{ $service }} service enable"
 fi


### PR DESCRIPTION
## Summary
- `run_onchange_install-apt-packages.sh.tmpl`'s systemd-service-enable step always ran `sudo systemctl enable --now <service>` unconditionally, so a non-interactive apply (no TTY, no cached sudo ticket) hard-failed even when the service was already enabled and running — hit this today via `atd`.
- Adds an `is-enabled`/`is-active` guard mirroring the existing `dpkg -l` idempotency check used for package installs, so once a service is enabled it's a no-op.
- Probes `sudo -n true` (covers cached credentials and passwordless sudo) before falling back to an interactive prompt, and only warns+exits when enabling is actually still needed.
- No code change needed for the "retry on next apply" behavior — chezmoi only persists the onchange script's success hash when it exits 0, so a non-zero exit already guarantees a retry on the next `chezmoi apply`.

## Test plan
- [x] `chezmoi execute-template -f --with-stdin` renders the template cleanly with the new branch
- [x] `shellcheck -x` on the rendered script passes
- [x] `uv run pytest tests/integration/test_shellcheck.py tests/integration/test_conftest.py` — 55 passed, 7 skipped