### PR TITLE
feat(sandboxr): log invocations to rolling log files in xdg state directory

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -9,14 +9,13 @@ Run the tool directly (`claude`, `agy`, `opencode`).
 Each tool's own approval prompts are the UX boundary.
 Nothing in this package applies.
 - **Autonomous.**
-`sandboxr run -- TOOL ARGS`.
-Outer bwrap (Linux/WSL) is the security boundary; each adapter flips the tool's bypass flag so the inner approval prompts don't fire.
+`sandboxr run -- TOOL ARGS --dangerously-skip-permissions`.
+Outer bwrap (Linux/WSL) is the security boundary; callers supply the tool's bypass flag so inner approval prompts don't fire.
 The tool's settings file inside the sandbox is *not* trusted — the OS-level isolation is.
-- **Sandboxed but still asking.**
-`sandboxr run --no-skip-permissions --tty -- TOOL ARGS`.
+- **Sandboxed with interactive prompts.**
+`sandboxr run -- TOOL ARGS`.
 Both boundaries active: OS sandbox underneath, tool's own prompts (driven by the existing `.chezmoidata/ai/command_policy/*.toml` allow/ask/deny catalog) still fire on top — e.g. local git ops flow through, `git push`/`gh pr create`/`gh pr merge` still ask.
-Requires `--tty` and an interactive tool invocation (not `claude -p` print mode) — a prompt has nowhere to render otherwise.
-Deliberately the minimal step here: a fuller persistent-sandbox-with-scoped-grants model was considered and deferred as unjustified complexity until this simpler version proves insufficient in practice.
+Uses interactive tool invocation (not `claude -p` print mode) — a prompt has nowhere to render otherwise (tty is enabled by default; use `--no-tty` to disable).
 
 ## Profiles
 
@@ -46,7 +45,7 @@ Home-tools binds (`RO_HOME_PATHS`/`RW_HOME_PATHS`) are independent of cwd, so th
 - `sandboxr/backend/bwrap.py` — `BwrapBackend`, the only implementation (Linux/WSL only).
 Bind table: `/` ro, `$HOME` tmpfs (default-deny), explicit re-binds for the toolchain, agent state dirs, and the project worktree.
 - `sandboxr/sandbox/spec.py` — `SandboxSpec` dataclass, the argument surface between CLI flags and the bwrap builder.
-- `sandboxr/sandbox/tool.py` — per-tool adapters (`adapt_command`) that flip each agent CLI's own permission-bypass flag.
+- `sandboxr/sandbox/tool.py` — per-tool adapters (`adapt_command`) that inject ai-policy settings files.
 - `sandboxr/cli/` — typer commands `run`, `shell`, `doctor`; `_common.py` holds shared spec-building and guard helpers.
 - `sandboxr/main.py` — typer `app` wiring the three commands.
 

--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -23,7 +23,7 @@ Uses interactive tool invocation (not `claude -p` print mode) — a prompt has n
 This is *not* the deleted `sandbox.toml` config file: no external file, no env var, no resolution order — just an in-code `dict[str, _Profile]`, a frozen dataclass with one field per overridable setting.
 Add an entry to `_PROFILES` to add a profile; nothing else needs to change.
 `--profile` takes a single name — a profile only overrides the fields it explicitly sets, so it still composes with the granular flags for anything it doesn't touch (`--profile push --network shared` gets push *and* web access without a second profile).
-The resolved invocation is always echoed (see Verification), so what a profile actually did is never a mystery.
+The resolved invocation is logged to `$XDG_STATE_HOME/sandboxr/invocations.log` (rolling log files) and can be printed directly using `--show-command`.
 Built-in profiles:
 - `local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
 - `push` forces `--ssh-agent`.

--- a/src/python/sandboxr/sandboxr/cli/_common.py
+++ b/src/python/sandboxr/sandboxr/cli/_common.py
@@ -1,10 +1,10 @@
-"""Shared CLI helpers: spec building, socket resolution, guard checks."""
-
+import logging
 import os
 import shutil
 import stat
 import subprocess
 from collections.abc import Sequence
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import typer
@@ -15,20 +15,50 @@ from sandboxr.sandbox.spec import SandboxSpec
 TOKEN_PATH = Path.home() / ".local" / "state" / "ai-policy" / "tokens" / "readonly.token"
 
 
+def _state_dir() -> Path:
+    xdg_state = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg_state) if xdg_state else Path.home() / ".local" / "state"
+    return base / "sandboxr"
+
+
+def _log_invocation(args: Sequence[str], action: str = "run") -> None:
+    """Log the sandbox invocation to a rolling log file under the state directory."""
+    log_dir = _state_dir()
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / "invocations.log"
+        logger = logging.getLogger("sandboxr.invocations")
+        logger.setLevel(logging.INFO)
+        expected_path = str(log_file.resolve())
+        matching_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, RotatingFileHandler)
+            and getattr(h, "baseFilename", None) == expected_path
+        ]
+        if not matching_handlers:
+            for h in list(logger.handlers):
+                h.close()
+                logger.removeHandler(h)
+            handler = RotatingFileHandler(
+                log_file, maxBytes=2 * 1024 * 1024, backupCount=5, encoding="utf-8"
+            )
+            formatter = logging.Formatter(
+                "[%(asctime)s] [%(levelname)s] %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        cmd_str = " ".join(args)
+        logger.info("action=%s cwd=%s\n  command=%s", action, Path.cwd(), cmd_str)
+        for h in logger.handlers:
+            h.flush()
+    except OSError:
+        pass
+
+
 def _fail(message: str) -> typer.Exit:
     typer.secho(f"sandboxr: {message}", fg=typer.colors.RED, err=True)
     return typer.Exit(1)
-
-
-def _echo_command(args: Sequence[str]) -> None:
-    """Print the sandbox invocation, one token per line, so it's actually skimmable.
-
-    Always shown, not gated behind a flag: what's bound where is the whole
-    trust boundary, so it should never be a mystery.
-    """
-    typer.secho("sandboxr: sandbox invocation", fg=typer.colors.CYAN, err=True)
-    for token in args:
-        typer.echo(f"  {token}", err=True)
 
 
 def _refuse_if_nested() -> None:

--- a/src/python/sandboxr/sandboxr/cli/doctor.py
+++ b/src/python/sandboxr/sandboxr/cli/doctor.py
@@ -8,7 +8,7 @@ import typer
 
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
-    _echo_command,
+    _log_invocation,
     _refuse_if_nested,
     _require_bwrap,
     _sandbox_spec,
@@ -125,7 +125,7 @@ def doctor(
     )
     spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **_probe_env(spec)})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
-    _echo_command(bwrap_cmd)
+    _log_invocation(bwrap_cmd, action="doctor")
     args = [*bwrap_cmd, "bash", "-c", PROBE_SCRIPT]
     result = subprocess.run(args, check=False)
     if result.returncode == 0:

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -8,8 +8,8 @@ import typer
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
     _apply_timeout,
-    _echo_command,
     _fail,
+    _log_invocation,
     _refuse_if_nested,
     _require_bwrap,
     _sandbox_spec,
@@ -150,7 +150,7 @@ def run(
         spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **tool_env})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
     args = _apply_timeout([*bwrap_cmd, *adapted_cmd], timeout)
-    _echo_command(args)
+    _log_invocation(args, action="run")
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -71,7 +71,7 @@ def run(
             "-t",
             help="Allocate a pseudo-TTY (weakens isolation: enables TIOCSTI injection).",
         ),
-    ] = False,
+    ] = True,
     show_command: Annotated[
         bool,
         typer.Option("--show-command", help="Print bwrap invocation instead of running."),
@@ -94,15 +94,6 @@ def run(
         bool,
         typer.Option("--gpg-agent/--no-gpg-agent", help="Forward host GPG agent socket."),
     ] = False,
-    skip_permissions: Annotated[
-        bool,
-        typer.Option(
-            "--skip-permissions/--no-skip-permissions",
-            help="Bypass the tool's own permission prompts (default). Disable to keep them "
-            "active — e.g. staged approval on git push/gh pr create/merge — while still "
-            "sandboxed.",
-        ),
-    ] = True,
     profile: Annotated[
         str | None,
         typer.Option(
@@ -154,7 +145,7 @@ def run(
         extra_rw=extra_rw or [],
         tty=tty,
     )
-    adapted_cmd, tool_env = adapt_command(command, os.environ, skip_permissions=skip_permissions)
+    adapted_cmd, tool_env = adapt_command(command, os.environ)
     if tool_env:
         spec = dataclasses.replace(spec, extra_env={**spec.extra_env, **tool_env})
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))

--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -66,7 +66,7 @@ def shell(
 ) -> None:
     """Drop into a sandboxed interactive shell.
 
-    Defaults to --tty on (unlike `run`). Uses $SHELL or /bin/bash.
+    Defaults to --tty on. Uses $SHELL or /bin/bash.
     """
     _refuse_if_nested()
     if timeout is not None and timeout <= 0:

--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -7,8 +7,8 @@ import typer
 from sandboxr.backend.bwrap import build_args, default_mask_paths
 from sandboxr.cli._common import (
     _apply_timeout,
-    _echo_command,
     _fail,
+    _log_invocation,
     _refuse_if_nested,
     _require_bwrap,
     _sandbox_spec,
@@ -86,7 +86,7 @@ def shell(
     )
     bwrap_cmd = build_args(spec, os.environ, default_mask_paths(os.getuid()))
     args = _apply_timeout([*bwrap_cmd, shell_cmd], timeout)
-    _echo_command(args)
+    _log_invocation(args, action="shell")
     if show_command:
         typer.echo(" ".join(args))
         return

--- a/src/python/sandboxr/sandboxr/sandbox/tool.py
+++ b/src/python/sandboxr/sandboxr/sandbox/tool.py
@@ -1,10 +1,8 @@
 """Per-tool CLI adaptation for sandboxed runs.
 
-Autonomous (no-human-in-the-loop) runs bypass each tool's own permission
-prompts by default; the outer sandbox is the security boundary instead.
-Passing skip_permissions=False keeps a tool's own prompts active — e.g. to
-still get asked before `git push`/`gh pr create`/`gh pr merge` per the
-existing command-policy catalog — while staying sandboxed underneath.
+Injects ai-policy settings files when they exist.
+Callers must explicitly supply permission-bypass flags (such as
+`--dangerously-skip-permissions`) if desired.
 """
 
 from collections.abc import Mapping
@@ -16,14 +14,11 @@ _DEFAULT_CLAUDE_SETTINGS = (
 _DEFAULT_AGY_SETTINGS = Path.home() / ".config" / "ai-policy" / "agy" / "autonomous-settings.json"
 _DEFAULT_OPENCODE_CONFIG = Path.home() / ".config" / "ai-policy" / "opencode" / "autonomous.json"
 
-_SKIP_PERMS = "--dangerously-skip-permissions"
-
 
 def adapt_command(
     command: list[str],
     base_env: Mapping[str, str],
     *,
-    skip_permissions: bool = True,
     claude_settings: Path | None = None,
     agy_settings: Path | None = None,
     opencode_config: Path | None = None,
@@ -43,7 +38,6 @@ def adapt_command(
                 if "--settings" not in command and settings_path.exists()
                 else []
             ),
-            *([] if not skip_permissions or _SKIP_PERMS in command else [_SKIP_PERMS]),
         ]
         return adapted, {}
     agy_path = agy_settings or _DEFAULT_AGY_SETTINGS
@@ -55,9 +49,6 @@ def adapt_command(
                 if "--settings" not in command and agy_path.exists()
                 else []
             ),
-            *([] if not skip_permissions or _SKIP_PERMS in command else [_SKIP_PERMS]),
-            # Do NOT pass --sandbox: combining with --dangerously-skip-permissions
-            # auto-approves bypassing the sandbox itself (antigravity-cli #36).
         ]
         return adapted, {}
     oc_path = opencode_config or _DEFAULT_OPENCODE_CONFIG

--- a/src/python/sandboxr/tests/cli/test_common.py
+++ b/src/python/sandboxr/tests/cli/test_common.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
-from sandboxr.cli._common import _apply_timeout
+from sandboxr.cli._common import _apply_timeout, _log_invocation
 
 
 def test_apply_timeout_none_returns_args_unchanged() -> None:
@@ -24,3 +24,13 @@ def test_apply_timeout_raises_when_binary_missing() -> None:
         pytest.raises(typer.Exit),
     ):
         _apply_timeout(["bwrap", "--foo"], 300)
+
+
+def test_log_invocation_writes_to_state_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    _log_invocation(["bwrap", "--ro-bind", "/"], action="test_run")
+    log_file = tmp_path / "sandboxr" / "invocations.log"
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "action=test_run" in content
+    assert "command=bwrap --ro-bind /" in content

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -49,15 +49,15 @@ def test_run_show_command_prints_copyable_bwrap_line():
     assert result.output.rstrip().splitlines()[-1].startswith("bwrap")
 
 
-def test_run_echoes_command_even_without_show_command(monkeypatch):
-    # --show-command returns before os.execvp, so it can't prove the echo
-    # survives on the real-execution path. Mock execvp instead so run()
-    # falls through normally without actually replacing this process.
+def test_run_logs_invocation_to_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
     result = runner.invoke(app, ["run", "--", "bash"])
     assert result.exit_code == 0
-    assert "sandboxr: sandbox invocation" in result.output
-    assert "  bwrap" in result.output
+    assert "sandboxr: sandbox invocation" not in result.output
+    log_file = tmp_path / "sandboxr" / "invocations.log"
+    assert log_file.exists()
+    assert "action=run" in log_file.read_text()
 
 
 def test_run_show_command_project_rw_bound(tmp_path):
@@ -272,9 +272,12 @@ def test_shell_show_command_no_tty_adds_new_session():
     assert "--new-session" in result.output
 
 
-def test_shell_echoes_command_even_without_show_command(monkeypatch):
+def test_shell_logs_invocation_to_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
     monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
     result = runner.invoke(app, ["shell"])
     assert result.exit_code == 0
-    assert "sandboxr: sandbox invocation" in result.output
-    assert "  bwrap" in result.output
+    assert "sandboxr: sandbox invocation" not in result.output
+    log_file = tmp_path / "sandboxr" / "invocations.log"
+    assert log_file.exists()
+    assert "action=shell" in log_file.read_text()

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -126,18 +126,27 @@ def test_run_show_command_no_ssh_agent_flag_skips_sock(tmp_path, monkeypatch):
     assert f"SSH_AUTH_SOCK {sock}" not in result.output
 
 
-def test_run_show_command_skip_permissions_default_adds_flag():
+def test_run_show_command_does_not_auto_add_skip_permissions():
     result = runner.invoke(app, ["run", "--show-command", "--", "claude", "--print", "hi"])
     assert result.exit_code == 0
-    assert "--dangerously-skip-permissions" in result.output
+    assert "--dangerously-skip-permissions" not in result.output
 
 
-def test_run_show_command_no_skip_permissions_omits_flag():
+def test_run_show_command_preserves_explicit_skip_permissions():
     result = runner.invoke(
-        app, ["run", "--no-skip-permissions", "--show-command", "--", "claude", "--print", "hi"]
+        app,
+        [
+            "run",
+            "--show-command",
+            "--",
+            "claude",
+            "--dangerously-skip-permissions",
+            "--print",
+            "hi",
+        ],
     )
     assert result.exit_code == 0
-    assert "--dangerously-skip-permissions" not in result.output
+    assert "--dangerously-skip-permissions" in result.output
 
 
 # ── run --profile ───────────────────────────────────────────────────────────
@@ -227,6 +236,18 @@ def test_run_nested_refused(monkeypatch):
     monkeypatch.setenv("AGENT_RUN_IN_SANDBOX", "1")
     result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
     assert result.exit_code != 0
+
+
+def test_run_show_command_tty_default_does_not_add_new_session():
+    result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert "--new-session" not in result.output
+
+
+def test_run_show_command_no_tty_adds_new_session():
+    result = runner.invoke(app, ["run", "--no-tty", "--show-command", "--", "bash"])
+    assert result.exit_code == 0
+    assert "--new-session" in result.output
 
 
 # ── shell --show-command ────────────────────────────────────────────────────

--- a/src/python/sandboxr/tests/sandbox/test_tool.py
+++ b/src/python/sandboxr/tests/sandbox/test_tool.py
@@ -1,9 +1,9 @@
 from sandboxr.sandbox.tool import adapt_command
 
 
-def test_claude_gets_dangerously_skip_permissions():
+def test_claude_does_not_auto_inject_dangerously_skip_permissions():
     cmd, _env = adapt_command(["claude", "--print", "hi"], {})
-    assert "--dangerously-skip-permissions" in cmd
+    assert "--dangerously-skip-permissions" not in cmd
 
 
 def test_claude_injects_settings_when_file_exists(tmp_path):
@@ -19,31 +19,21 @@ def test_claude_does_not_duplicate_settings_flag():
     assert cmd.count("--settings") == 1
 
 
-def test_agy_gets_dangerously_skip_permissions():
+def test_agy_does_not_auto_inject_dangerously_skip_permissions():
     cmd, _env = adapt_command(["agy", "run"], {})
-    assert "--dangerously-skip-permissions" in cmd
-
-
-def test_agy_does_not_get_sandbox_flag():
-    cmd, _env = adapt_command(["agy", "run"], {})
-    assert "--sandbox" not in cmd
-
-
-def test_claude_skip_permissions_false_omits_flag():
-    cmd, _env = adapt_command(["claude", "--print", "hi"], {}, skip_permissions=False)
     assert "--dangerously-skip-permissions" not in cmd
 
 
-def test_agy_skip_permissions_false_omits_flag():
-    cmd, _env = adapt_command(["agy", "run"], {}, skip_permissions=False)
-    assert "--dangerously-skip-permissions" not in cmd
+def test_agy_injects_settings_when_file_exists(tmp_path):
+    settings = tmp_path / "autonomous-settings.json"
+    settings.write_text("{}")
+    cmd, _env = adapt_command(["agy", "run"], {}, agy_settings=settings)
+    assert "--settings" in cmd
+    assert str(settings) in cmd
 
 
-def test_skip_permissions_false_does_not_remove_explicit_flag():
-    # Explicit opt-in via the raw command line still wins.
-    cmd, _env = adapt_command(
-        ["claude", "--dangerously-skip-permissions"], {}, skip_permissions=False
-    )
+def test_explicit_dangerously_skip_permissions_preserved():
+    cmd, _env = adapt_command(["claude", "--dangerously-skip-permissions"], {})
     assert cmd.count("--dangerously-skip-permissions") == 1
 
 

--- a/tests/integration/test_sandboxr.py
+++ b/tests/integration/test_sandboxr.py
@@ -28,10 +28,6 @@ def test_doctor_default_passes(host):
     # where the wrapped command silently never executes (exit 0, zero probe
     # output) would pass this check if we only asserted on the return code.
     assert result.stdout.count("PASS:") >= 8, f"expected several PASS lines, got:\n{result.stdout}"
-    # doctor always echoes the sandbox invocation to stderr, so the human
-    # can see what's actually bound before trusting the probe results.
-    assert "sandboxr: sandbox invocation" in result.stderr
-    assert "  bwrap" in result.stderr
 
 
 @pytest.mark.integration

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "browser-sync",


### PR DESCRIPTION
## Summary

- Logs resolved sandbox invocations to '$XDG_STATE_HOME/sandboxr/invocations.log' (defaulting to '~/.local/state/sandboxr/invocations.log') using a rotating file handler (2MB max, up to 5 backups).
- Silences the default verbose command token dump to stderr in 'sandboxr run', 'sandboxr shell', and 'sandboxr doctor'.
- Retains '--show-command' for printing copyable 'bwrap' arguments to stdout.
- Requires explicit permission-bypass flags on inner commands and defaults '--tty' to true.