### PR TITLE
refactor(sandboxr): make --profile single-valued

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -20,10 +20,11 @@ Deliberately the minimal step here: a fuller persistent-sandbox-with-scoped-gran
 
 ## Profiles
 
-`sandboxr run --profile NAME` (repeatable) selects named bundles of the granular flags below, defined in `_PROFILES` in `cli/run.py`.
+`sandboxr run --profile NAME` selects a named bundle of the granular flags below, defined in `_PROFILES` in `cli/run.py`.
 This is *not* the deleted `sandbox.toml` config file: no external file, no env var, no resolution order — just an in-code `dict[str, _Profile]`, a frozen dataclass with one field per overridable setting.
 Add an entry to `_PROFILES` to add a profile; nothing else needs to change.
-Multiple `--profile` flags compose, later wins on conflicting fields; the resolved invocation is always echoed (see Verification), so what a profile actually did is never a mystery.
+`--profile` takes a single name — a profile only overrides the fields it explicitly sets, so it still composes with the granular flags for anything it doesn't touch (`--profile push --network shared` gets push *and* web access without a second profile).
+The resolved invocation is always echoed (see Verification), so what a profile actually did is never a mystery.
 Built-in profiles:
 - `local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
 - `push` forces `--ssh-agent`.

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -1,6 +1,5 @@
 import dataclasses
 import os
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Annotated
 
@@ -36,10 +35,13 @@ class _Profile:
 
 # Named bundles of the flags below -- pure in-code sugar, not a config file.
 # No resolution order, no env var, nothing to go read elsewhere: --profile
-# just pre-sets fields on top of the granular flags' own defaults, applied
-# in list order (later wins on conflicting keys). Add an entry here to add
-# a profile; nothing else needs to change. gh_config triggers the
-# read-only ~/.config/gh bind below, since it isn't a plain SandboxSpec field.
+# just pre-sets fields on top of the granular flags' own defaults. A profile
+# only overrides the fields it sets -- anything it leaves None still falls
+# through to the granular flag, so e.g. `--profile push --network shared`
+# already composes push with web access without needing two profiles. Add
+# an entry here to add a profile; nothing else needs to change. gh_config
+# triggers the read-only ~/.config/gh bind below, since it isn't a plain
+# SandboxSpec field.
 _PROFILES: dict[str, _Profile] = {
     "local-commit": _Profile(ssh_agent=False, gpg_agent=False),
     "push": _Profile(ssh_agent=True),
@@ -48,20 +50,12 @@ _PROFILES: dict[str, _Profile] = {
 }
 
 
-def _merge_profiles(names: Sequence[str]) -> _Profile:
-    merged = _Profile()
-    for name in names:
-        if name not in _PROFILES:
-            raise _fail(f"unknown profile {name!r}; available: {', '.join(sorted(_PROFILES))}")
-        wanted = _PROFILES[name]
-        merged = dataclasses.replace(
-            merged,
-            ssh_agent=wanted.ssh_agent if wanted.ssh_agent is not None else merged.ssh_agent,
-            gpg_agent=wanted.gpg_agent if wanted.gpg_agent is not None else merged.gpg_agent,
-            network=wanted.network if wanted.network is not None else merged.network,
-            gh_config=wanted.gh_config if wanted.gh_config is not None else merged.gh_config,
-        )
-    return merged
+def _resolve_profile(name: str | None) -> _Profile:
+    if name is None:
+        return _Profile()
+    if name not in _PROFILES:
+        raise _fail(f"unknown profile {name!r}; available: {', '.join(sorted(_PROFILES))}")
+    return _PROFILES[name]
 
 
 app = typer.Typer()
@@ -110,11 +104,11 @@ def run(
         ),
     ] = True,
     profile: Annotated[
-        list[str] | None,
+        str | None,
         typer.Option(
             "--profile",
-            help=f"Named flag bundle, repeatable, later wins on conflicts. "
-            f"Available: {', '.join(sorted(_PROFILES))}.",
+            help=f"Named flag bundle. Composes with granular flags for any field it "
+            f"doesn't set. Available: {', '.join(sorted(_PROFILES))}.",
         ),
     ] = None,
     extra_ro: Annotated[
@@ -139,7 +133,7 @@ def run(
         raise _fail("no command given; usage: sandboxr run [FLAGS] -- COMMAND [ARGS...]")
     cwd = Path.cwd()
     _require_bwrap()
-    overrides = _merge_profiles(profile or [])
+    overrides = _resolve_profile(profile)
     ssh_agent = overrides.ssh_agent if overrides.ssh_agent is not None else ssh_agent
     gpg_agent = overrides.gpg_agent if overrides.gpg_agent is not None else gpg_agent
     network = overrides.network if overrides.network is not None else network

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -196,25 +196,19 @@ def test_run_profile_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
     assert f"SSH_AUTH_SOCK {sock}" in result.output
 
 
-def test_run_profile_repeatable_later_wins_on_conflict(tmp_path, monkeypatch):
+def test_run_profile_composes_with_granular_flag_for_untouched_field(tmp_path, monkeypatch):
+    # --profile push doesn't touch network, so --network none still applies
+    # on top of it -- no second --profile needed to combine the two.
     sock = tmp_path / "agent.sock"
     sock.touch()
     monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
     result = runner.invoke(
         app,
-        [
-            "run",
-            "--profile",
-            "push",
-            "--profile",
-            "local-commit",
-            "--show-command",
-            "--",
-            "bash",
-        ],
+        ["run", "--profile", "push", "--network", "none", "--show-command", "--", "bash"],
     )
     assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" not in result.output
+    assert f"SSH_AUTH_SOCK {sock}" in result.output
+    assert "--unshare-net" in result.output
 
 
 def test_run_unknown_profile_fails_with_available_list():


### PR DESCRIPTION
## Summary
- `--profile` takes one name instead of being repeatable. A profile only overrides the fields it explicitly sets, so it already composes with granular flags for anything it doesn't touch (`--profile push --network none` gets push *and* the network override without a second `--profile`).
- Repeatable `--profile` only bought later-wins conflict resolution between two profiles on the *same* field, which isn't a real use case — just removed complexity.

## Test plan
- [x] `uv run pytest src/python/sandboxr` (61 passed)
- [x] `ruff check` / `ruff format --check` / `ty check` all clean
- [x] Live-verified `sandboxr run --profile push --network none --show-command` composes correctly, and `--profile nope` fails with the available list

🤖 Generated with [Claude Code](https://claude.com/claude-code)