### PR TITLE
feat(codex): install codex-code-mode-host alongside codex

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/codex-code-mode-host.toml
+++ b/src/chezmoi/.chezmoidata/bin/codex-code-mode-host.toml
@@ -1,0 +1,28 @@
+# Required by openai/codex for Code Mode host execution
+# Reference: https://github.com/openai/codex/issues/31831
+[bin.codex-code-mode-host]
+bom_key = "codex"
+version = "0.148.0"
+
+[bin.codex-code-mode-host.github_releases]
+repo            = "openai/codex"
+bin_name        = "codex-code-mode-host"
+external_type   = "archive-file"
+executable      = true
+checksum_type   = "sha256"
+tag_format      = "rust-v{version}"
+filename_format = "codex-code-mode-host-{target}.tar.gz"
+path_format     = "codex-code-mode-host-{target}"
+url_format      = "{base}/{repo}/releases/download/{tag}/{filename}"
+
+[bin.codex-code-mode-host.github_releases.platforms]
+darwin_arm64 = "aarch64-apple-darwin"
+darwin_amd64 = "x86_64-apple-darwin"
+linux_amd64  = "x86_64-unknown-linux-musl"
+linux_arm64  = "aarch64-unknown-linux-musl"
+
+[bin.codex-code-mode-host.github_releases.checksums]
+darwin_arm64 = "10eaf562ecefee1b9f17fb609cd8f32b6f01876674555abd2ddb81962f3b5e34"
+darwin_amd64 = "a2ad5c6e8654c60b63aed172cb0e36cd0dead563cf2a0aec88cdcb5af484da50"
+linux_amd64  = "8e6e559b228fa61b18fb2c28c31ec02068751025bcce3f00cf63c79499d59829"
+linux_arm64  = "1c410fe4bb174949649efe05c150b1512fb4775d5874eb54b2edb624cf7513a4"

--- a/src/chezmoi/dot_local/bin/.chezmoiexternals/bins.toml.tmpl
+++ b/src/chezmoi/dot_local/bin/.chezmoiexternals/bins.toml.tmpl
@@ -8,7 +8,8 @@
 {{- $base     := dig "github_releases" "base_url" "https://github.com" . -}}
 {{- $localBin := dig "local" (dict) $ | dig "bin" (dict) -}}
 {{- range $name, $tool := .bin -}}
-{{-   $method := dig $name (dict) $localBin | dig "installation_method" "none" -}}
+{{-   $bomKey := dig "bom_key" $name $tool -}}
+{{-   $method := dig $bomKey (dict) $localBin | dig "installation_method" "none" -}}
 {{-   if eq $method "github_releases" -}}
 {{-     if not (hasKey $tool "github_releases") -}}
 {{-       fail (printf "bin.%s: installation_method is github_releases but no github_releases catalog entry exists" $name) -}}

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -13,6 +13,10 @@ import pytest
         "zoxide",
         pytest.param("btop", marks=pytest.mark.chezmoi_installation("local.bin.btop", methods={"github_releases"})),
         pytest.param("codex", marks=pytest.mark.chezmoi_installation("local.bin.codex", methods={"github_releases"})),
+        pytest.param(
+            "codex-code-mode-host",
+            marks=pytest.mark.chezmoi_installation("local.bin.codex", methods={"github_releases"}),
+        ),
         pytest.param("pi", marks=pytest.mark.chezmoi_installation("local.bin.pi", methods={"github_releases"})),
     ],
 )

--- a/tests/integration/test_codex.py
+++ b/tests/integration/test_codex.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -24,3 +26,25 @@ def test_codex_version(host):
     """Verify codex --version runs successfully on supported platforms."""
     result = host.run("codex --version")
     assert result.rc == 0, f"'codex --version' failed.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+
+
+@pytest.mark.integration
+@pytest.mark.chezmoi_installation("local.bin.codex", methods={"github_releases"})
+def test_codex_code_mode_host_help(host):
+    """Verify codex-code-mode-host --help runs successfully on supported platforms."""
+    result = host.run("codex-code-mode-host --help")
+    assert result.rc == 0, f"'codex-code-mode-host --help' failed.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+
+
+@pytest.mark.integration
+@pytest.mark.chezmoi_installation("local.bin.codex", methods={"github_releases"})
+def test_codex_doctor_local_environment(host):
+    """Verify codex doctor reports healthy local installation and config."""
+    result = host.run("TERM=xterm-256color codex doctor --json")
+    assert result.stdout, f"'codex doctor --json' produced no output.\nstderr: {result.stderr}"
+    report = json.loads(result.stdout)
+    checks = report.get("checks", {})
+    assert checks.get("config.load", {}).get("status") == "ok", f"config.load failed: {checks.get('config.load')}"
+    assert checks.get("installation", {}).get("status") == "ok", (
+        f"installation check failed: {checks.get('installation')}"
+    )


### PR DESCRIPTION
installs `codex-code-mode-host` companion binary alongside `codex` when `local.bin.codex` is enabled.

resolves https://github.com/openai/codex/issues/31831