### PR TITLE
Add anti-bloat bullet to shared agent guidelines

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/guidelines.toml
+++ b/src/chezmoi/.chezmoidata/ai/guidelines.toml
@@ -17,7 +17,8 @@ content = """
 ## Approach
 - State assumptions before implementing; if multiple interpretations exist, surface them rather than picking silently.
 - Ask rather than guess.
-- Minimum code for the task; no speculative features or abstractions."""
+- Minimum code for the task; no speculative features or abstractions.
+- Minimal prose for the task; don't inflate with session length — no recapping known context, no narrating steps before doing them, no praise or hedge filler."""
 
 [[ai.guidelines.sections]]
 content = """


### PR DESCRIPTION
Response length and tone drift upward over long sessions (recapping context, narrating steps, hedge/praise filler); this line is injected into every Claude Code and Codex CLI session via guidelines.toml.

Committed-By-Agent: claude