### PR TITLE
feat: enable vim mode in antigravity-cli

### DIFF
--- a/src/chezmoi/.chezmoidata/agy.toml
+++ b/src/chezmoi/.chezmoidata/agy.toml
@@ -1,3 +1,3 @@
 [agy]
 # Update to trigger reinstall; installer always fetches latest from the manifest service
-version             = "1.0.2"
+version             = "1.1.11"

--- a/src/chezmoi/dot_gemini/antigravity-cli/modify_settings.json
+++ b/src/chezmoi/dot_gemini/antigravity-cli/modify_settings.json
@@ -34,7 +34,6 @@
         "general" (dict
           "enableAutoUpdate" .gemini.general.enable_auto_update
           "previewFeatures" .gemini.general.preview_features
-          "vimMode" .gemini.general.vim_mode
           "sessionRetention" (dict
             "enabled" .gemini.general.sessionRetention.enabled
             "maxAge" .gemini.general.sessionRetention.max_age
@@ -68,6 +67,9 @@
           "enabled" true
         )
   -}}
+{{-   if .gemini.general.vim_mode -}}
+{{-     $settings = set $settings "editorMode" "vim" -}}
+{{-   end -}}
 {{-   $config = mergeOverwrite $config $settings -}}
 {{- end -}}
 {{- $config | toPrettyJson | trimSuffix "\n" -}}

--- a/test_json.sh
+++ b/test_json.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+chezmoi -S "$(pwd)/src/chezmoi" execute-template < src/chezmoi/dot_gemini/antigravity-cli/modify_settings.json

--- a/test_json.sh
+++ b/test_json.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-chezmoi -S "$(pwd)/src/chezmoi" execute-template < src/chezmoi/dot_gemini/antigravity-cli/modify_settings.json


### PR DESCRIPTION
Bumps antigravity-cli to v1.1.11 which adds vim mode.
Maps `.gemini.general.vim_mode` to the new top-level `editorMode: "vim"` key in `settings.json` according to the new release format.

---
*PR created automatically by Jules for task [10737949975318553333](https://jules.google.com/task/10737949975318553333) started by @mkobit*