### PR TITLE
feat(ai): allow bd stats in command policy

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/beads.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/beads.toml
@@ -100,6 +100,7 @@
 "bd show" = "allow"
 "bd stale" = "allow"
 "bd state" = "allow"
+"bd stats" = "allow"
 "bd status" = "allow"
 "bd statuses" = "allow"
 "bd supersede" = "allow"


### PR DESCRIPTION
## Summary
- Adds `bd stats` to the beads command-policy allowlist — read-only query, same class as `bd status`/`bd state`/`bd count`, was simply missing.

## Test plan
- [x] `chezmoi diff` reviewed — renders into Claude/Gemini/etc. settings as expected
- [x] `chezmoi apply` run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)