### PR TITLE
feat(sandboxr): always echo the sandbox invocation before running it

### DIFF
--- a/src/python/sandboxr/sandboxr/cli/_common.py
+++ b/src/python/sandboxr/sandboxr/cli/_common.py
@@ -20,6 +20,17 @@ def _fail(message: str) -> typer.Exit:
     return typer.Exit(1)
 
 
+def _echo_command(args: Sequence[str]) -> None:
+    """Print the sandbox invocation, one token per line, so it's actually skimmable.
+
+    Always shown, not gated behind a flag: what's bound where is the whole
+    trust boundary, so it should never be a mystery.
+    """
+    typer.secho("sandboxr: sandbox invocation", fg=typer.colors.CYAN, err=True)
+    for token in args:
+        typer.echo(f"  {token}", err=True)
+
+
 def _refuse_if_nested() -> None:
     if os.environ.get("AGENT_RUN_IN_SANDBOX") == "1":
         raise _fail(

--- a/src/python/sandboxr/sandboxr/cli/doctor.py
+++ b/src/python/sandboxr/sandboxr/cli/doctor.py
@@ -8,6 +8,7 @@ import typer
 
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
+    _echo_command,
     _refuse_if_nested,
     _require_bwrap,
     _sandbox_spec,
@@ -124,6 +125,7 @@ def doctor(
     )
     spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **_probe_env(spec)})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
+    _echo_command(bwrap_cmd)
     args = [*bwrap_cmd, "bash", "-c", PROBE_SCRIPT]
     result = subprocess.run(args, check=False)
     if result.returncode == 0:

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -8,6 +8,7 @@ import typer
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
     _apply_timeout,
+    _echo_command,
     _fail,
     _refuse_if_nested,
     _require_bwrap,
@@ -94,6 +95,7 @@ def run(
         spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **tool_env})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
     args = _apply_timeout([*bwrap_cmd, *adapted_cmd], timeout)
+    _echo_command(args)
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -7,6 +7,7 @@ import typer
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
     _apply_timeout,
+    _echo_command,
     _fail,
     _refuse_if_nested,
     _require_bwrap,
@@ -85,6 +86,7 @@ def shell(
     )
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
     args = _apply_timeout([*bwrap_cmd, shell_cmd], timeout)
+    _echo_command(args)
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -40,10 +40,23 @@ def _chdir(tmp_path, monkeypatch):
 # ── run --show-command ──────────────────────────────────────────────────────
 
 
-def test_run_show_command_starts_with_bwrap():
+def test_run_show_command_prints_copyable_bwrap_line():
     result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
     assert result.exit_code == 0
-    assert result.output.startswith("bwrap")
+    # --show-command's own output is the last line: a single, copy-pasteable
+    # command. Everything before it is the always-on per-token echo.
+    assert result.output.rstrip().splitlines()[-1].startswith("bwrap")
+
+
+def test_run_echoes_command_even_without_show_command(monkeypatch):
+    # --show-command returns before os.execvp, so it can't prove the echo
+    # survives on the real-execution path. Mock execvp instead so run()
+    # falls through normally without actually replacing this process.
+    monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
+    result = runner.invoke(app, ["run", "--", "bash"])
+    assert result.exit_code == 0
+    assert "sandboxr: sandbox invocation" in result.output
+    assert "  bwrap" in result.output
 
 
 def test_run_show_command_project_rw_bound(tmp_path):
@@ -143,3 +156,11 @@ def test_shell_show_command_no_tty_adds_new_session():
     result = runner.invoke(app, ["shell", "--no-tty", "--show-command"])
     assert result.exit_code == 0
     assert "--new-session" in result.output
+
+
+def test_shell_echoes_command_even_without_show_command(monkeypatch):
+    monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
+    result = runner.invoke(app, ["shell"])
+    assert result.exit_code == 0
+    assert "sandboxr: sandbox invocation" in result.output
+    assert "  bwrap" in result.output

--- a/tests/integration/test_sandboxr.py
+++ b/tests/integration/test_sandboxr.py
@@ -28,6 +28,10 @@ def test_doctor_default_passes(host):
     # where the wrapped command silently never executes (exit 0, zero probe
     # output) would pass this check if we only asserted on the return code.
     assert result.stdout.count("PASS:") >= 8, f"expected several PASS lines, got:\n{result.stdout}"
+    # doctor always echoes the sandbox invocation to stderr, so the human
+    # can see what's actually bound before trusting the probe results.
+    assert "sandboxr: sandbox invocation" in result.stderr
+    assert "  bwrap" in result.stderr
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- `run`/`shell`/`doctor` now unconditionally print the full bwrap argv (one token per line, to stderr) before executing — not gated behind `--show-command` anymore.
- `--show-command` keeps its original job unchanged: print a single-line, copy-pasteable command and exit without running anything.
- `doctor` gets this too (it never had `--show-command` at all) — echoes just the sandbox-construction argv, not the embedded probe script.
- Motivation: the bind table *is* the trust boundary. Requiring a special flag to see what's actually exposed was working against building confidence in the tool, not for it.

## Test plan
- [x] `uv run pytest src/python/sandboxr` — 49 passed (2 new: run/shell echo even without `--show-command`, verified by mocking `os.execvp` so the real exec path executes without hijacking the test process)
- [x] `uv run pytest tests/integration/test_sandboxr.py` — 3 passed, live against real `bwrap`; asserts the echo lands on stderr (doesn't disturb the existing stdout probe-output assertions)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
- [x] Manual: `sandboxr run --network none -- echo hi` prints the full bind table then `hi`; `sandboxr doctor` prints the bind table on stderr, probes on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)