### PR TITLE
Update mise to v2026.8.10

### DIFF
--- a/src/chezmoi/.chezmoidata/bin/mise.toml
+++ b/src/chezmoi/.chezmoidata/bin/mise.toml
@@ -1,6 +1,6 @@
 # mise version already includes "v" prefix — tag_format = "{version}" (no added v)
 [bin.mise]
-version = "v2026.8.0"
+version = "v2026.8.10"
 
 [bin.mise.github_releases]
 repo            = "jdx/mise"
@@ -18,10 +18,10 @@ linux_amd64  = "linux-x64"
 linux_arm64  = "linux-arm64"
 
 [bin.mise.github_releases.checksums]
-darwin_arm64 = "69c4e838e68acee987849cf618f0c0e156021970c275b5c154d32eb49e807fca"
-darwin_amd64 = "8bf9f2e77a84f38e4fb89af74cdb71ce72e9f7cc1f7189b8d6667e676c8f8334"
-linux_amd64  = "dc62954db7ac2c5a37e3c0454d1744d2eb0bec373222cda6219c5ae3704a759c"
-linux_arm64  = "8db14e256aab170ea7be41068198fb29dbbec97fc532055ddb6934e7aec62328"
+darwin_arm64 = "a91ccafc1a90087c94c4c70bd61b455bfae087b899c1e5619f4ef515aa2e036f"
+darwin_amd64 = "37b1dabb65d96b266790fb8371ddc93884c004f796dbad8253c82712f80a4e08"
+linux_amd64  = "1f5e8795d24073904ef20ba70c1250ad6389d8c5672226d152e0ed24909ba72f"
+linux_arm64  = "57a14ecddf45aab8463a03bfbd424ebb08ba2d5808e19d45bd06d40c27019c4d"
 
 [mise]
 


### PR DESCRIPTION
Update `mise` version in `src/chezmoi/.chezmoidata/bin/mise.toml` to `v2026.8.10` bypassing the 7 day rule as versions >= v2026.8.7 contain security fixes.
Checksums are correctly set for the raw executables.
Chezmoi is already up-to-date at `v2.72.0` in `.github/workflows/ci.yml`.

---
*PR created automatically by Jules for task [4754939933586758306](https://jules.google.com/task/4754939933586758306) started by @mkobit*