### PR TITLE
add git ls-files to command policy allowlist

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/git.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/git.toml
@@ -18,6 +18,7 @@
 "git diff" = "allow"
 "git fetch" = "allow"
 "git log" = "allow"
+"git ls-files" = "allow"
 "git merge" = "allow"
 "git mv" = "allow"
 "git pull" = "allow"


### PR DESCRIPTION
Add `git ls-files` to `src/chezmoi/.chezmoidata/ai/command_policy/git.toml` so AI coding agents auto-approve read-only repository file listings.