### PR TITLE
feat(ai): onboard diataxis documentation-governance skill

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/skills.toml
+++ b/src/chezmoi/.chezmoidata/ai/skills.toml
@@ -69,6 +69,19 @@ sha256 = "3fa5cb4472fc79626be4ebc3bf997b1ef57e413b8801a7ccac874860b287317f"
 skill-creator = "claude" # authoring tooling is only useful inside Claude Code
 webapp-testing = "absent"
 
+# Onboarded 2026-08-05: diataxis audited (security: approve, no caveat —
+# plain-markdown documentation-governance skill, no scripts, no external
+# fetches). Flat repo with the skill directory at the archive root (no
+# skills/ subdirectory); uses skills_root = "." instead of the default.
+[ai.skills.external.diataxis]
+repo = "keithpatton/diataxis-agent-skill"
+ref = "5b095a5e7aebe77ce4af855809123e12d92b9efd" # 2026-08-05
+sha256 = "eff8b85a38e5c7a03cf9ce48ec9972217b86def7e6647709fbe86e1a423c0634"
+skills_root = "."
+
+[ai.skills.external.diataxis.skills]
+diataxis = "present"
+
 # Built distribution repo (GoogleChrome/modern-web-guidance-src is the source repo;
 # its skills-src content is bundled into the modern-web-guidance skill's guides here).
 [ai.skills.external.modern-web-guidance]


### PR DESCRIPTION
## Summary
- Pins `keithpatton/diataxis-agent-skill` (from a tessl.io registry link) at `5b095a5`, deployed `present` on all four tools (claude, antigravity, cursor, codex).
- Security audit: plain markdown only (SKILL.md + 3 reference docs), no scripts, no external fetches — approved with no caveat.
- New `skills_root = "."` catalog pattern: this repo's skill dir sits at the archive root instead of under a `skills/` subdirectory.
- Licensed CC-BY-SA-4.0 (first ShareAlike source in the catalog; existing sources are MIT/Apache-2.0). Attribution retained in the deployed SKILL.md.

## Test plan
- [x] Verified `skill_filter` re-roots the selection correctly against the downloaded tarball (`SKILL.md` + `references/` at output root, LICENSE/README excluded)
- [x] `chezmoi diff` shows only the expected new files across `.claude/skills/diataxis`, `.codex/skills/diataxis`, `.cursor/skills/diataxis`, `.gemini/antigravity-cli/skills/diataxis`
- [x] `chezmoi apply` deployed and confirmed live on disk for all four targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)