### PR TITLE
feat(bin): deploy full sbx directory to ~/.local/lib/docker-sbx

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/sbx.toml
+++ b/src/chezmoi/.chezmoidata/bin/sbx.toml
@@ -2,14 +2,14 @@
 version = "0.38.0"
 
 [bin.sbx.github_releases]
-repo            = "docker/sbx-releases"
-external_type   = "archive-file"
-executable      = true
-checksum_type   = "sha256"
-tag_format      = "v{version}"
-filename_format = "DockerSandboxes-{target}.{ext}"
-path_format     = "docker-sbx/sbx"
-url_format      = "{base}/{repo}/releases/download/{tag}/{filename}"
+repo             = "docker/sbx-releases"
+external_type    = "archive"
+checksum_type    = "sha256"
+tag_format       = "v{version}"
+filename_format  = "DockerSandboxes-{target}.{ext}"
+path_format      = "lib/docker-sbx"
+url_format       = "{base}/{repo}/releases/download/{tag}/{filename}"
+strip_components = 1
 
 [bin.sbx.github_releases.platforms]
 linux_amd64 = "linux-amd64"

--- a/src/chezmoi/.chezmoitemplates/bin/github-releases-entry.tmpl
+++ b/src/chezmoi/.chezmoitemplates/bin/github-releases-entry.tmpl
@@ -23,7 +23,10 @@
 {{- $url      := $gr.url_format      | replace "{base}" $base | replace "{repo}" $gr.repo | replace "{tag}" $tag | replace "{filename}" $filename -}}
 {{- $checksum := dig "checksums" $platform "" $gr -}}
 
-{{- $binName := dig "path_format" "" $gr | splitList "/" | last -}}
+{{- $binName := dig "path_format" "" $gr -}}
+{{- if eq $gr.external_type "archive-file" -}}
+{{-   $binName = $binName | splitList "/" | last -}}
+{{- end -}}
 {{- if not $binName -}}{{- $binName = $name -}}{{- end -}}
 
 ["{{ $binName }}"]

--- a/src/chezmoi/dot_local/.chezmoiexternals/sbx.toml.tmpl
+++ b/src/chezmoi/dot_local/.chezmoiexternals/sbx.toml.tmpl
@@ -1,0 +1,6 @@
+{{- $platform := printf "%s_%s" .chezmoi.os .chezmoi.arch -}}
+{{- $base     := dig "github_releases" "base_url" "https://github.com" . -}}
+{{- $method   := dig "local" "bin" "sbx" "installation_method" "none" $ -}}
+{{- if eq $method "github_releases" -}}
+{{- includeTemplate "bin/github-releases-entry.tmpl" (dict "name" "sbx" "tool" .bin.sbx "platform" $platform "base" $base) -}}
+{{- end -}}

--- a/src/chezmoi/dot_local/bin/symlink_sbx.tmpl
+++ b/src/chezmoi/dot_local/bin/symlink_sbx.tmpl
@@ -1,0 +1,4 @@
+{{- $method := dig "local" "bin" "sbx" "installation_method" "none" . -}}
+{{- if eq $method "github_releases" -}}
+{{ .chezmoi.destDir }}/.local/lib/docker-sbx/sbx
+{{- end -}}


### PR DESCRIPTION
extracts full docker-sbx release directory into `~/.local/lib/docker-sbx/` and links `~/.local/bin/sbx` -> `~/.local/lib/docker-sbx/sbx`.
ensures `sandboxd` containerd plugins and microVM helper libraries (`libsailor.so`, `containerd-shim-nerdbox-v1`) are available next to `sbx`.