### PR TITLE
fix(vscode): send CSI Alt+arrow sequences instead of readline word-nav escape

### DIFF
--- a/src/chezmoi/.chezmoidata/vscode.toml
+++ b/src/chezmoi/.chezmoidata/vscode.toml
@@ -6,3 +6,22 @@ key = "shift+enter"
 command = "workbench.action.terminal.sendSequence"
 when = "terminalFocus"
 args = { text = "\u001b[13;2u" }
+
+# VS Code/Cursor hardcode Option+Right/Left in the integrated terminal to the
+# readline word-nav convention (ESC f / ESC b) instead of standard CSI
+# Alt+arrow sequences. Zellij's input parser can't tell ESC f apart from a
+# literal Alt+F keypress, so Option+Right fires zellij's "Alt f" binding
+# (ToggleFloatingPanes) instead of MoveFocusOrTab. Send the CSI form other
+# terminals (Ghostty, iTerm2, kitty) already send.
+[[vscode.keybindings]]
+key = "alt+right"
+command = "workbench.action.terminal.sendSequence"
+when = "terminalFocus"
+args = { text = "\u001b[1;3C" }
+
+[[vscode.keybindings]]
+key = "alt+left"
+command = "workbench.action.terminal.sendSequence"
+when = "terminalFocus"
+args = { text = "\u001b[1;3D" }
+


### PR DESCRIPTION
VS Code/Cursor hardcode Option+Right/Left to ESC f / ESC b (readline word-nav), which zellij's parser can't distinguish from literal Alt+F, firing ToggleFloatingPanes instead of MoveFocusOrTab. Send the same CSI sequences Ghostty/iTerm2/kitty already send.

Committed-By-Agent: claude