### PR TITLE
docs(sandboxr): record the egress-allowlisting tradeoff and why srt/sbx aren't adopted

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -27,6 +27,11 @@ Bind table: `/` ro, `$HOME` tmpfs (default-deny), explicit re-binds for the tool
 
 - **No profile/config file** — every knob is an explicit CLI flag (`--project-write`, `--network`, `--ssh-agent`, `--gpg-agent`, `--ro`, `--rw`).
 A prior design read profiles from `.chezmoidata/ai/sandbox.toml` and supported a pluggable `srt` backend; both were removed as unneeded indirection over a single, always-on `bwrap` path.
+- **No domain-allowlisted egress** — `--network` is binary (`none` or full host network); bwrap has no proxy/filtering primitive of its own.
+`srt` (`@anthropic-ai/sandbox-runtime`) was tried for exactly this gap and reverted: its seccomp filter architecturally cannot forward SSH/GPG agent sockets on Linux (path-based unix-socket filtering isn't possible under seccomp-bpf), and porting bwrap's bind-table concepts into its config surface produced most of the integration bugs this project has hit.
+The gain is bounded anyway — the agent's own session credential can't be denylisted, so an allowlist stops arbitrary-domain exfil but not exfil through the one API domain a run necessarily needs.
+`sbx` (Docker Sandboxes) has stronger egress policy but requires a Docker cloud login and is closed-source — revisit only once it reaches GA with a local-auth mode.
+If scoped egress becomes a hard requirement before then, prefer a filtering proxy inside bwrap's own network namespace over re-adopting a vendor sandbox runtime.
 - **No global PreToolUse guard hook** — earlier design ripped out because the agent's own config files are agent-writable; only the OS-level boundary is real.
 - **No `--sandbox` flag passed to `agy`** — antigravity-cli#36: combining it with `--dangerously-skip-permissions` auto-approves bypassing it.
 - **No `OPENCODE_HARDENED_MODE=1`** — it would engage opencode's own bwrap inside our bwrap and create nested namespaces.


### PR DESCRIPTION
## Summary
- Follow-up to #784 (which stripped `sandboxr` back to a bwrap-only runner).
- An Opus subagent architecture review compared bwrap (current), re-adding `srt`, and adopting `sbx` (Docker Sandboxes) for the agent-CLI-wrapping use case. Verdict: keep bwrap-only.
  - `srt` structurally cannot forward SSH/GPG agent sockets on Linux (seccomp-bpf can't do path-based unix-socket filtering) and reintroduces the bwrap→srt config-porting bug surface already hit once.
  - `sbx` requires a Docker cloud login and is closed-source/pre-1.0 — too much new trust surface for a repo that treats itself as the higher-privilege control plane.
  - Domain allowlisting's marginal value is bounded regardless: the agent's own session credential can't be denylisted, so it stops arbitrary-domain exfil but not exfil through the one API domain a run necessarily needs.
- Adds one `AGENTS.md` bullet recording this reasoning and the fallback (a filtering proxy inside bwrap's own network namespace, built only on actual demand) so a future session doesn't have to re-derive it.
- No code changes — this is documentation only, since the recommendation is to hold the current merged state.

## Test plan
- N/A — docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)