### PR TITLE
chore: update chezmoi and mise versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   CHEZMOI_CACHE_DIR: /tmp/.chezmoi-cache
   CHEZMOI_CONFIG: /tmp/.chezmoi-config.toml
   CHEZMOI_DEST: /tmp/chezmoi-test
-  CHEZMOI_VERSION: v2.71.0
+  CHEZMOI_VERSION: v2.71.1
 
 defaults:
   run:

--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -1,6 +1,6 @@
 # mise version already includes "v" prefix — tag_format = "{version}" (no added v)
 [bin.mise]
-version = "v2026.7.7"
+version = "v2026.7.14"
 
 [bin.mise.github_releases]
 repo            = "jdx/mise"
@@ -18,10 +18,10 @@ linux_amd64  = "linux-x64"
 linux_arm64  = "linux-arm64"
 
 [bin.mise.github_releases.checksums]
-darwin_arm64 = "5b890cccc75fc43a494b83ace21dbd2ee26120ff19ba1994cdcd054b3a15abbd"
-darwin_amd64 = "7b860e6495eea9a264a16dae575ac20d5618ea2fe97905756c661eb02035c5d9"
-linux_amd64  = "429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c"
-linux_arm64  = "1b4ef061d25f0ceb508f11169482f3074e55c1698a1494f666386b2fcfb46b9b"
+darwin_arm64 = "082262daa1cd73e22f71272c574afda560c4fcf39852bc18884eae9e13cd5f2c"
+darwin_amd64 = "3a3cf40fd034f83bd5cdffd4d673d40b04a79d06affbd30e5fcc4f00ae0ac460"
+linux_amd64  = "fc96308f4fa085d7359892ac6351ededb35ecfabf1ddc34f5757bc755a2af8a6"
+linux_arm64  = "94a01dd78c22819aa38f9ef6c0780f48d5160b7f1f557407d6d486667296be6d"
 
 [mise]
 


### PR DESCRIPTION
This PR updates `chezmoi` and `mise` versions in accordance with the minimum release age and security constraints.

- `chezmoi` is bumped to `v2.71.1` (released > 7 days ago).
- `mise` is bumped to `v2026.7.14`, which contains a critical security patch addressing config trust, satisfying the security override constraint.
- The corresponding `mise` raw binary SHA256 hashes are updated for `darwin_arm64`, `darwin_amd64`, `linux_amd64`, and `linux_arm64`.

---
*PR created automatically by Jules for task [1243845111363785897](https://jules.google.com/task/1243845111363785897) started by @mkobit*