### PR TITLE
Allow bd --help in AI command policy

### DIFF
--- a/src/chezmoi/.chezmoidata/ai/command_policy/beads.toml
+++ b/src/chezmoi/.chezmoidata/ai/command_policy/beads.toml
@@ -35,6 +35,7 @@
 #   - "bd repo sync": hydrates issues in from other local repos — not
 #     the agent's own local work, same reasoning as "bd dolt pull".
 [ai.command_policy.commands]
+"bd --help" = "allow"
 "bd admin cleanup" = "allow"
 "bd admin compact" = "allow"
 "bd assign" = "allow"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "browser-sync",


### PR DESCRIPTION
Adds "bd --help" = "allow" to src/chezmoi/.chezmoidata/ai/command_policy/beads.toml under [ai.command_policy.commands], ensuring bd --help is automatically allowed for both Claude Code and Antigravity CLI (agy).

---
*PR created automatically by Jules for task [4344003585574463650](https://jules.google.com/task/4344003585574463650) started by @mkobit*