### PR TITLE
fix(agy): skip reinstall when agy is already present

### DIFF
--- a/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
+++ b/src/chezmoi/.chezmoiscripts/run_onchange_install-agy.sh.tmpl
@@ -4,11 +4,8 @@
 set -euo pipefail
 
 if command -v agy &>/dev/null; then
-    current=$(agy --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
-    if [[ "$current" == "{{ .agy.version }}" ]]; then
-        echo "agy {{ .agy.version }} already installed"
-        exit 0
-    fi
+    echo "agy already installed at $(command -v agy); self-updates automatically"
+    exit 0
 fi
 
 echo "Installing Antigravity CLI {{ .agy.version }}..."


### PR DESCRIPTION
## Summary
- agy self-updates itself, so re-running the installer on every `.agy.version` bump in `agy.toml` was unnecessary churn
- the guard now just checks the binary is on PATH instead of comparing `agy --version` against the pinned version

## Test plan
- [x] `uv run pytest tests/integration/test_shellcheck.py -k agy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)