### PR TITLE
feat(sandboxr): add --no-skip-permissions for sandboxed-but-still-asking runs

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -12,6 +12,11 @@ Nothing in this package applies.
 `sandboxr run -- TOOL ARGS`.
 Outer bwrap (Linux/WSL) is the security boundary; each adapter flips the tool's bypass flag so the inner approval prompts don't fire.
 The tool's settings file inside the sandbox is *not* trusted — the OS-level isolation is.
+- **Sandboxed but still asking.**
+`sandboxr run --no-skip-permissions --tty -- TOOL ARGS`.
+Both boundaries active: OS sandbox underneath, tool's own prompts (driven by the existing `.chezmoidata/ai/command_policy/*.toml` allow/ask/deny catalog) still fire on top — e.g. local git ops flow through, `git push`/`gh pr create`/`gh pr merge` still ask.
+Requires `--tty` and an interactive tool invocation (not `claude -p` print mode) — a prompt has nowhere to render otherwise.
+Deliberately the minimal step here: a fuller persistent-sandbox-with-scoped-grants model was considered and deferred as unjustified complexity until this simpler version proves insufficient in practice.
 
 ## Files in the package
 

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -58,6 +58,15 @@ def run(
         bool,
         typer.Option("--gpg-agent/--no-gpg-agent", help="Forward host GPG agent socket."),
     ] = False,
+    skip_permissions: Annotated[
+        bool,
+        typer.Option(
+            "--skip-permissions/--no-skip-permissions",
+            help="Bypass the tool's own permission prompts (default). Disable to keep them "
+            "active — e.g. staged approval on git push/gh pr create/merge — while still "
+            "sandboxed.",
+        ),
+    ] = True,
     extra_ro: Annotated[
         list[str] | None,
         typer.Option("--ro", help="Bind path read-only (repeatable)."),
@@ -90,7 +99,7 @@ def run(
         extra_rw=extra_rw or [],
         tty=tty,
     )
-    adapted_cmd, tool_env = adapt_command(command, os.environ)
+    adapted_cmd, tool_env = adapt_command(command, os.environ, skip_permissions=skip_permissions)
     if tool_env:
         spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **tool_env})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))

--- a/src/python/sandboxr/sandboxr/sandbox/tool.py
+++ b/src/python/sandboxr/sandboxr/sandbox/tool.py
@@ -1,7 +1,10 @@
-"""Per-tool CLI adaptation for autonomous (no-human-in-the-loop) runs.
+"""Per-tool CLI adaptation for sandboxed runs.
 
-The outer sandbox is the security boundary; each tool's own permission
-prompts are bypassed because they would only add friction here.
+Autonomous (no-human-in-the-loop) runs bypass each tool's own permission
+prompts by default; the outer sandbox is the security boundary instead.
+Passing skip_permissions=False keeps a tool's own prompts active — e.g. to
+still get asked before `git push`/`gh pr create`/`gh pr merge` per the
+existing command-policy catalog — while staying sandboxed underneath.
 """
 
 from collections.abc import Mapping
@@ -20,6 +23,7 @@ def adapt_command(
     command: list[str],
     base_env: Mapping[str, str],
     *,
+    skip_permissions: bool = True,
     claude_settings: Path | None = None,
     agy_settings: Path | None = None,
     opencode_config: Path | None = None,
@@ -39,7 +43,7 @@ def adapt_command(
                 if "--settings" not in command and settings_path.exists()
                 else []
             ),
-            *([] if _SKIP_PERMS in command else [_SKIP_PERMS]),
+            *([] if not skip_permissions or _SKIP_PERMS in command else [_SKIP_PERMS]),
         ]
         return adapted, {}
     agy_path = agy_settings or _DEFAULT_AGY_SETTINGS
@@ -51,7 +55,7 @@ def adapt_command(
                 if "--settings" not in command and agy_path.exists()
                 else []
             ),
-            *([] if _SKIP_PERMS in command else [_SKIP_PERMS]),
+            *([] if not skip_permissions or _SKIP_PERMS in command else [_SKIP_PERMS]),
             # Do NOT pass --sandbox: combining with --dangerously-skip-permissions
             # auto-approves bypassing the sandbox itself (antigravity-cli #36).
         ]

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -125,6 +125,20 @@ def test_run_show_command_no_ssh_agent_flag_skips_sock(tmp_path, monkeypatch):
     assert f"SSH_AUTH_SOCK {sock}" not in result.output
 
 
+def test_run_show_command_skip_permissions_default_adds_flag():
+    result = runner.invoke(app, ["run", "--show-command", "--", "claude", "--print", "hi"])
+    assert result.exit_code == 0
+    assert "--dangerously-skip-permissions" in result.output
+
+
+def test_run_show_command_no_skip_permissions_omits_flag():
+    result = runner.invoke(
+        app, ["run", "--no-skip-permissions", "--show-command", "--", "claude", "--print", "hi"]
+    )
+    assert result.exit_code == 0
+    assert "--dangerously-skip-permissions" not in result.output
+
+
 def test_run_no_command_exits_nonzero():
     result = runner.invoke(app, ["run", "--show-command"])
     assert result.exit_code != 0

--- a/src/python/sandboxr/tests/sandbox/test_tool.py
+++ b/src/python/sandboxr/tests/sandbox/test_tool.py
@@ -29,6 +29,24 @@ def test_agy_does_not_get_sandbox_flag():
     assert "--sandbox" not in cmd
 
 
+def test_claude_skip_permissions_false_omits_flag():
+    cmd, _env = adapt_command(["claude", "--print", "hi"], {}, skip_permissions=False)
+    assert "--dangerously-skip-permissions" not in cmd
+
+
+def test_agy_skip_permissions_false_omits_flag():
+    cmd, _env = adapt_command(["agy", "run"], {}, skip_permissions=False)
+    assert "--dangerously-skip-permissions" not in cmd
+
+
+def test_skip_permissions_false_does_not_remove_explicit_flag():
+    # Explicit opt-in via the raw command line still wins.
+    cmd, _env = adapt_command(
+        ["claude", "--dangerously-skip-permissions"], {}, skip_permissions=False
+    )
+    assert cmd.count("--dangerously-skip-permissions") == 1
+
+
 def test_opencode_sets_config_env():
     _cmd, env = adapt_command(["opencode"], {})
     assert "OPENCODE_CONFIG" in env


### PR DESCRIPTION
## Summary
- `sandboxr run` forced `--dangerously-skip-permissions` onto `claude`/`agy` unconditionally, which discarded the command-policy catalog that already exists (`.chezmoidata/ai/command_policy/{git,gh}.toml` already excludes `git push` and `gh pr create`/`merge` from auto-allow — only read-only `gh pr` subcommands are allow-listed).
- `adapt_command()` gains `skip_permissions: bool = True`; `sandboxr run` gains `--skip-permissions/--no-skip-permissions` (default unchanged — fully autonomous, same as today).
- `--no-skip-permissions` keeps the OS sandbox active underneath while leaving the tool's own permission prompts on top, so local git ops (add/commit/diff/etc.) still flow through unattended but `git push`/`gh pr create`/`gh pr merge` still ask — staged approval using what's already built, not a new framework.
- Requires `--tty` and an interactive (non `-p`) invocation to actually render a prompt — documented in `AGENTS.md`'s new "Sandboxed but still asking" mode-split bullet, along with a note that a fuller persistent-sandbox + scoped-credential-grant model was considered and deliberately deferred as unjustified complexity for now.

## Test plan
- [x] `uv run pytest src/python/sandboxr` — 54 passed (5 new: `adapt_command` unit coverage for `skip_permissions=False` on claude/agy and explicit-flag-not-duplicated; CLI coverage for both flag states via `--show-command`)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
- [x] Manual: `sandboxr run --show-command -- claude --print hi` includes `--dangerously-skip-permissions`; `sandboxr run --no-skip-permissions --show-command -- claude --print hi` omits it entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)