### PR TITLE
fix(browser-sync): require explicit key for shortcut sync prune mode

### DIFF
--- a/src/python/browser_sync/browser_sync/_terminal.py
+++ b/src/python/browser_sync/browser_sync/_terminal.py
@@ -89,9 +89,9 @@ def prompt_done_or_recopy(copy_fn: Callable[[], None]) -> None:
             sys.exit(0)
 
 
-def _shortcut_sync_mode_for_key(key: str) -> str | None:
+def _shortcut_mode_for_key(key: str) -> str | None:
     """Return the payload mode selected by a shortcut-sync keypress."""
-    if key in ("\r", "\n"):
+    if key.lower() == "p":
         return "prune"
     if key.lower() == "x":
         return "exclude_removals"
@@ -103,30 +103,19 @@ def _shortcut_sync_mode_for_key(key: str) -> str | None:
 def prompt_shortcut_sync_mode() -> str:
     """Choose the Chrome shortcuts sync payload to copy."""
     print(
-        "\033[0;33m[!]\033[0m    Enter: sync + prune, 'x': sync without removals, 'd': dry run ",
+        "\033[0;33m[!]\033[0m    'p': sync + prune, 'x': sync without removals, 'd': dry run ",
         end="",
         flush=True,
     )
     while True:
         ch = getkey()
-        if mode := _shortcut_sync_mode_for_key(ch):
-            print(ch if ch not in ("\r", "\n") else "")
+        if mode := _shortcut_mode_for_key(ch):
+            print(ch)
             return mode
         if ch == "\x03":
             print()
             _log.info("skipped")
             sys.exit(0)
-
-
-def _shortcut_recopy_mode_for_key(key: str) -> str | None:
-    """Return the payload mode selected by a shortcut-sync recopy keypress."""
-    if key.lower() == "p":
-        return "prune"
-    if key.lower() == "x":
-        return "exclude_removals"
-    if key.lower() == "d":
-        return "dry_run"
-    return None
 
 
 _SHORTCUT_RECOPY_PROMPT = (
@@ -142,7 +131,7 @@ def prompt_shortcut_done_or_recopy(copy_fns: Mapping[str, Callable[[], None]]) -
         if ch in ("\r", "\n"):
             print()
             return
-        if mode := _shortcut_recopy_mode_for_key(ch):
+        if mode := _shortcut_mode_for_key(ch):
             print(ch)
             copy_fns[mode]()
             _log.log(OK, "recopied %s payload", mode.replace("_", " "))

--- a/src/python/browser_sync/tests/test_shortcuts.py
+++ b/src/python/browser_sync/tests/test_shortcuts.py
@@ -1,6 +1,6 @@
 """Tests for generated Chrome site-search shortcut sync payloads."""
 
-from browser_sync._terminal import _shortcut_recopy_mode_for_key, _shortcut_sync_mode_for_key
+from browser_sync._terminal import _shortcut_mode_for_key
 from browser_sync.shortcuts import _build_sync_script, _Shortcut
 
 _SHORTCUTS = (_Shortcut(keyword="@stripe", name="Stripe", url="https://go/search/%s"),)
@@ -32,15 +32,9 @@ def test_dry_run_payload_gates_all_mutations() -> None:
     assert "WOULD-DEL" in script
 
 
-def test_shortcut_sync_mode_selects_payload() -> None:
-    assert _shortcut_sync_mode_for_key("\r") == "prune"
-    assert _shortcut_sync_mode_for_key("x") == "exclude_removals"
-    assert _shortcut_sync_mode_for_key("d") == "dry_run"
-    assert _shortcut_sync_mode_for_key("q") is None
-
-
-def test_shortcut_recopy_mode_selects_payload() -> None:
-    assert _shortcut_recopy_mode_for_key("p") == "prune"
-    assert _shortcut_recopy_mode_for_key("x") == "exclude_removals"
-    assert _shortcut_recopy_mode_for_key("d") == "dry_run"
-    assert _shortcut_recopy_mode_for_key("q") is None
+def test_shortcut_mode_for_key_selects_payload() -> None:
+    assert _shortcut_mode_for_key("p") == "prune"
+    assert _shortcut_mode_for_key("x") == "exclude_removals"
+    assert _shortcut_mode_for_key("d") == "dry_run"
+    assert _shortcut_mode_for_key("q") is None
+    assert _shortcut_mode_for_key("\r") is None


### PR DESCRIPTION
Bare Enter in the shortcuts --prune --confirm prompt selected the destructive prune payload, while the recopy prompt bound the same action to 'p' — inconsistent keys for the same action, and an easy accidental keypress away from a destructive default. Drop the Enter case and dedupe the two now-identical key-mapping helpers into one.


Committed-By-Agent: claude