### PR TITLE
feat(sandboxr): add intent-named flags (--local-commit/--web-access/--push/--pr)

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -18,6 +18,18 @@ Both boundaries active: OS sandbox underneath, tool's own prompts (driven by the
 Requires `--tty` and an interactive tool invocation (not `claude -p` print mode) — a prompt has nowhere to render otherwise.
 Deliberately the minimal step here: a fuller persistent-sandbox-with-scoped-grants model was considered and deferred as unjustified complexity until this simpler version proves insufficient in practice.
 
+## Intent flags
+
+`sandboxr run` also has `--local-commit`, `--web-access`, `--push`, and `--pr` — pure shorthand over the granular flags below, not a config layer.
+Each just sets `ssh_agent`/`gpg_agent`/`network`/`extra_ro` directly in code; nothing is hidden, and the resolved invocation is always echoed (see Verification), so what a flag actually did is never a mystery.
+- `--local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
+- `--web-access`/`--no-web-access` is `--network shared`/`none`, applied after `--network` so it always wins if both are given.
+- `--push`/`--no-push` is `--ssh-agent`/`--no-ssh-agent`.
+- `--pr` implies `--push` and additionally read-only-binds your real `~/.config/gh`.
+This is *not* a scoped credential — there's no short-lived or per-usage token issuance, so the agent gets whatever access your actual `gh auth login` session has, not just this repo.
+Read-only only stops the sandbox from tampering with the credential file; it does not limit what the token itself can do once `gh` reads it.
+Chose this over a second hand-scoped PAT file because a hand-scoped token is still just another standing secret to create and remember to rotate, for a security property achievable another way if it ever matters (see the deferred broker idea, not built).
+
 ## Files in the package
 
 - `sandboxr/backend/protocol.py` — `SandboxBackend` `Protocol`.

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -67,6 +67,31 @@ def run(
             "sandboxed.",
         ),
     ] = True,
+    local_commit: Annotated[
+        bool | None,
+        typer.Option(
+            "--local-commit/--no-local-commit",
+            help="Shorthand: no push/sign capability at all "
+            "(forces --no-ssh-agent --no-gpg-agent).",
+        ),
+    ] = None,
+    web_access: Annotated[
+        bool | None,
+        typer.Option("--web-access/--no-web-access", help="Shorthand for --network shared/none."),
+    ] = None,
+    push: Annotated[
+        bool | None,
+        typer.Option("--push/--no-push", help="Shorthand for --ssh-agent/--no-ssh-agent."),
+    ] = None,
+    pr: Annotated[
+        bool,
+        typer.Option(
+            "--pr/--no-pr",
+            help="Push capability plus read-only access to your real gh credentials "
+            "(~/.config/gh), so `gh pr create` works. Not a scoped credential — the agent "
+            "gets whatever access your own `gh auth login` session has.",
+        ),
+    ] = False,
     extra_ro: Annotated[
         list[str] | None,
         typer.Option("--ro", help="Bind path read-only (repeatable)."),
@@ -89,13 +114,29 @@ def run(
         raise _fail("no command given; usage: sandboxr run [FLAGS] -- COMMAND [ARGS...]")
     cwd = Path.cwd()
     _require_bwrap()
+    if local_commit:
+        ssh_agent = False
+        gpg_agent = False
+    if push is not None:
+        ssh_agent = push
+    if pr:
+        ssh_agent = True
+    if web_access is not None:
+        network = "shared" if web_access else "none"
+    resolved_extra_ro = list(extra_ro or [])
+    if pr:
+        # Real gh session, not a scoped credential: no short-lived or
+        # per-usage token issuance exists yet. Read-only only protects the
+        # file from tampering inside the sandbox -- it does not limit what
+        # the token itself can do once `gh` reads it.
+        resolved_extra_ro.append(str(Path.home() / ".config" / "gh"))
     spec = _sandbox_spec(
         cwd,
         project_write=project_write,
         network=network,
         ssh_agent=ssh_agent,
         gpg_agent=gpg_agent,
-        extra_ro=extra_ro or [],
+        extra_ro=resolved_extra_ro,
         extra_rw=extra_rw or [],
         tty=tty,
     )

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -8,6 +8,7 @@ is faked so _require_bwrap passes on non-Linux hosts.
 
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -137,6 +138,69 @@ def test_run_show_command_no_skip_permissions_omits_flag():
     )
     assert result.exit_code == 0
     assert "--dangerously-skip-permissions" not in result.output
+
+
+# ── run intent flags (--local-commit / --web-access / --push / --pr) ──────
+
+
+def test_run_local_commit_forces_no_ssh_agent(tmp_path, monkeypatch):
+    sock = tmp_path / "agent.sock"
+    sock.touch()
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+    result = runner.invoke(app, ["run", "--local-commit", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert f"SSH_AUTH_SOCK {sock}" not in result.output
+
+
+def test_run_push_true_binds_ssh_agent_sock(tmp_path, monkeypatch):
+    sock = tmp_path / "agent.sock"
+    sock.touch()
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+    result = runner.invoke(app, ["run", "--no-ssh-agent", "--push", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert f"SSH_AUTH_SOCK {sock}" in result.output
+
+
+def test_run_push_false_omits_ssh_agent_sock(tmp_path, monkeypatch):
+    sock = tmp_path / "agent.sock"
+    sock.touch()
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+    result = runner.invoke(app, ["run", "--no-push", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert f"SSH_AUTH_SOCK {sock}" not in result.output
+
+
+def test_run_web_access_false_unshares_net():
+    result = runner.invoke(app, ["run", "--no-web-access", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert "--unshare-net" in result.output
+
+
+def test_run_web_access_true_overrides_network_none():
+    result = runner.invoke(
+        app, ["run", "--network", "none", "--web-access", "--show-command", "--", "bash"]
+    )
+    assert result.exit_code == 0
+    assert "--unshare-net" not in result.output
+
+
+def test_run_pr_binds_gh_config_read_only(tmp_path, tmp_path_factory, monkeypatch):
+    fake_home = tmp_path_factory.mktemp("home")
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    gh_dir = fake_home / ".config" / "gh"
+    gh_dir.mkdir(parents=True)
+    result = runner.invoke(app, ["run", "--pr", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert f"--ro-bind {gh_dir} {gh_dir}" in result.output
+
+
+def test_run_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
+    sock = tmp_path / "agent.sock"
+    sock.touch()
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+    result = runner.invoke(app, ["run", "--no-ssh-agent", "--pr", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert f"SSH_AUTH_SOCK {sock}" in result.output
 
 
 def test_run_no_command_exits_nonzero():


### PR DESCRIPTION
## Summary
- `sandboxr run` gains `--local-commit`, `--web-access`, `--push`, and `--pr` — pure shorthand over the existing granular flags (`--ssh-agent`, `--gpg-agent`, `--network`, `--ro`), not a new config layer. Each just sets `SandboxSpec` fields directly in `run.py`; nothing hidden, still visible via the always-on invocation echo (#787).
  - `--local-commit`: forces `--no-ssh-agent --no-gpg-agent` — no push/sign capability at all.
  - `--web-access`/`--no-web-access`: shorthand for `--network shared`/`none`, applied after `--network` so it always wins if both given.
  - `--push`/`--no-push`: shorthand for `--ssh-agent`/`--no-ssh-agent`.
  - `--pr`: implies push, plus read-only-binds the real `~/.config/gh` so `gh pr create` works.
- `--pr` deliberately does **not** use a separate scoped credential file (considered, explicitly rejected): sandboxr has no short-lived/per-usage token issuance, so a hand-scoped PAT would just be a second standing secret to create and remember to rotate. Reuses the real `gh auth login` session instead — documented plainly in `AGENTS.md` that this means broader scope than just this repo, and that read-only only protects the file from tampering, not what the token can do once read.
- No merge tier — PRs get merged by hand. Deliberately out of scope for this pass.

## Test plan
- [x] `uv run pytest src/python/sandboxr` — 61 passed (7 new, covering each flag's override behavior including the `--pr`-forces-`--push` interaction and the real `.config/gh` bind)
- [x] `uv run pytest tests/integration/test_sandboxr.py` — 3 passed, live against real `bwrap`
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
- [x] Manual: `sandboxr run --pr --show-command -- echo hi` shows `--ro-bind /home/mkobit/.config/gh /home/mkobit/.config/gh` exactly once; `--local-commit` omits any SSH_AUTH_SOCK bind even with a live agent socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)