### PR TITLE
fix(termstatus): handle unknown payload fields and timedelta cache serialization

### DIFF
--- a/src/python/termstatus/termstatus/cache.py
+++ b/src/python/termstatus/termstatus/cache.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 
 from whenever import Instant
@@ -64,7 +64,17 @@ class SegmentCache:
                 self.cache_file.parent.mkdir(parents=True, exist_ok=True)
                 serialized = {
                     key: {
-                        "results": [asdict(r) for r in cs.results],
+                        "results": [
+                            {
+                                "segment": {"text": r.segment.text},
+                                "line": r.line,
+                                "index": r.index,
+                                "column": r.column,
+                                "generator": r.generator,
+                                "cache_duration": str(r.cache_duration) if r.cache_duration is not None else None,
+                            }
+                            for r in cs.results
+                        ],
                         "expires_at": str(cs.expires_at),
                     }
                     for key, cs in cache_data.items()

--- a/src/python/termstatus/termstatus/payload.py
+++ b/src/python/termstatus/termstatus/payload.py
@@ -1,6 +1,14 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
+
+
+def _instantiate_dataclass[T](cls: type[T], data: Any) -> T:
+    if not isinstance(data, dict):
+        return cls()
+    valid_fields = {f.name for f in fields(cls)}
+    filtered = {k: v for k, v in data.items() if k in valid_fields}
+    return cls(**filtered)
 
 
 @dataclass
@@ -100,51 +108,32 @@ class StatusLineStdIn:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> StatusLineStdIn:
-        model_raw = data.get("model")
-        model = ModelInfo(**model_raw) if isinstance(model_raw, dict) else ModelInfo()
+        if not isinstance(data, dict):
+            return cls()
 
-        workspace_raw = data.get("workspace")
-        workspace = WorkspaceInfo(**workspace_raw) if isinstance(workspace_raw, dict) else WorkspaceInfo()
-
-        cost_raw = data.get("cost")
-        cost = CostInfo(**cost_raw) if isinstance(cost_raw, dict) else CostInfo()
+        model = _instantiate_dataclass(ModelInfo, data.get("model"))
+        workspace = _instantiate_dataclass(WorkspaceInfo, data.get("workspace"))
+        cost = _instantiate_dataclass(CostInfo, data.get("cost"))
 
         cw_raw = data.get("context_window")
         if isinstance(cw_raw, dict):
-            cu_raw = cw_raw.get("current_usage")
-            cu = CurrentUsageInfo(**cu_raw) if isinstance(cu_raw, dict) else CurrentUsageInfo()
-            cw = ContextWindowInfo(
-                total_input_tokens=cw_raw.get("total_input_tokens", 0),
-                total_output_tokens=cw_raw.get("total_output_tokens", 0),
-                context_window_size=cw_raw.get("context_window_size", 0),
-                used_percentage=cw_raw.get("used_percentage", 0.0),
-                remaining_percentage=cw_raw.get("remaining_percentage", 0.0),
-                current_usage=cu,
-            )
+            cw = _instantiate_dataclass(ContextWindowInfo, cw_raw)
+            cw.current_usage = _instantiate_dataclass(CurrentUsageInfo, cw_raw.get("current_usage"))
         else:
             cw = ContextWindowInfo()
 
         rl_raw = data.get("rate_limits")
         if isinstance(rl_raw, dict):
-            fh_raw = rl_raw.get("five_hour")
-            fh = RateLimitWindow(**fh_raw) if isinstance(fh_raw, dict) else RateLimitWindow()
-            sd_raw = rl_raw.get("seven_day")
-            sd = RateLimitWindow(**sd_raw) if isinstance(sd_raw, dict) else RateLimitWindow()
+            fh = _instantiate_dataclass(RateLimitWindow, rl_raw.get("five_hour"))
+            sd = _instantiate_dataclass(RateLimitWindow, rl_raw.get("seven_day"))
             rl = RateLimits(five_hour=fh, seven_day=sd)
         else:
             rl = RateLimits()
 
-        out_raw = data.get("output_style")
-        output_style = OutputStyle(**out_raw) if isinstance(out_raw, dict) else OutputStyle()
-
-        vim_raw = data.get("vim")
-        vim = VimInfo(**vim_raw) if isinstance(vim_raw, dict) else VimInfo()
-
-        agent_raw = data.get("agent")
-        agent = AgentInfo(**agent_raw) if isinstance(agent_raw, dict) else AgentInfo()
-
-        wt_raw = data.get("worktree")
-        worktree = WorktreeInfo(**wt_raw) if isinstance(wt_raw, dict) else WorktreeInfo()
+        output_style = _instantiate_dataclass(OutputStyle, data.get("output_style"))
+        vim = _instantiate_dataclass(VimInfo, data.get("vim"))
+        agent = _instantiate_dataclass(AgentInfo, data.get("agent"))
+        worktree = _instantiate_dataclass(WorktreeInfo, data.get("worktree"))
 
         return cls(
             model=model,
@@ -163,3 +152,4 @@ class StatusLineStdIn:
             agent=agent,
             worktree=worktree,
         )
+

--- a/src/python/termstatus/termstatus/payload.py
+++ b/src/python/termstatus/termstatus/payload.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 def _instantiate_dataclass[T](cls: type[T], data: Any) -> T:
     if not isinstance(data, dict):
         return cls()
-    valid_fields = {f.name for f in fields(cls)}
+    valid_fields = {f.name for f in fields(cast(Any, cls))}
     filtered = {k: v for k, v in data.items() if k in valid_fields}
     return cls(**filtered)
 

--- a/src/python/termstatus/termstatus/payload.py
+++ b/src/python/termstatus/termstatus/payload.py
@@ -152,4 +152,3 @@ class StatusLineStdIn:
             agent=agent,
             worktree=worktree,
         )
-

--- a/src/python/termstatus/tests/test_cache.py
+++ b/src/python/termstatus/tests/test_cache.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 import pytest
-from whenever import Instant, hours
+from whenever import Instant, TimeDelta, hours
 
 from termstatus.cache import SegmentCache
 from termstatus.layout import Segment, SegmentGenerationResult
@@ -142,3 +142,26 @@ def test_cache_load_io_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -
 
     assert bad_cache._cache == {}
     assert "Failed to load cache from" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_cache_save_with_timedelta_cache_duration(cache: SegmentCache, cache_file: Path) -> None:
+    """Goals: Verify that SegmentGenerationResult containing a TimeDelta cache_duration serializes cleanly."""
+    results = [
+        SegmentGenerationResult(
+            line=1,
+            index=10,
+            column=1,
+            generator="internal.git",
+            segment=Segment(text="main"),
+            cache_duration=TimeDelta(seconds=5),
+        )
+    ]
+    expires = Instant.from_utc(2026, 1, 1, 12, 0, 0)
+    await cache.set("git_key", results, expires)
+
+    new_cache = SegmentCache(cache_file)
+    new_cache.load()
+    assert "git_key" in new_cache._cache
+    assert new_cache._cache["git_key"].results[0].segment.text == "main"
+

--- a/src/python/termstatus/tests/test_cache.py
+++ b/src/python/termstatus/tests/test_cache.py
@@ -164,4 +164,3 @@ async def test_cache_save_with_timedelta_cache_duration(cache: SegmentCache, cac
     new_cache.load()
     assert "git_key" in new_cache._cache
     assert new_cache._cache["git_key"].results[0].segment.text == "main"
-

--- a/src/python/termstatus/tests/test_main.py
+++ b/src/python/termstatus/tests/test_main.py
@@ -262,5 +262,21 @@ def test_git_cancellation_and_p99_latency_under_slow_git():
     assert p99_ms < 200.0, f"P99 latency under slow git was {p99_ms:.2f}ms (> 200.0ms)"
 
 
+def test_claude_render_with_unknown_payload_fields(tmp_path):
+    """Goals: Verify that unknown fields in payload sub-objects do not cause validation failure."""
+    raw = json.dumps(
+        {
+            "model": {"id": "claude-3-7-sonnet", "display_name": "Sonnet 3.7 Custom", "extra_vendor": "anthropic"},
+            "cost": {"total_cost_usd": 3.50, "total_duration_ms": 12000, "extra_metric": 99},
+            "workspace": {"current_dir": "/tmp", "extra_ws": True},
+        }
+    )
+    with patch.dict(os.environ, {"XDG_CACHE_HOME": str(tmp_path)}):
+        result = runner.invoke(cli, ["claude", "render"], input=raw)
+        assert result.exit_code == 0
+        assert "Sonnet 3.7 Custom" in result.stdout
+        assert "$3.50" in result.stdout
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
filters dataclass kwarg instantiation in payload.py to drop unknown fields from Claude Code payloads.
serializes SegmentGenerationResult cache_duration field to string during cache.json writes.
adds test coverage for unknown payload fields and cache serialization.