### PR TITLE
Ignore mise.*.local.toml in global gitignore

### DIFF
--- a/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
+++ b/src/chezmoi/dot_dotfiles/git/snippets/gitignore_global
@@ -7,6 +7,8 @@
 /bazel-*
 .scratch/
 docs/superpowers/plans/*
+# Documentation: https://mise.jdx.dev/configuration/environments.html
+mise.*.local.toml
 mise.local.toml
 .antigravity/
 .antigravitycli/


### PR DESCRIPTION
Add mise.*.local.toml to the global gitignore snippet with a comment link to https://mise.jdx.dev/configuration/environments.html.

---
*PR created automatically by Jules for task [15319028524429888745](https://jules.google.com/task/15319028524429888745) started by @mkobit*