### PR TITLE
feat(mise): add uv as a global mise tool

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -64,6 +64,9 @@ package_manager = "bun"
   [mise.global_tools.gemini-cli]
   version = "0.42.0"
 
+  [mise.global_tools.uv]
+  version = "0.11.33"
+
   # sandboxr's srt backend (#695: srt-primary decision, backend):
   # enforcement runtime for domain-allowlisted sandboxing. No registry
   # shorthand exists for this package, so the tool key is the fully


### PR DESCRIPTION
Formalizes a manually-installed global uv pin (0.11.33) into the catalog so chezmoi tracks and relocks it instead of treating it as external drift.

Committed-By-Agent: claude