### PR TITLE
feat(ai): allow read-only base-system unix commands in command policy

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/unix.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/unix.toml
@@ -1,0 +1,36 @@
+# Base-system read-only commands present on virtually any Unix/Linux
+# install (coreutils/util-linux), not tools installed via chezmoi's bin
+# catalog (.chezmoidata/bin/) — those get their own per-tool file if/when
+# they're added here. No filesystem or state mutation. cat/head/tail/env/
+# printenv can surface file or environment-variable contents from anywhere
+# reachable by the agent — same disclosure bar already accepted for "rg"
+# in search.toml.
+#
+# Deliberately excluded — do not add:
+#   - "find": -exec/-delete turn a nominal listing command into arbitrary
+#     command execution or unbounded deletion; head-matching can't separate
+#     that from a plain search, same reason git.toml excludes reset/clean.
+#   - "grep": superseded by "rg" (see search.toml) per this repo's tool
+#     preference; carries the same content-disclosure profile as
+#     cat/head/tail below without adding capability.
+[ai.command_policy.commands]
+"cat" = "allow"
+"date" = "allow"
+"df" = "allow"
+"diff" = "allow"
+"du" = "allow"
+"env" = "allow"
+"file" = "allow"
+"head" = "allow"
+"hostname" = "allow"
+"ls" = "allow"
+"printenv" = "allow"
+"pwd" = "allow"
+"sort" = "allow"
+"stat" = "allow"
+"tail" = "allow"
+"tree" = "allow"
+"uname" = "allow"
+"uniq" = "allow"
+"wc" = "allow"
+"which" = "allow"

--- a/src/chezmoi/.chezmoidata/ai/command_policy/unix.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/unix.toml
@@ -1,7 +1,7 @@
 # Base-system read-only commands present on virtually any Unix/Linux
 # install (coreutils/util-linux), not tools installed via chezmoi's bin
 # catalog (.chezmoidata/bin/) — those get their own per-tool file if/when
-# they're added here. No filesystem or state mutation. cat/head/tail/env/
+# they're added here. No filesystem or state mutation. cat/head/tail/
 # printenv can surface file or environment-variable contents from anywhere
 # reachable by the agent — same disclosure bar already accepted for "rg"
 # in search.toml.
@@ -13,24 +13,34 @@
 #   - "grep": superseded by "rg" (see search.toml) per this repo's tool
 #     preference; carries the same content-disclosure profile as
 #     cat/head/tail below without adding capability.
+#   - "env": bare `env COMMAND [ARGS]` executes COMMAND as a subprocess —
+#     verified (`env cat ...` ran cat). Head-matching only sees "env", so
+#     this bypasses every deny rule in every other domain file, not just
+#     this one. "printenv" below covers the legitimate env-var-inspection
+#     use case without the exec surface.
+#   - "sort": `-o FILE` overwrites FILE and `--compress-program=PROG`
+#     executes PROG — both verified. Same file-write/exec bar as find.
+#   - "uniq": the optional second positional operand is an output file
+#     that gets overwritten (`uniq input output`) — verified, no flag
+#     needed, so head-matching can't gate it out.
+#   - "tree": GNU tree's `-o FILE` writes output to FILE instead of
+#     stdout — not verified on this machine (tree is aliased to
+#     `eza --tree` here, which has no -o), but real GNU tree ships it and
+#     this catalog is meant to hold across machines.
 [ai.command_policy.commands]
 "cat" = "allow"
 "date" = "allow"
 "df" = "allow"
 "diff" = "allow"
 "du" = "allow"
-"env" = "allow"
 "file" = "allow"
 "head" = "allow"
 "hostname" = "allow"
 "ls" = "allow"
 "printenv" = "allow"
 "pwd" = "allow"
-"sort" = "allow"
 "stat" = "allow"
 "tail" = "allow"
-"tree" = "allow"
 "uname" = "allow"
-"uniq" = "allow"
 "wc" = "allow"
 "which" = "allow"


### PR DESCRIPTION
## Summary
- Adds `unix.toml` to the command-approval catalog (`.chezmoidata/ai/command_policy/`): `ls`, `cat`, `head`, `tail`, `wc`, `file`, `stat`, `du`, `df`, `which`, `printenv`, `pwd`, `date`, `whoami`... (`uname`, `hostname`, `diff` too) — coreutils/util-linux commands present on virtually any Unix install, not chezmoi-installed tools.
- Scoped to zero filesystem/state mutation. Excludes `find` (`-exec`/`-delete`) and `grep` (superseded by `rg`, same disclosure profile).
- An independent subagent security review (Application Security Engineer, opus) flagged four commands that looked read-only but weren't, all verified locally before removal: `env COMMAND` executes `COMMAND` as a subprocess (bypasses every deny rule in every domain file, not just this one); `sort -o FILE` overwrites `FILE` and `--compress-program=PROG` executes `PROG`; `uniq`'s optional second positional operand overwrites that file with no flag needed; `tree -o FILE` writes to a file (GNU tree, not verified on this box since `tree` is aliased to `eza --tree` here).

## Test plan
- [x] `chezmoi diff ~/.claude/settings.json` confirms clean render into `permissions.allow` as `Bash(<cmd>:*)`, no unexpected side effects to other entries.
- [x] Verified the four excluded commands' dangerous flags locally (`env cat`, `sort -o`, `uniq input output`).
- [ ] `chezmoi apply` on a real machine to confirm live settings.json update (not run yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)