### PR TITLE
feat(sandboxr): enable commit signing via gpg-agent by default in push and pr profiles

### DIFF
--- a/src/chezmoi/dot_config/ai-policy/git/sandbox.gitconfig.tmpl
+++ b/src/chezmoi/dot_config/ai-policy/git/sandbox.gitconfig.tmpl
@@ -1,10 +1,4 @@
 # Global git config used inside sandboxr sandboxes via GIT_CONFIG_GLOBAL.
-# Inherits the regular config, then forces signing off: ~/.gnupg is masked in
-# the sandbox, so signed commits would fail. Unsigned commits also mark
-# sandbox-made history for later human review.
+# Inherits the regular host git config.
 [include]
 	path = {{ .chezmoi.destDir }}/.dotfiles/git/config
-[commit]
-	gpgsign = false
-[tag]
-	gpgSign = false

--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -26,9 +26,9 @@ Add an entry to `_PROFILES` to add a profile; nothing else needs to change.
 The resolved invocation is logged to `$XDG_STATE_HOME/sandboxr/invocations.log` (rolling log files) and can be printed directly using `--show-command`.
 Built-in profiles:
 - `local-commit` forces `--no-ssh-agent --no-gpg-agent`: no push/sign capability, full stop.
-- `push` forces `--ssh-agent`.
+- `push` forces `--ssh-agent --gpg-agent`.
 - `web-access` forces `--network shared`.
-- `pr` implies `push` and additionally read-only-binds the real `~/.config/gh`.
+- `pr` implies `push` (ssh + gpg agent) and additionally read-only-binds the real `~/.config/gh`.
 This is *not* a scoped credential — there's no short-lived or per-usage token issuance, so the agent gets whatever access your actual `gh auth login` session has, not just this repo.
 Read-only only stops the sandbox from tampering with the credential file; it does not limit what the token itself can do once `gh` reads it.
 Chose this over a second hand-scoped PAT file because a hand-scoped token is still just another standing secret to create and remember to rotate, for a security property achievable another way if it ever matters (see the deferred broker idea, not built).

--- a/src/python/sandboxr/sandboxr/cli/doctor.py
+++ b/src/python/sandboxr/sandboxr/cli/doctor.py
@@ -24,16 +24,19 @@ pass() { printf 'PASS: %s\n' "$1"; }
 fail() { printf 'FAIL: %s\n' "$1"; fails=$((fails+1)); }
 hidden() { if [ -e "$2" ]; then fail "$1 visible at $2"; else pass "$1 hidden"; fi; }
 hidden "ssh keys" "$HOME/.ssh"
-hidden "gpg keys" "$HOME/.gnupg"
 hidden "gh credentials" "$HOME/.config/gh"
 hidden "ai-policy token store" "$HOME/.local/state/ai-policy"
+if [ "$PROBE_EXPECT_GPG_AGENT" = "1" ]; then
+  if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ]; then
+    pass "gpg keyring mounted"
+  else
+    fail "gpg keyring missing"
+  fi
+else
+  hidden "gpg keys" "$HOME/.gnupg"
+fi
 command -v git >/dev/null 2>&1 && pass "git on PATH" || fail "git missing"
 command -v rg >/dev/null 2>&1 && pass "rg on PATH" || fail "rg missing"
-if [ "$(git config --global commit.gpgsign 2>/dev/null)" = "false" ]; then
-  pass "commit signing disabled"
-else
-  fail "commit signing not disabled"
-fi
 if touch /agent-sandbox-probe 2>/dev/null; then
   rm -f /agent-sandbox-probe
   fail "root filesystem writable"
@@ -52,6 +55,13 @@ if [ "$PROBE_EXPECT_SSH_AGENT" = "1" ]; then
     pass "SSH agent socket forwarded"
   else
     fail "SSH agent socket missing or not a socket"
+  fi
+fi
+if [ "$PROBE_EXPECT_GPG_AGENT" = "1" ]; then
+  if [ -n "${GNUPGHOME:-}" ]; then
+    pass "GPG agent socket forwarded"
+  else
+    fail "GPG agent socket missing"
   fi
 fi
 if command -v gh >/dev/null 2>&1; then
@@ -97,6 +107,7 @@ def _probe_env(spec: SandboxSpec) -> dict[str, str]:
         "PROBE_PROJECT_WRITE": "1" if spec.project_write else "0",
         "PROBE_EXPECT_GH": "1" if "GH_TOKEN" in spec.extra_env else "0",
         "PROBE_EXPECT_SSH_AGENT": "1" if spec.ssh_agent_sock is not None else "0",
+        "PROBE_EXPECT_GPG_AGENT": "1" if spec.gpg_agent_sock is not None else "0",
         "PROBE_NETWORK": spec.network,
     }
 
@@ -109,7 +120,7 @@ def doctor(
         typer.Option("--network", help="Network mode: shared|none."),
     ] = "shared",
     ssh_agent: Annotated[bool, typer.Option("--ssh-agent/--no-ssh-agent")] = True,
-    gpg_agent: Annotated[bool, typer.Option("--gpg-agent/--no-gpg-agent")] = False,
+    gpg_agent: Annotated[bool, typer.Option("--gpg-agent/--no-gpg-agent")] = True,
 ) -> None:
     """Verify sandbox guarantees by probing from inside it."""
     _refuse_if_nested()

--- a/src/python/sandboxr/sandboxr/cli/run.py
+++ b/src/python/sandboxr/sandboxr/cli/run.py
@@ -44,9 +44,9 @@ class _Profile:
 # SandboxSpec field.
 _PROFILES: dict[str, _Profile] = {
     "local-commit": _Profile(ssh_agent=False, gpg_agent=False),
-    "push": _Profile(ssh_agent=True),
+    "push": _Profile(ssh_agent=True, gpg_agent=True),
     "web-access": _Profile(network="shared"),
-    "pr": _Profile(ssh_agent=True, gh_config=True),
+    "pr": _Profile(ssh_agent=True, gpg_agent=True, gh_config=True),
 }
 
 
@@ -93,7 +93,7 @@ def run(
     gpg_agent: Annotated[
         bool,
         typer.Option("--gpg-agent/--no-gpg-agent", help="Forward host GPG agent socket."),
-    ] = False,
+    ] = True,
     profile: Annotated[
         str | None,
         typer.Option(

--- a/src/python/sandboxr/sandboxr/cli/shell.py
+++ b/src/python/sandboxr/sandboxr/cli/shell.py
@@ -50,7 +50,7 @@ def shell(
     gpg_agent: Annotated[
         bool,
         typer.Option("--gpg-agent/--no-gpg-agent", help="Forward host GPG agent socket."),
-    ] = False,
+    ] = True,
     extra_ro: Annotated[
         list[str] | None,
         typer.Option("--ro", help="Bind path read-only (repeatable)."),

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -205,6 +205,24 @@ def test_run_profile_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
     assert f"SSH_AUTH_SOCK {sock}" in result.output
 
 
+def test_run_profile_pr_forces_gpg_agent_on(tmp_path, monkeypatch):
+    sock = tmp_path / "gpg-agent.sock"
+    sock.touch()
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: type("Result", (), {"returncode": 0, "stdout": str(sock)})(),
+    )
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name, **kwargs: "/usr/bin/gpgconf" if name == "gpgconf" else "/usr/bin/bwrap",
+    )
+    result = runner.invoke(
+        app, ["run", "--no-gpg-agent", "--profile", "pr", "--show-command", "--", "bash"]
+    )
+    assert result.exit_code == 0
+    assert f"--bind {sock} {sock}" in result.output
+
+
 def test_run_profile_composes_with_granular_flag_for_untouched_field(tmp_path, monkeypatch):
     # --profile push doesn't touch network, so --network none still applies
     # on top of it -- no second --profile needed to combine the two.


### PR DESCRIPTION
## Summary

- Removes hardcoded 'gpgsign = false' in 'sandbox.gitconfig.tmpl' so sandboxed git operations can sign commits using the forwarded GPG agent.
- Enables '--gpg-agent' forwarding by default in 'sandboxr run', 'sandboxr shell', and in 'push' and 'pr' profiles.
- Updates 'sandboxr doctor' probes to verify GPG agent socket forwarding.