### PR TITLE
refactor(sandboxr): replace intent flags with a --profile registry

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -18,17 +18,26 @@ Both boundaries active: OS sandbox underneath, tool's own prompts (driven by the
 Requires `--tty` and an interactive tool invocation (not `claude -p` print mode) — a prompt has nowhere to render otherwise.
 Deliberately the minimal step here: a fuller persistent-sandbox-with-scoped-grants model was considered and deferred as unjustified complexity until this simpler version proves insufficient in practice.
 
-## Intent flags
+## Profiles
 
-`sandboxr run` also has `--local-commit`, `--web-access`, `--push`, and `--pr` — pure shorthand over the granular flags below, not a config layer.
-Each just sets `ssh_agent`/`gpg_agent`/`network`/`extra_ro` directly in code; nothing is hidden, and the resolved invocation is always echoed (see Verification), so what a flag actually did is never a mystery.
-- `--local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
-- `--web-access`/`--no-web-access` is `--network shared`/`none`, applied after `--network` so it always wins if both are given.
-- `--push`/`--no-push` is `--ssh-agent`/`--no-ssh-agent`.
-- `--pr` implies `--push` and additionally read-only-binds your real `~/.config/gh`.
+`sandboxr run --profile NAME` (repeatable) selects named bundles of the granular flags below, defined in `_PROFILES` in `cli/run.py`.
+This is *not* the deleted `sandbox.toml` config file: no external file, no env var, no resolution order — just an in-code `dict[str, _Profile]`, a frozen dataclass with one field per overridable setting.
+Add an entry to `_PROFILES` to add a profile; nothing else needs to change.
+Multiple `--profile` flags compose, later wins on conflicting fields; the resolved invocation is always echoed (see Verification), so what a profile actually did is never a mystery.
+Built-in profiles:
+- `local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
+- `push` forces `--ssh-agent`.
+- `web-access` forces `--network shared`.
+- `pr` implies `push` and additionally read-only-binds the real `~/.config/gh`.
 This is *not* a scoped credential — there's no short-lived or per-usage token issuance, so the agent gets whatever access your actual `gh auth login` session has, not just this repo.
 Read-only only stops the sandbox from tampering with the credential file; it does not limit what the token itself can do once `gh` reads it.
 Chose this over a second hand-scoped PAT file because a hand-scoped token is still just another standing secret to create and remember to rotate, for a security property achievable another way if it ever matters (see the deferred broker idea, not built).
+
+## Isolated concurrent sessions
+
+Already works today, no sandboxr-specific support needed: create a git worktree (`git worktree add ../feature-x`, or the `using-git-worktrees` skill), `cd` into it, then `sandboxr run`/`shell` from there.
+`_git_common_dir()` (`cli/_common.py`) detects you're in a linked worktree and binds both the worktree's own directory (isolated, per-session) and the main checkout's `.git` (shared object store, so commits/refs are visible across sessions) — verified live, not assumed.
+Home-tools binds (`RO_HOME_PATHS`/`RW_HOME_PATHS`) are independent of cwd, so they're identical across every concurrent session regardless.
 
 ## Files in the package
 
@@ -42,7 +51,7 @@ Bind table: `/` ro, `$HOME` tmpfs (default-deny), explicit re-binds for the tool
 
 ## Deliberate omissions
 
-- **No profile/config file** — every knob is an explicit CLI flag (`--project-write`, `--network`, `--ssh-agent`, `--gpg-agent`, `--ro`, `--rw`).
+- **No external profile/config file** — every knob is an explicit CLI flag (`--project-write`, `--network`, `--ssh-agent`, `--gpg-agent`, `--ro`, `--rw`), or a named bundle of them via `--profile` (see Profiles — an in-code registry, not a file).
 A prior design read profiles from `.chezmoidata/ai/sandbox.toml` and supported a pluggable `srt` backend; both were removed as unneeded indirection over a single, always-on `bwrap` path.
 - **No domain-allowlisted egress** — `--network` is binary (`none` or full host network); bwrap has no proxy/filtering primitive of its own.
 `srt` (`@anthropic-ai/sandbox-runtime`) was tried for exactly this gap and reverted: its seccomp filter architecturally cannot forward SSH/GPG agent sockets on Linux (path-based unix-socket filtering isn't possible under seccomp-bpf), and porting bwrap's bind-table concepts into its config surface produced most of the integration bugs this project has hit.
@@ -69,3 +78,4 @@ A read-only `gh` PAT at `~/.local/state/ai-policy/tokens/readonly.token` (chmod 
 - Add new RW or RO home paths in `bwrap.py` (`RW_HOME_PATHS` / `RO_HOME_PATHS`) when a tool needs persistent state inside the sandbox.
 Bind defensively — if the path doesn't exist on the host, the bwrap step is skipped, so adding speculative candidate paths is cheap.
 - New sandbox knobs are CLI flags threaded through `_sandbox_spec` (`cli/_common.py`) into `SandboxSpec`, not config file keys.
+- New profiles are entries in `_PROFILES` (`cli/run.py`) — add a field to `_Profile` first if the knob doesn't exist yet.

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -1,5 +1,6 @@
 import dataclasses
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Annotated
 
@@ -21,6 +22,47 @@ _CTX = {
     "ignore_unknown_options": True,
     "allow_interspersed_args": False,
 }
+
+
+@dataclasses.dataclass(frozen=True)
+class _Profile:
+    """One field per overridable flag; None means "this profile doesn't touch it"."""
+
+    ssh_agent: bool | None = None
+    gpg_agent: bool | None = None
+    network: str | None = None
+    gh_config: bool | None = None
+
+
+# Named bundles of the flags below -- pure in-code sugar, not a config file.
+# No resolution order, no env var, nothing to go read elsewhere: --profile
+# just pre-sets fields on top of the granular flags' own defaults, applied
+# in list order (later wins on conflicting keys). Add an entry here to add
+# a profile; nothing else needs to change. gh_config triggers the
+# read-only ~/.config/gh bind below, since it isn't a plain SandboxSpec field.
+_PROFILES: dict[str, _Profile] = {
+    "local-commit": _Profile(ssh_agent=False, gpg_agent=False),
+    "push": _Profile(ssh_agent=True),
+    "web-access": _Profile(network="shared"),
+    "pr": _Profile(ssh_agent=True, gh_config=True),
+}
+
+
+def _merge_profiles(names: Sequence[str]) -> _Profile:
+    merged = _Profile()
+    for name in names:
+        if name not in _PROFILES:
+            raise _fail(f"unknown profile {name!r}; available: {', '.join(sorted(_PROFILES))}")
+        wanted = _PROFILES[name]
+        merged = dataclasses.replace(
+            merged,
+            ssh_agent=wanted.ssh_agent if wanted.ssh_agent is not None else merged.ssh_agent,
+            gpg_agent=wanted.gpg_agent if wanted.gpg_agent is not None else merged.gpg_agent,
+            network=wanted.network if wanted.network is not None else merged.network,
+            gh_config=wanted.gh_config if wanted.gh_config is not None else merged.gh_config,
+        )
+    return merged
+
 
 app = typer.Typer()
 
@@ -67,31 +109,14 @@ def run(
             "sandboxed.",
         ),
     ] = True,
-    local_commit: Annotated[
-        bool | None,
+    profile: Annotated[
+        list[str] | None,
         typer.Option(
-            "--local-commit/--no-local-commit",
-            help="Shorthand: no push/sign capability at all "
-            "(forces --no-ssh-agent --no-gpg-agent).",
+            "--profile",
+            help=f"Named flag bundle, repeatable, later wins on conflicts. "
+            f"Available: {', '.join(sorted(_PROFILES))}.",
         ),
     ] = None,
-    web_access: Annotated[
-        bool | None,
-        typer.Option("--web-access/--no-web-access", help="Shorthand for --network shared/none."),
-    ] = None,
-    push: Annotated[
-        bool | None,
-        typer.Option("--push/--no-push", help="Shorthand for --ssh-agent/--no-ssh-agent."),
-    ] = None,
-    pr: Annotated[
-        bool,
-        typer.Option(
-            "--pr/--no-pr",
-            help="Push capability plus read-only access to your real gh credentials "
-            "(~/.config/gh), so `gh pr create` works. Not a scoped credential — the agent "
-            "gets whatever access your own `gh auth login` session has.",
-        ),
-    ] = False,
     extra_ro: Annotated[
         list[str] | None,
         typer.Option("--ro", help="Bind path read-only (repeatable)."),
@@ -114,17 +139,12 @@ def run(
         raise _fail("no command given; usage: sandboxr run [FLAGS] -- COMMAND [ARGS...]")
     cwd = Path.cwd()
     _require_bwrap()
-    if local_commit:
-        ssh_agent = False
-        gpg_agent = False
-    if push is not None:
-        ssh_agent = push
-    if pr:
-        ssh_agent = True
-    if web_access is not None:
-        network = "shared" if web_access else "none"
+    overrides = _merge_profiles(profile or [])
+    ssh_agent = overrides.ssh_agent if overrides.ssh_agent is not None else ssh_agent
+    gpg_agent = overrides.gpg_agent if overrides.gpg_agent is not None else gpg_agent
+    network = overrides.network if overrides.network is not None else network
     resolved_extra_ro = list(extra_ro or [])
-    if pr:
+    if overrides.gh_config:
         # Real gh session, not a scoped credential: no short-lived or
         # per-usage token issuance exists yet. Read-only only protects the
         # file from tampering inside the sandbox -- it does not limit what

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -140,67 +140,88 @@ def test_run_show_command_no_skip_permissions_omits_flag():
     assert "--dangerously-skip-permissions" not in result.output
 
 
-# ── run intent flags (--local-commit / --web-access / --push / --pr) ──────
+# ── run --profile ───────────────────────────────────────────────────────────
 
 
-def test_run_local_commit_forces_no_ssh_agent(tmp_path, monkeypatch):
+def test_run_profile_local_commit_forces_no_ssh_agent(tmp_path, monkeypatch):
     sock = tmp_path / "agent.sock"
     sock.touch()
     monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--local-commit", "--show-command", "--", "bash"])
+    result = runner.invoke(
+        app, ["run", "--profile", "local-commit", "--show-command", "--", "bash"]
+    )
     assert result.exit_code == 0
     assert f"SSH_AUTH_SOCK {sock}" not in result.output
 
 
-def test_run_push_true_binds_ssh_agent_sock(tmp_path, monkeypatch):
+def test_run_profile_push_binds_ssh_agent_sock(tmp_path, monkeypatch):
     sock = tmp_path / "agent.sock"
     sock.touch()
     monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--no-ssh-agent", "--push", "--show-command", "--", "bash"])
+    result = runner.invoke(
+        app,
+        ["run", "--no-ssh-agent", "--profile", "push", "--show-command", "--", "bash"],
+    )
     assert result.exit_code == 0
     assert f"SSH_AUTH_SOCK {sock}" in result.output
 
 
-def test_run_push_false_omits_ssh_agent_sock(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--no-push", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" not in result.output
-
-
-def test_run_web_access_false_unshares_net():
-    result = runner.invoke(app, ["run", "--no-web-access", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert "--unshare-net" in result.output
-
-
-def test_run_web_access_true_overrides_network_none():
+def test_run_profile_web_access_overrides_network_none():
     result = runner.invoke(
-        app, ["run", "--network", "none", "--web-access", "--show-command", "--", "bash"]
+        app,
+        ["run", "--network", "none", "--profile", "web-access", "--show-command", "--", "bash"],
     )
     assert result.exit_code == 0
     assert "--unshare-net" not in result.output
 
 
-def test_run_pr_binds_gh_config_read_only(tmp_path, tmp_path_factory, monkeypatch):
+def test_run_profile_pr_binds_gh_config_read_only(tmp_path, tmp_path_factory, monkeypatch):
     fake_home = tmp_path_factory.mktemp("home")
     monkeypatch.setattr(Path, "home", lambda: fake_home)
     gh_dir = fake_home / ".config" / "gh"
     gh_dir.mkdir(parents=True)
-    result = runner.invoke(app, ["run", "--pr", "--show-command", "--", "bash"])
+    result = runner.invoke(app, ["run", "--profile", "pr", "--show-command", "--", "bash"])
     assert result.exit_code == 0
     assert f"--ro-bind {gh_dir} {gh_dir}" in result.output
 
 
-def test_run_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
+def test_run_profile_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
     sock = tmp_path / "agent.sock"
     sock.touch()
     monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--no-ssh-agent", "--pr", "--show-command", "--", "bash"])
+    result = runner.invoke(
+        app, ["run", "--no-ssh-agent", "--profile", "pr", "--show-command", "--", "bash"]
+    )
     assert result.exit_code == 0
     assert f"SSH_AUTH_SOCK {sock}" in result.output
+
+
+def test_run_profile_repeatable_later_wins_on_conflict(tmp_path, monkeypatch):
+    sock = tmp_path / "agent.sock"
+    sock.touch()
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--profile",
+            "push",
+            "--profile",
+            "local-commit",
+            "--show-command",
+            "--",
+            "bash",
+        ],
+    )
+    assert result.exit_code == 0
+    assert f"SSH_AUTH_SOCK {sock}" not in result.output
+
+
+def test_run_unknown_profile_fails_with_available_list():
+    result = runner.invoke(app, ["run", "--profile", "nope", "--show-command", "--", "bash"])
+    assert result.exit_code != 0
+    assert "unknown profile" in result.output
+    assert "local-commit" in result.output
 
 
 def test_run_no_command_exits_nonzero():


### PR DESCRIPTION
## Summary
- `--local-commit`/`--web-access`/`--push`/`--pr` (#789, merged minutes earlier) become `sandboxr run --profile NAME`, repeatable, later wins on conflicting fields.
- Backed by `_PROFILES: dict[str, _Profile]` in `cli/run.py` — `_Profile` is a frozen dataclass with one `Optional` field per overridable setting, merged via `_merge_profiles()`. Strongly typed throughout, not a stringly-typed dict.
- Explicitly **not** the deleted `sandbox.toml` config system: no external file, no env var, no resolution order — just an in-code registry. Adding a profile means adding one dict entry, not a new CLI flag.
- Unknown profile names fail with the list of valid ones (`sandboxr run --profile nope` → `unknown profile 'nope'; available: local-commit, pr, push, web-access`).
- Also documents (in `AGENTS.md`) that isolated concurrent sessions via git worktrees already work today with zero new code — verified live by creating a real worktree and confirming `sandboxr run` from inside it binds both the worktree's own directory and the shared `.git` common dir correctly.

## Test plan
- [x] `uv run pytest src/python/sandboxr` — 61 passed (profile-name tests replacing the removed boolean-flag tests, plus new coverage for repeatable-later-wins and unknown-profile-name error)
- [x] `uv run pytest tests/integration/test_sandboxr.py` — 3 passed, live against real `bwrap`
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean
- [x] Manual: `sandboxr run --profile pr --show-command` binds `~/.config/gh` read-only exactly once; `sandboxr run --profile bogus` fails with the available-profiles list; `--help` shows the profile list in the flag's own help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)