### PR TITLE
feat(ai): allow git rev-parse in command approval policy

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/git.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/git.toml
@@ -23,6 +23,7 @@
 "git pull" = "allow"
 "git rebase" = "allow"
 "git restore" = "allow"
+"git rev-parse" = "allow"
 "git show" = "allow"
 "git stash" = "allow"
 "git status" = "allow"


### PR DESCRIPTION
## Summary
- Adds `"git rev-parse" = "allow"` to `.chezmoidata/ai/command_policy/git.toml` — read-only ref/path resolution, no network write, no data-loss risk, same bucket as the already-allowed `git status`/`git log`.
- Single source renders into both Claude Code's and Antigravity's (`agy`) `permissions.allow`, no per-tool wiring needed.

## Test plan
- [x] Rendered `dot_claude/modify_settings.json` and `dot_gemini/antigravity-cli/modify_settings.json` locally — `git rev-parse` present in both
- [x] `uv run pytest tests/integration -k "command_policy or settings"` — 4 passed, 2 skipped