### PR TITLE
feat(bin): add Docker Sandboxes (sbx) tool

### DIFF
--- a/src/chezmoi/.chezmoi.toml.tmpl
+++ b/src/chezmoi/.chezmoi.toml.tmpl
@@ -63,6 +63,9 @@ installation_method = {{ if eq .chezmoi.os "darwin" }}"homebrew"{{ else if and (
 [data.local.bin.opencode]
 installation_method = {{ if eq .chezmoi.os "linux" }}"github_releases"{{ else }}"none"{{ end }}
 
+[data.local.bin.sbx]
+installation_method = {{ if eq .chezmoi.os "linux" }}"github_releases"{{ else }}"none"{{ end }}
+
 [data.local.bin.gh]
 installation_method = "github_releases"
 

--- a/src/chezmoi/.chezmoidata/bin/sbx.toml
+++ b/src/chezmoi/.chezmoidata/bin/sbx.toml
@@ -1,0 +1,24 @@
+[bin.sbx]
+version = "0.38.0"
+
+[bin.sbx.github_releases]
+repo            = "docker/sbx-releases"
+external_type   = "archive-file"
+executable      = true
+checksum_type   = "sha256"
+tag_format      = "v{version}"
+filename_format = "DockerSandboxes-{target}.{ext}"
+path_format     = "docker-sbx/sbx"
+url_format      = "{base}/{repo}/releases/download/{tag}/{filename}"
+
+[bin.sbx.github_releases.platforms]
+linux_amd64 = "linux-amd64"
+linux_arm64 = "linux-arm64"
+
+[bin.sbx.github_releases.ext]
+linux_amd64 = "tar.gz"
+linux_arm64 = "tar.gz"
+
+[bin.sbx.github_releases.checksums]
+linux_amd64 = "9ebcea831d4d270e25ae1777bf15e24756abfbf8791ad27294754682838ed00b"
+linux_arm64 = "051fdf8349f8a66db47a990e11a30cd1d2e013ac6c8e42e48c072bfcec06a1d5"

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -39,6 +39,23 @@ def test_opencode_help(host):
 
 
 @pytest.mark.integration
+@pytest.mark.chezmoi_installation("local.bin.sbx", methods={"github_releases"})
+@pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
+def test_sbx_available(host, shell_cmd):
+    """Verify sbx is on PATH in bash and zsh, if supported by the OS."""
+    result = host.run(f"{shell_cmd} 'command -v sbx'")
+    assert result.rc == 0, f"'sbx' not found via {shell_cmd!r}.\nstderr: {result.stderr}"
+
+
+@pytest.mark.integration
+@pytest.mark.chezmoi_installation("local.bin.sbx", methods={"github_releases"})
+def test_sbx_help(host):
+    """Verify sbx --help runs successfully on supported platforms."""
+    result = host.run("sbx --help")
+    assert result.rc == 0, f"'sbx --help' failed.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+
+
+@pytest.mark.integration
 @pytest.mark.chezmoi_installation("agy", methods={"dotfiles.script", "preinstalled"})
 @pytest.mark.parametrize("shell_cmd", ["bash -l -c", "zsh -l -c"])
 def test_agy_available(host, shell_cmd):


### PR DESCRIPTION
adds catalog entry for Docker Sandboxes (`sbx`) v0.38.0 from [docker/sbx-releases](https://github.com/docker/sbx-releases).
enables `sbx` via `github_releases` on Linux in `.chezmoi.toml.tmpl`.
adds integration tests for `sbx` availability and `--help` in `tests/integration/test_cli_tools.py`.