### PR TITLE
ignore agent worktrees in global gitignore

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -14,3 +14,6 @@ mise.local.toml
 __pycache__/
 *.py[cod]
 .claude/settings.local.json
+# Agent git worktrees
+.worktrees/
+.worktree/


### PR DESCRIPTION
adds .worktrees/ and .worktree/ to gitignore_global snippet