### PR TITLE
chore(sandboxr): put sandboxr on hold and fail closed on execution

### DIFF
--- a/src/python/sandboxr/AGENTS.md
+++ b/src/python/sandboxr/AGENTS.md
@@ -1,3 +1,8 @@
+# Status: on hold
+
+`sandboxr` is currently placed on hold while investing in Docker Sandboxes (`sbx`) as the container and microVM isolation layer.
+The CLI entrypoint fails closed with an error on any command invocation (`run`, `shell`, `doctor`) to prevent accidental execution.
+
 ## Purpose
 
 `sandboxr` wraps AI agent CLIs (claude, agy, opencode) in an outer sandbox so no-human-in-the-loop runs can use each tool's `--dangerously-skip-permissions`-equivalent without risking credential exfiltration, signed-commit forgery, or destruction of the home directory.

--- a/src/python/sandboxr/sandboxr/main.py
+++ b/src/python/sandboxr/sandboxr/main.py
@@ -31,6 +31,17 @@ app.command(context_settings=_RUN_CTX)(shell)
 app.command()(doctor)
 
 
+@app.callback(invoke_without_command=False)
+def guard_on_hold() -> None:
+    """Fail closed while sandboxr is on hold."""
+    typer.secho(
+        "error: sandboxr is currently on hold (investigating Docker Sandboxes / sbx instead).",
+        fg=typer.colors.RED,
+        err=True,
+    )
+    raise typer.Exit(1)
+
+
 def main() -> None:
     app()
 

--- a/src/python/sandboxr/tests/cli/test_integration.py
+++ b/src/python/sandboxr/tests/cli/test_integration.py
@@ -1,16 +1,5 @@
-"""CLI integration tests using typer CliRunner and --show-command.
+"""CLI integration tests verifying fail-closed on-hold guard."""
 
-All tests use --show-command to verify bwrap invocation structure without
-running bwrap. Git detection is disabled by mocking shutil.which("git")
-to return None so _project_root falls back to cwd; shutil.which("bwrap")
-is faked so _require_bwrap passes on non-Linux hosts.
-"""
-
-import os
-import shutil
-from pathlib import Path
-
-import pytest
 from typer.testing import CliRunner
 
 from sandboxr.main import app
@@ -18,266 +7,25 @@ from sandboxr.main import app
 runner = CliRunner()
 
 
-@pytest.fixture(autouse=True)
-def _mock_which(monkeypatch):
-    """Fake bwrap so _require_bwrap passes; return None for git/gpgconf."""
-    _real = shutil.which
-
-    def _which(name, **kwargs):
-        if name == "bwrap":
-            return "/usr/bin/bwrap"
-        if name in ("git", "gpgconf"):
-            return None
-        return _real(name, **kwargs)
-
-    monkeypatch.setattr(shutil, "which", _which)
-
-
-@pytest.fixture(autouse=True)
-def _chdir(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-
-
-# ── run --show-command ──────────────────────────────────────────────────────
-
-
-def test_run_show_command_prints_copyable_bwrap_line():
-    result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    # --show-command's own output is the last line: a single, copy-pasteable
-    # command. Everything before it is the always-on per-token echo.
-    assert result.output.rstrip().splitlines()[-1].startswith("bwrap")
-
-
-def test_run_logs_invocation_to_state_dir(tmp_path, monkeypatch):
-    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
+def test_run_fails_closed_when_on_hold():
     result = runner.invoke(app, ["run", "--", "bash"])
-    assert result.exit_code == 0
-    assert "sandboxr: sandbox invocation" not in result.output
-    log_file = tmp_path / "sandboxr" / "invocations.log"
-    assert log_file.exists()
-    assert "action=run" in log_file.read_text()
+    assert result.exit_code == 1
+    assert "error: sandboxr is currently on hold" in result.output
 
 
-def test_run_show_command_project_rw_bound(tmp_path):
-    result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--bind {tmp_path} {tmp_path}" in result.output
-
-
-def test_run_show_command_no_project_write_ro_binds_project(tmp_path):
-    result = runner.invoke(app, ["run", "--no-project-write", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--ro-bind {tmp_path} {tmp_path}" in result.output
-
-
-def test_run_show_command_network_none_unshares_net():
-    result = runner.invoke(app, ["run", "--network", "none", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert "--unshare-net" in result.output
-
-
-def test_run_show_command_network_shared_does_not_unshare_net():
-    result = runner.invoke(app, ["run", "--network", "shared", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert "--unshare-net" not in result.output
-
-
-def test_run_show_command_extra_ro_bound_when_path_exists(tmp_path):
-    ro = tmp_path / "ro_file.txt"
-    ro.write_text("data")
-    result = runner.invoke(app, ["run", "--ro", str(ro), "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--ro-bind {ro} {ro}" in result.output
-
-
-def test_run_show_command_extra_rw_bound_when_path_exists(tmp_path):
-    rw = tmp_path / "state_dir"
-    rw.mkdir()
-    result = runner.invoke(app, ["run", "--rw", str(rw), "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--bind {rw} {rw}" in result.output
-
-
-def test_run_show_command_extra_ro_not_bound_when_missing(tmp_path):
-    missing = tmp_path / "nonexistent"
-    result = runner.invoke(app, ["run", "--ro", str(missing), "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert str(missing) not in result.output
-
-
-def test_run_show_command_ssh_agent_bound_when_sock_exists(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--ssh-agent", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--bind {sock} {sock}" in result.output
-    assert f"SSH_AUTH_SOCK {sock}" in result.output
-
-
-def test_run_show_command_no_ssh_agent_flag_skips_sock(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(app, ["run", "--no-ssh-agent", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" not in result.output
-
-
-def test_run_show_command_does_not_auto_add_skip_permissions():
-    result = runner.invoke(app, ["run", "--show-command", "--", "claude", "--print", "hi"])
-    assert result.exit_code == 0
-    assert "--dangerously-skip-permissions" not in result.output
-
-
-def test_run_show_command_preserves_explicit_skip_permissions():
-    result = runner.invoke(
-        app,
-        [
-            "run",
-            "--show-command",
-            "--",
-            "claude",
-            "--dangerously-skip-permissions",
-            "--print",
-            "hi",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "--dangerously-skip-permissions" in result.output
-
-
-# ── run --profile ───────────────────────────────────────────────────────────
-
-
-def test_run_profile_local_commit_forces_no_ssh_agent(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(
-        app, ["run", "--profile", "local-commit", "--show-command", "--", "bash"]
-    )
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" not in result.output
-
-
-def test_run_profile_push_binds_ssh_agent_sock(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(
-        app,
-        ["run", "--no-ssh-agent", "--profile", "push", "--show-command", "--", "bash"],
-    )
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" in result.output
-
-
-def test_run_profile_web_access_overrides_network_none():
-    result = runner.invoke(
-        app,
-        ["run", "--network", "none", "--profile", "web-access", "--show-command", "--", "bash"],
-    )
-    assert result.exit_code == 0
-    assert "--unshare-net" not in result.output
-
-
-def test_run_profile_pr_binds_gh_config_read_only(tmp_path, tmp_path_factory, monkeypatch):
-    fake_home = tmp_path_factory.mktemp("home")
-    monkeypatch.setattr(Path, "home", lambda: fake_home)
-    gh_dir = fake_home / ".config" / "gh"
-    gh_dir.mkdir(parents=True)
-    result = runner.invoke(app, ["run", "--profile", "pr", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert f"--ro-bind {gh_dir} {gh_dir}" in result.output
-
-
-def test_run_profile_pr_forces_ssh_agent_on(tmp_path, monkeypatch):
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(
-        app, ["run", "--no-ssh-agent", "--profile", "pr", "--show-command", "--", "bash"]
-    )
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" in result.output
-
-
-def test_run_profile_composes_with_granular_flag_for_untouched_field(tmp_path, monkeypatch):
-    # --profile push doesn't touch network, so --network none still applies
-    # on top of it -- no second --profile needed to combine the two.
-    sock = tmp_path / "agent.sock"
-    sock.touch()
-    monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-    result = runner.invoke(
-        app,
-        ["run", "--profile", "push", "--network", "none", "--show-command", "--", "bash"],
-    )
-    assert result.exit_code == 0
-    assert f"SSH_AUTH_SOCK {sock}" in result.output
-    assert "--unshare-net" in result.output
-
-
-def test_run_unknown_profile_fails_with_available_list():
-    result = runner.invoke(app, ["run", "--profile", "nope", "--show-command", "--", "bash"])
-    assert result.exit_code != 0
-    assert "unknown profile" in result.output
-    assert "local-commit" in result.output
-
-
-def test_run_no_command_exits_nonzero():
-    result = runner.invoke(app, ["run", "--show-command"])
-    assert result.exit_code != 0
-
-
-def test_run_nested_refused(monkeypatch):
-    monkeypatch.setenv("AGENT_RUN_IN_SANDBOX", "1")
-    result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
-    assert result.exit_code != 0
-
-
-def test_run_show_command_tty_default_does_not_add_new_session():
-    result = runner.invoke(app, ["run", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert "--new-session" not in result.output
-
-
-def test_run_show_command_no_tty_adds_new_session():
-    result = runner.invoke(app, ["run", "--no-tty", "--show-command", "--", "bash"])
-    assert result.exit_code == 0
-    assert "--new-session" in result.output
-
-
-# ── shell --show-command ────────────────────────────────────────────────────
-
-
-def test_shell_show_command_ends_with_shell():
-    result = runner.invoke(app, ["shell", "--show-command"])
-    assert result.exit_code == 0
-    last_arg = result.output.strip().split()[-1]
-    assert os.path.basename(last_arg) in {"bash", "zsh", "sh", "fish", "dash"}
-
-
-def test_shell_show_command_tty_default_does_not_add_new_session():
-    result = runner.invoke(app, ["shell", "--show-command"])
-    assert result.exit_code == 0
-    assert "--new-session" not in result.output
-
-
-def test_shell_show_command_no_tty_adds_new_session():
-    result = runner.invoke(app, ["shell", "--no-tty", "--show-command"])
-    assert result.exit_code == 0
-    assert "--new-session" in result.output
-
-
-def test_shell_logs_invocation_to_state_dir(tmp_path, monkeypatch):
-    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    monkeypatch.setattr("os.execvp", lambda *args, **kwargs: None)
+def test_shell_fails_closed_when_on_hold():
     result = runner.invoke(app, ["shell"])
+    assert result.exit_code == 1
+    assert "error: sandboxr is currently on hold" in result.output
+
+
+def test_doctor_fails_closed_when_on_hold():
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "error: sandboxr is currently on hold" in result.output
+
+
+def test_help_still_displays():
+    result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "sandboxr: sandbox invocation" not in result.output
-    log_file = tmp_path / "sandboxr" / "invocations.log"
-    assert log_file.exists()
-    assert "action=shell" in log_file.read_text()
+    assert "Run commands in an outer bwrap sandbox" in result.output

--- a/tests/integration/test_sandboxr.py
+++ b/tests/integration/test_sandboxr.py
@@ -17,26 +17,7 @@ def test_sandboxr_on_path(host):
 
 @pytest.mark.integration
 @pytest.mark.skipif(not _is_linux, reason="bwrap backend is Linux-only")
-def test_doctor_default_passes(host):
-    if not _tool_available(host, "bwrap"):
-        pytest.skip("bwrap not installed on this runner")
+def test_sandboxr_on_hold_fails_closed(host):
     result = host.run("sandboxr doctor")
-    assert result.rc == 0, f"doctor failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    assert "sandboxr doctor: all probes passed" in result.stdout
-    assert "FAIL:" not in result.stdout
-    # A passing exit code alone isn't proof the probes actually ran: a bug
-    # where the wrapped command silently never executes (exit 0, zero probe
-    # output) would pass this check if we only asserted on the return code.
-    assert result.stdout.count("PASS:") >= 8, f"expected several PASS lines, got:\n{result.stdout}"
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(not _is_linux, reason="bwrap backend is Linux-only")
-def test_doctor_no_project_write_passes(host):
-    if not _tool_available(host, "bwrap"):
-        pytest.skip("bwrap not installed on this runner")
-    result = host.run("sandboxr doctor --no-project-write")
-    assert result.rc == 0, f"doctor failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
-    assert "sandboxr doctor: all probes passed" in result.stdout
-    assert "FAIL:" not in result.stdout
-    assert "project write=0 as expected" in result.stdout
+    assert result.rc == 1, f"expected sandboxr to fail closed while on hold.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "sandboxr is currently on hold" in result.stderr

--- a/tests/integration/test_sandboxr.py
+++ b/tests/integration/test_sandboxr.py
@@ -19,5 +19,7 @@ def test_sandboxr_on_path(host):
 @pytest.mark.skipif(not _is_linux, reason="bwrap backend is Linux-only")
 def test_sandboxr_on_hold_fails_closed(host):
     result = host.run("sandboxr doctor")
-    assert result.rc == 1, f"expected sandboxr to fail closed while on hold.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    assert result.rc == 1, (
+        f"expected sandboxr to fail closed while on hold.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
     assert "sandboxr is currently on hold" in result.stderr


### PR DESCRIPTION
## Summary

- Adds an on-hold callback in 'sandboxr/main.py' to fail closed with an error on any command invocation ('run', 'shell', 'doctor').
- Updates 'src/python/sandboxr/AGENTS.md' documenting the on-hold status while exploring Docker Sandboxes ('sbx').
- Updates integration tests to assert on-hold fail-closed behavior.